### PR TITLE
refactor(dashboard): split DeploymentList into single-responsibility units

### DIFF
--- a/dashboard/src/deployments/DeploymentRow.tsx
+++ b/dashboard/src/deployments/DeploymentRow.tsx
@@ -1,0 +1,31 @@
+import { Trash2 } from 'lucide-react'
+import type { Deployment } from '../lib/api'
+import { StatusBadge } from './StatusBadge'
+
+type Props = {
+  deployment: Deployment
+  onDelete: (id: string) => void
+  isDeleting: boolean
+}
+
+export function DeploymentRow({ deployment: d, onDelete, isDeleting }: Props) {
+  return (
+    <tr className="bg-white hover:bg-gray-50">
+      <td className="px-4 py-3 font-medium text-gray-900">{d.name}</td>
+      <td className="px-4 py-3 text-gray-600 font-mono text-xs">{d.image}</td>
+      <td className="px-4 py-3">
+        <StatusBadge status={d.status} error={d.error} />
+      </td>
+      <td className="px-4 py-3 text-right">
+        <button
+          onClick={() => onDelete(d.id)}
+          disabled={isDeleting}
+          aria-label={`Delete ${d.name}`}
+          className="p-1.5 rounded text-gray-400 hover:text-red-600 hover:bg-red-50 disabled:opacity-40"
+        >
+          <Trash2 size={15} />
+        </button>
+      </td>
+    </tr>
+  )
+}

--- a/dashboard/src/deployments/DeploymentTable.tsx
+++ b/dashboard/src/deployments/DeploymentTable.tsx
@@ -1,0 +1,41 @@
+import type { UseMutationResult } from '@tanstack/react-query'
+import type { Deployment } from '../lib/api'
+import { DeploymentRow } from './DeploymentRow'
+
+type Props = {
+  deployments: Deployment[] | undefined
+  isLoading: boolean
+  isError: boolean
+  deleteMutation: UseMutationResult<void, Error, string>
+}
+
+export function DeploymentTable({ deployments, isLoading, isError, deleteMutation }: Props) {
+  if (isLoading) return <p className="text-sm text-gray-500">Loading deployments…</p>
+  if (isError) return <p className="text-sm text-red-600">Failed to load deployments.</p>
+  if (!deployments?.length) return <p className="text-sm text-gray-500">No deployments yet.</p>
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50 border-b border-gray-200">
+          <tr>
+            <th className="text-left px-4 py-3 font-medium text-gray-600">Name</th>
+            <th className="text-left px-4 py-3 font-medium text-gray-600">Image</th>
+            <th className="text-left px-4 py-3 font-medium text-gray-600">Status</th>
+            <th className="px-4 py-3" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {deployments.map(d => (
+            <DeploymentRow
+              key={d.id}
+              deployment={d}
+              onDelete={id => deleteMutation.mutate(id)}
+              isDeleting={deleteMutation.isPending}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/dashboard/src/deployments/StatusBadge.tsx
+++ b/dashboard/src/deployments/StatusBadge.tsx
@@ -1,0 +1,26 @@
+import type { DeploymentStatus } from '../lib/api'
+
+const STATUS_STYLES: Record<DeploymentStatus, string> = {
+  idle: 'bg-gray-100 text-gray-600',
+  deploying: 'bg-blue-100 text-blue-700',
+  healthy: 'bg-green-100 text-green-700',
+  failed: 'bg-red-100 text-red-700',
+}
+
+type Props = {
+  status: DeploymentStatus
+  error?: string
+}
+
+export function StatusBadge({ status, error }: Props) {
+  return (
+    <>
+      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[status]}`}>
+        {status}
+      </span>
+      {status === 'failed' && error && (
+        <p className="mt-1 text-xs text-red-600">{error}</p>
+      )}
+    </>
+  )
+}

--- a/dashboard/src/deployments/useDeploymentList.ts
+++ b/dashboard/src/deployments/useDeploymentList.ts
@@ -1,0 +1,18 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getDeployments, deleteDeployment } from '../lib/api'
+
+export function useDeploymentList() {
+  const queryClient = useQueryClient()
+
+  const { data: deployments, isLoading, isError } = useQuery({
+    queryKey: ['deployments'],
+    queryFn: getDeployments,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteDeployment,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['deployments'] }),
+  })
+
+  return { deployments, isLoading, isError, deleteMutation }
+}

--- a/dashboard/src/pages/DeploymentList.tsx
+++ b/dashboard/src/pages/DeploymentList.tsx
@@ -1,82 +1,17 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Trash2 } from 'lucide-react'
-import { getDeployments, deleteDeployment, type DeploymentStatus } from '../lib/api'
 import CreateDeploymentForm from '../deployments/CreateDeploymentForm'
+import { DeploymentTable } from '../deployments/DeploymentTable'
+import { useDeploymentList } from '../deployments/useDeploymentList'
 import { useDeploymentSSE } from '../deployments/useDeploymentSSE'
 
-const STATUS_STYLES: Record<DeploymentStatus, string> = {
-  idle: 'bg-gray-100 text-gray-600',
-  deploying: 'bg-blue-100 text-blue-700',
-  healthy: 'bg-green-100 text-green-700',
-  failed: 'bg-red-100 text-red-700',
-}
-
 export default function DeploymentList() {
-  const queryClient = useQueryClient()
   useDeploymentSSE()
-
-  const { data: deployments, isLoading, isError } = useQuery({
-    queryKey: ['deployments'],
-    queryFn: getDeployments,
-  })
-
-  const deleteMutation = useMutation({
-    mutationFn: deleteDeployment,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['deployments'] }),
-  })
+  const listState = useDeploymentList()
 
   return (
     <main className="max-w-4xl mx-auto px-6 py-10">
       <h1 className="text-2xl font-semibold text-gray-900 mb-8">Deployments</h1>
-
       <CreateDeploymentForm />
-
-      {/* Deployment table */}
-      {isLoading && <p className="text-sm text-gray-500">Loading deployments…</p>}
-      {isError && <p className="text-sm text-red-600">Failed to load deployments.</p>}
-      {deployments && deployments.length === 0 && (
-        <p className="text-sm text-gray-500">No deployments yet.</p>
-      )}
-      {deployments && deployments.length > 0 && (
-        <div className="border border-gray-200 rounded-lg overflow-hidden shadow-sm">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Name</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Image</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Status</th>
-                <th className="px-4 py-3" />
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {deployments.map(d => (
-                <tr key={d.id} className="bg-white hover:bg-gray-50">
-                  <td className="px-4 py-3 font-medium text-gray-900">{d.name}</td>
-                  <td className="px-4 py-3 text-gray-600 font-mono text-xs">{d.image}</td>
-                  <td className="px-4 py-3">
-                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[d.status]}`}>
-                      {d.status}
-                    </span>
-                    {d.status === 'failed' && d.error && (
-                      <p className="mt-1 text-xs text-red-600">{d.error}</p>
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <button
-                      onClick={() => deleteMutation.mutate(d.id)}
-                      disabled={deleteMutation.isPending}
-                      aria-label={`Delete ${d.name}`}
-                      className="p-1.5 rounded text-gray-400 hover:text-red-600 hover:bg-red-50 disabled:opacity-40"
-                    >
-                      <Trash2 size={15} />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <DeploymentTable {...listState} />
     </main>
   )
 }


### PR DESCRIPTION
## Summary

- Extract `useDeploymentList` hook for query + delete mutation (was inline in the page)
- Extract `StatusBadge` component for the coloured status pill + failed error text
- Extract `DeploymentRow` component for the single `<tr>` (~30 lines)
- Extract `DeploymentTable` component for the table shell + loading/error/empty states (~42 lines)
- `DeploymentList` page reduced to layout-only (~16 lines)

No behaviour changes — SSE, create, and delete all wire through the same logic as before.

## Test plan

- [ ] `make dev` — dashboard loads at `:5173`, deployments table renders correctly
- [ ] Create a deployment — form still works, new row appears
- [ ] Delete a deployment — row disappears
- [ ] Trigger a deployment from the orchestrator — SSE updates status badge in real time
- [ ] `bun run tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)