### PR TITLE
feat(installer): download Dirigent binary and create Docker network

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -122,10 +122,52 @@ else
     step "Docker installed ($(docker --version | head -1))"
 fi
 
+# ─── Dirigent binary ──────────────────────────────────────────────────────────
+
+DIRIGENT_BIN="/usr/local/bin/dirigent"
+
+# Normalise the machine architecture to the naming convention used in release
+# asset filenames (e.g. "linux-amd64", "linux-arm64").
+ARCH="$(uname -m)"
+case "${ARCH}" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    *) error "Unsupported architecture: ${ARCH}. Supported: x86_64, aarch64." ;;
+esac
+
+DOWNLOAD_URL="https://github.com/ercadev/dirigent/releases/latest/download/dirigent-linux-${ARCH}"
+
+if [ -f "${DIRIGENT_BIN}" ]; then
+    step "Updating Dirigent binary at ${DIRIGENT_BIN} (linux/${ARCH})"
+else
+    step "Downloading Dirigent binary (linux/${ARCH})"
+fi
+
+curl -fsSL "${DOWNLOAD_URL}" -o "${DIRIGENT_BIN}"
+chmod 755 "${DIRIGENT_BIN}"
+
+step "Dirigent binary ready at ${DIRIGENT_BIN}"
+
+# ─── Docker network ───────────────────────────────────────────────────────────
+
+DIRIGENT_NETWORK="dirigent"
+
+step "Checking for Dirigent Docker network"
+
+if docker network inspect "${DIRIGENT_NETWORK}" > /dev/null 2>&1; then
+    step "Docker network '${DIRIGENT_NETWORK}' already exists; skipping"
+else
+    step "Creating Docker bridge network '${DIRIGENT_NETWORK}'"
+    docker network create --driver bridge "${DIRIGENT_NETWORK}"
+    step "Docker network '${DIRIGENT_NETWORK}' created"
+fi
+
 # ─── completion ───────────────────────────────────────────────────────────────
 
 echo ""
-echo "  Dirigent pre-install complete."
-echo "  OS:     ${PRETTY_NAME:-${OS_ID} ${OS_VERSION_ID}}"
-echo "  Docker: $(docker --version | head -1)"
+echo "  Dirigent installed successfully."
+echo "  OS:      ${PRETTY_NAME:-${OS_ID} ${OS_VERSION_ID}}"
+echo "  Docker:  $(docker --version | head -1)"
+echo "  Binary:  ${DIRIGENT_BIN}"
+echo "  Network: ${DIRIGENT_NETWORK}"
 echo ""


### PR DESCRIPTION
## Summary

Closes #7.

- Detects machine architecture (`x86_64` → `amd64`, `aarch64` → `arm64`) and downloads the matching binary from `github.com/ercadev/dirigent/releases/latest` into `/usr/local/bin/dirigent` with `755` permissions
- Re-running overwrites the existing binary (doubles as an upgrade path); a distinct progress message distinguishes fresh install from update
- Creates a dedicated Docker bridge network named `dirigent`; skips with a progress message if the network already exists (idempotent)
- Expands the completion summary to show binary path and network name alongside OS and Docker version

> **Note:** Base branch is `feat/installer-docker` (not `main`) — this step depends on Docker being installed first.

## Test plan

- [ ] Fresh system — binary downloaded to `/usr/local/bin/dirigent`, `chmod 755` confirmed
- [ ] Re-run — prints "Updating Dirigent binary…", no error
- [ ] `docker network ls` shows `dirigent` bridge network after first run
- [ ] Re-run — prints "already exists; skipping", no error
- [ ] Unsupported arch (e.g. `armv7l`) — script exits with descriptive error
- [ ] `bash -n install.sh` passes (syntax check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)