### PR TITLE
feat(installer): systemd service setup and completion summary with GUI URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,9 +117,11 @@ step "Checking for existing Docker installation"
 
 if command -v docker > /dev/null 2>&1; then
     step "Docker already installed ($(docker --version | head -1)); skipping"
+    STEP_DOCKER="already installed"
 else
     install_docker
     step "Docker installed ($(docker --version | head -1))"
+    STEP_DOCKER="installed"
 fi
 
 # ─── Dirigent binary ──────────────────────────────────────────────────────────
@@ -139,8 +141,10 @@ DOWNLOAD_URL="https://github.com/ercadev/dirigent/releases/latest/download/dirig
 
 if [ -f "${DIRIGENT_BIN}" ]; then
     step "Updating Dirigent binary at ${DIRIGENT_BIN} (linux/${ARCH})"
+    STEP_BINARY="updated"
 else
     step "Downloading Dirigent binary (linux/${ARCH})"
+    STEP_BINARY="installed"
 fi
 
 curl -fsSL "${DOWNLOAD_URL}" -o "${DIRIGENT_BIN}"
@@ -156,18 +160,79 @@ step "Checking for Dirigent Docker network"
 
 if docker network inspect "${DIRIGENT_NETWORK}" > /dev/null 2>&1; then
     step "Docker network '${DIRIGENT_NETWORK}' already exists; skipping"
+    STEP_NETWORK="already exists"
 else
     step "Creating Docker bridge network '${DIRIGENT_NETWORK}'"
     docker network create --driver bridge "${DIRIGENT_NETWORK}"
     step "Docker network '${DIRIGENT_NETWORK}' created"
+    STEP_NETWORK="created"
+fi
+
+# ─── systemd service ──────────────────────────────────────────────────────────
+
+DIRIGENT_PORT="8080"
+DIRIGENT_UNIT="/etc/systemd/system/dirigent.service"
+
+step "Writing systemd unit file to ${DIRIGENT_UNIT}"
+
+cat > "${DIRIGENT_UNIT}" << EOF
+[Unit]
+Description=Dirigent container orchestrator
+Documentation=https://github.com/ercadev/dirigent
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+ExecStart=${DIRIGENT_BIN}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+step "Reloading systemd daemon"
+systemctl daemon-reload
+
+step "Enabling Dirigent service"
+systemctl enable dirigent
+
+if systemctl is-active --quiet dirigent; then
+    step "Dirigent service already running; restarting to apply any changes"
+    systemctl restart dirigent
+    STEP_SERVICE="restarted"
+else
+    step "Starting Dirigent service"
+    systemctl start dirigent
+    STEP_SERVICE="started"
+fi
+
+step "Verifying Dirigent service is active"
+if ! systemctl is-active --quiet dirigent; then
+    error "Dirigent service failed to start. Check logs with: journalctl -u dirigent -n 50"
 fi
 
 # ─── completion ───────────────────────────────────────────────────────────────
 
+# Resolve the primary non-loopback IP so we can print a usable GUI URL.
+SERVER_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+if [ -z "${SERVER_IP}" ]; then
+    SERVER_IP="<server-ip>"
+fi
+
 echo ""
-echo "  Dirigent installed successfully."
-echo "  OS:      ${PRETTY_NAME:-${OS_ID} ${OS_VERSION_ID}}"
-echo "  Docker:  $(docker --version | head -1)"
-echo "  Binary:  ${DIRIGENT_BIN}"
-echo "  Network: ${DIRIGENT_NETWORK}"
+echo "  ┌─────────────────────────────────────────────────────────┐"
+echo "  │  Dirigent is ready                                      │"
+echo "  └─────────────────────────────────────────────────────────┘"
+echo ""
+echo "  GUI:     http://${SERVER_IP}:${DIRIGENT_PORT}"
+echo ""
+echo "  Setup summary:"
+echo "    Docker        ${STEP_DOCKER}"
+echo "    Binary        ${STEP_BINARY} → ${DIRIGENT_BIN}"
+echo "    Network       ${STEP_NETWORK} → ${DIRIGENT_NETWORK}"
+echo "    Service       ${STEP_SERVICE} → dirigent.service"
+echo ""
+echo "  Open the GUI in your browser and start deploying containers."
 echo ""


### PR DESCRIPTION
Closes #8.

## Summary

- Writes `/etc/systemd/system/dirigent.service` on every run; `daemon-reload` makes re-runs safe
- Enables the service so it auto-starts on reboot (`systemctl is-enabled` → `enabled`)
- Starts or restarts depending on whether the service is already active (idempotent)
- Verifies the service is active post-start and exits with a `journalctl` hint if it fails
- Tracks the outcome of each install phase and prints a structured completion summary with the GUI URL

## Test plan

- [ ] Fresh Ubuntu 22.04 VM: `sudo bash install.sh` → `systemctl is-active dirigent` returns `active`
- [ ] `systemctl is-enabled dirigent` returns `enabled`
- [ ] Re-run the script on the same VM → service restarts without error, script exits 0
- [ ] Completion summary printed with correct GUI URL (`http://<ip>:8080`)
- [ ] GUI reachable at the printed URL immediately after install
- [ ] Smoke test on Debian 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)