### PR TITLE
feat(control-plane): PATCH endpoint + start-then-stop redeploy strategy

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -18,6 +18,7 @@ type Store interface {
 	Get(id string) (store.Deployment, error)
 	Create(d store.Deployment) (store.Deployment, error)
 	Update(d store.Deployment) (store.Deployment, error)
+	Patch(id string, patch store.Deployment) (store.Deployment, error)
 	Delete(id string) error
 }
 
@@ -29,6 +30,14 @@ type EventBus interface {
 
 type deploymentRequest struct {
 	Name    string            `json:"name"`
+	Image   string            `json:"image"`
+	Envs    map[string]string `json:"envs"`
+	Ports   []string          `json:"ports"`
+	Volumes []string          `json:"volumes"`
+	Domain  string            `json:"domain"`
+}
+
+type patchDeploymentRequest struct {
 	Image   string            `json:"image"`
 	Envs    map[string]string `json:"envs"`
 	Ports   []string          `json:"ports"`
@@ -210,18 +219,15 @@ func (h *Handler) updateDeploymentStatus(w http.ResponseWriter, r *http.Request)
 
 func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	var body deploymentRequest
 
+	var body patchDeploymentRequest
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
-
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
 
-	deployment := store.Deployment{
-		ID:      id,
-		Name:    body.Name,
+	patch := store.Deployment{
 		Image:   body.Image,
 		Envs:    body.Envs,
 		Ports:   body.Ports,
@@ -229,16 +235,23 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 		Domain:  body.Domain,
 		Status:  store.StatusDeploying,
 	}
-	updated, err := h.store.Update(deployment)
+
+	updated, err := h.store.Patch(id, patch)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			http.Error(w, "deployment not found", http.StatusNotFound)
 			return
 		}
-		http.Error(w, "error updating deployment", http.StatusBadRequest)
+		http.Error(w, "failed to update deployment", http.StatusInternalServerError)
 		return
 	}
-	writeJSON(w, http.StatusOK, updated)
+
+	h.events.Publish(events.StatusEvent{
+		DeploymentID: id,
+		Status:       string(store.StatusDeploying),
+	})
+
+	writeJSON(w, http.StatusAccepted, updated)
 }
 
 // deploymentEvents streams deployment status-change events as SSE.

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -80,12 +80,50 @@ func (m *memStore) Delete(id string) error {
 	return nil
 }
 
+func (m *memStore) Patch(id string, patch store.Deployment) (store.Deployment, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.deployments[id]
+	if !ok {
+		return store.Deployment{}, store.ErrNotFound
+	}
+	if patch.Image != "" {
+		d.Image = patch.Image
+	}
+	if patch.Envs != nil {
+		d.Envs = patch.Envs
+	}
+	if patch.Ports != nil {
+		d.Ports = patch.Ports
+	}
+	if patch.Volumes != nil {
+		d.Volumes = patch.Volumes
+	}
+	if patch.Domain != "" {
+		d.Domain = patch.Domain
+	}
+	if patch.Status != "" {
+		d.Status = patch.Status
+	}
+	m.deployments[id] = d
+	return d, nil
+}
+
 // failUpdateStore wraps memStore but always fails on Update.
 type failUpdateStore struct {
 	*memStore
 }
 
 func (f *failUpdateStore) Update(_ store.Deployment) (store.Deployment, error) {
+	return store.Deployment{}, errors.New("disk full")
+}
+
+// failPatchStore wraps memStore but always fails on Patch.
+type failPatchStore struct {
+	*memStore
+}
+
+func (f *failPatchStore) Patch(_ string, _ store.Deployment) (store.Deployment, error) {
 	return store.Deployment{}, errors.New("disk full")
 }
 
@@ -372,6 +410,9 @@ func (e *errStore) Create(_ store.Deployment) (store.Deployment, error) {
 	return store.Deployment{}, errors.New("disk full")
 }
 func (e *errStore) Update(_ store.Deployment) (store.Deployment, error) {
+	return store.Deployment{}, errors.New("disk full")
+}
+func (e *errStore) Patch(_ string, _ store.Deployment) (store.Deployment, error) {
 	return store.Deployment{}, errors.New("disk full")
 }
 func (e *errStore) Delete(_ string) error { return errors.New("disk full") }
@@ -696,5 +737,147 @@ func TestUpdateDeploymentStatus_InvalidBody(t *testing.T) {
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestPatchDeployment(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{
+		ID:     "d1",
+		Name:   "web",
+		Image:  "nginx:1",
+		Envs:   map[string]string{"PORT": "80"},
+		Ports:  []string{"80:80"},
+		Status: store.StatusHealthy,
+	}
+
+	srv := newTestServer(s)
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"image": "nginx:2"})
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/deployments/d1: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", resp.StatusCode)
+	}
+
+	var updated store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if updated.Image != "nginx:2" {
+		t.Errorf("want image nginx:2, got %s", updated.Image)
+	}
+	if updated.Status != store.StatusDeploying {
+		t.Errorf("want status deploying, got %s", updated.Status)
+	}
+	// Unpatched fields must be preserved.
+	if updated.Name != "web" {
+		t.Errorf("want name web, got %s", updated.Name)
+	}
+	if updated.Envs["PORT"] != "80" {
+		t.Errorf("want PORT=80 preserved, got %v", updated.Envs)
+	}
+}
+
+func TestPatchDeployment_NotFound(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"image": "nginx:2"})
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/nonexistent", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/deployments/nonexistent: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestPatchDeployment_StoreError(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Status: store.StatusHealthy}
+
+	srv := newTestServer(&failPatchStore{s})
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"image": "nginx:2"})
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/deployments/d1 store error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestPatchDeployment_InvalidBody(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/d1", bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/deployments/d1 invalid body: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestPatchDeployment_EmitsDeployingEvent(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Image: "nginx:1", Status: store.StatusHealthy}
+
+	broker := events.NewBroker()
+	srv := newTestServerWithBroker(s, broker)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	evtCh := readSSEEvents(ctx, t, srv.URL+"/api/deployments/events")
+	time.Sleep(50 * time.Millisecond)
+
+	body, _ := json.Marshal(map[string]string{"image": "nginx:2"})
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/deployments/d1: %v", err)
+	}
+	resp.Body.Close()
+
+	select {
+	case event := <-evtCh:
+		if event.DeploymentID != "d1" {
+			t.Errorf("want deploymentId d1, got %s", event.DeploymentID)
+		}
+		if event.Status != string(store.StatusDeploying) {
+			t.Errorf("want status deploying, got %s", event.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: no SSE event received after PATCH")
 	}
 }

--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -38,6 +39,7 @@ type Client interface {
 	ContainerList(ctx context.Context, options container.ListOptions) ([]dockertypes.Container, error)
 	ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error
 	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
+	ContainerRename(ctx context.Context, containerID string, newName string) error
 }
 
 // Docker manages container lifecycle for Dirigent deployments.
@@ -160,6 +162,90 @@ func (d *Docker) StopAndRemove(ctx context.Context, containerID string) error {
 			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 		}
 		return fmt.Errorf("docker: remove container %s: %w", containerID, err)
+	}
+
+	return nil
+}
+
+// StartAndReplace implements a start-then-stop redeploy strategy: it pulls the new
+// image, starts a temporary container, verifies it reaches running state, then stops
+// and removes the old container before renaming the new one to the deployment name.
+// If the new container fails to reach running state the old container is left intact
+// and an error is returned.
+func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldContainerID string) error {
+	if _, err := d.client.Ping(ctx); err != nil {
+		return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+	}
+
+	rc, err := d.client.ImagePull(ctx, dep.Image, image.PullOptions{})
+	if err != nil {
+		if dockerclient.IsErrConnectionFailed(err) {
+			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		}
+		return fmt.Errorf("docker: pull image %s: %w", dep.Image, err)
+	}
+	_, _ = io.Copy(io.Discard, rc)
+	rc.Close()
+
+	env := envsToSlice(dep.Envs)
+
+	exposedPorts, portBindings, err := parsePorts(dep.Ports)
+	if err != nil {
+		return fmt.Errorf("docker: parse ports: %w", err)
+	}
+
+	cfg := &container.Config{
+		Image:        dep.Image,
+		Env:          env,
+		ExposedPorts: exposedPorts,
+		Labels: map[string]string{
+			"dirigent.managed": "true",
+			"dirigent.id":      dep.ID,
+		},
+	}
+	hostCfg := &container.HostConfig{
+		PortBindings: portBindings,
+		Binds:        dep.Volumes,
+	}
+
+	nextName := dep.Name + "-next"
+	resp, err := d.client.ContainerCreate(ctx, cfg, hostCfg, nil, nil, nextName)
+	if err != nil {
+		if dockerclient.IsErrConnectionFailed(err) {
+			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		}
+		return fmt.Errorf("docker: create container %s: %w", nextName, err)
+	}
+
+	if err := d.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
+		if dockerclient.IsErrConnectionFailed(err) {
+			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		}
+		return fmt.Errorf("docker: start container %s: %w", resp.ID, err)
+	}
+
+	// Verify the new container reached running state.
+	f := filters.NewArgs(filters.Arg("id", resp.ID))
+	running, err := d.client.ContainerList(ctx, container.ListOptions{All: false, Filters: f})
+	if err != nil {
+		_ = d.client.ContainerStop(ctx, resp.ID, container.StopOptions{})
+		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
+		return fmt.Errorf("docker: inspect new container %s: %w", resp.ID, err)
+	}
+	if len(running) == 0 {
+		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
+		return fmt.Errorf("docker: new container %s did not reach running state", resp.ID)
+	}
+
+	// New container is healthy; tear down the old one.
+	if err := d.StopAndRemove(ctx, oldContainerID); err != nil {
+		log.Printf("docker: remove old container %s: %v", oldContainerID, err)
+	}
+
+	// Rename new container to the canonical deployment name.
+	if err := d.client.ContainerRename(ctx, resp.ID, dep.Name); err != nil {
+		log.Printf("docker: rename %s to %s: %v", resp.ID, dep.Name, err)
 	}
 
 	return nil

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -28,8 +28,10 @@ type mockClient struct {
 	listErr         error
 	stopErr         error
 	removeErr       error
+	renameErr       error
 	stopped         []string
 	removed         []string
+	renamed         []string
 }
 
 func (m *mockClient) Ping(_ context.Context) (dockertypes.Ping, error) {
@@ -63,6 +65,11 @@ func (m *mockClient) ContainerStop(_ context.Context, id string, _ container.Sto
 func (m *mockClient) ContainerRemove(_ context.Context, id string, _ container.RemoveOptions) error {
 	m.removed = append(m.removed, id)
 	return m.removeErr
+}
+
+func (m *mockClient) ContainerRename(_ context.Context, id string, _ string) error {
+	m.renamed = append(m.renamed, id)
+	return m.renameErr
 }
 
 func deployment() store.Deployment {
@@ -152,6 +159,58 @@ func TestDocker_StopAndRemove(t *testing.T) {
 	}
 	if len(mock.removed) != 1 || mock.removed[0] != "c1" {
 		t.Errorf("want c1 removed, got %v", mock.removed)
+	}
+}
+
+func TestDocker_StartAndReplace_OK(t *testing.T) {
+	mock := &mockClient{
+		containerCreate: container.CreateResponse{ID: "new-c1"},
+		// ContainerList returns the new container as running.
+		listContainers: []dockertypes.Container{
+			{ID: "new-c1", State: "running"},
+		},
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	if err := d.StartAndReplace(context.Background(), dep, "old-c1"); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+
+	// Old container must be stopped and removed.
+	if len(mock.stopped) != 1 || mock.stopped[0] != "old-c1" {
+		t.Errorf("want old-c1 stopped, got %v", mock.stopped)
+	}
+	if len(mock.removed) != 1 || mock.removed[0] != "old-c1" {
+		t.Errorf("want old-c1 removed, got %v", mock.removed)
+	}
+
+	// New container must be renamed to the deployment name.
+	if len(mock.renamed) != 1 || mock.renamed[0] != "new-c1" {
+		t.Errorf("want new-c1 renamed, got %v", mock.renamed)
+	}
+}
+
+func TestDocker_StartAndReplace_NewContainerNotRunning(t *testing.T) {
+	mock := &mockClient{
+		containerCreate: container.CreateResponse{ID: "new-c1"},
+		// Empty list means the new container is not running.
+		listContainers: []dockertypes.Container{},
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	err := d.StartAndReplace(context.Background(), dep, "old-c1")
+	if err == nil {
+		t.Fatal("want error when new container is not running, got nil")
+	}
+
+	// Old container must NOT have been touched.
+	if len(mock.stopped) != 0 {
+		t.Errorf("want old container untouched, got stopped: %v", mock.stopped)
+	}
+	if len(mock.removed) != 1 || mock.removed[0] != "new-c1" {
+		t.Errorf("want only new container cleaned up, got removed: %v", mock.removed)
 	}
 }
 

--- a/orchestrator/internal/reconciler/reconciler.go
+++ b/orchestrator/internal/reconciler/reconciler.go
@@ -12,6 +12,7 @@ import (
 // Docker is the container management interface required by the reconciler.
 type Docker interface {
 	Start(ctx context.Context, d store.Deployment) error
+	StartAndReplace(ctx context.Context, d store.Deployment, oldContainerID string) error
 	ListManagedContainers(ctx context.Context) ([]docker.ManagedContainer, error)
 	StopAndRemove(ctx context.Context, containerID string) error
 }
@@ -73,7 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		switch d.Status {
 		case store.StatusDeploying:
 			if !hasContainer {
-				// Start the container.
+				// Fresh deploy: no container exists yet — start one.
 				if err := r.docker.Start(ctx, d); err != nil {
 					log.Printf("reconciler: start %s (%s): %v", d.ID, d.Name, err)
 					r.updateStatus(d.ID, store.StatusFailed)
@@ -81,7 +82,13 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 					r.updateStatus(d.ID, store.StatusHealthy)
 				}
 			} else if c.Running {
-				r.updateStatus(d.ID, store.StatusHealthy)
+				// Container already running — this is a redeploy; apply start-then-stop.
+				if err := r.docker.StartAndReplace(ctx, d, c.ID); err != nil {
+					log.Printf("reconciler: redeploy %s (%s): %v", d.ID, d.Name, err)
+					r.updateStatus(d.ID, store.StatusFailed)
+				} else {
+					r.updateStatus(d.ID, store.StatusHealthy)
+				}
 			} else {
 				r.updateStatus(d.ID, store.StatusFailed)
 			}

--- a/orchestrator/internal/reconciler/reconciler_test.go
+++ b/orchestrator/internal/reconciler/reconciler_test.go
@@ -77,11 +77,13 @@ func (m *mockStore) getStatus(id string) store.Status {
 
 // mockDocker is a controllable Docker client for testing.
 type mockDocker struct {
-	mu         sync.Mutex
-	containers []docker.ManagedContainer
-	startErr   error
-	started    []string
-	removed    []string
+	mu                    sync.Mutex
+	containers            []docker.ManagedContainer
+	startErr              error
+	startAndReplaceErr    error
+	started               []string
+	replaced              []string // old container IDs passed to StartAndReplace
+	removed               []string
 }
 
 func (m *mockDocker) Start(_ context.Context, d store.Deployment) error {
@@ -91,6 +93,17 @@ func (m *mockDocker) Start(_ context.Context, d store.Deployment) error {
 		return m.startErr
 	}
 	m.started = append(m.started, d.ID)
+	return nil
+}
+
+func (m *mockDocker) StartAndReplace(_ context.Context, d store.Deployment, oldContainerID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.startAndReplaceErr != nil {
+		return m.startAndReplaceErr
+	}
+	m.started = append(m.started, d.ID)
+	m.replaced = append(m.replaced, oldContainerID)
 	return nil
 }
 
@@ -148,10 +161,10 @@ func TestReconcile_DeployingNoContainer_StartFails_BecomesFailed(t *testing.T) {
 	}
 }
 
-func TestReconcile_DeployingWithRunningContainer_BecomesHealthy(t *testing.T) {
+func TestReconcile_DeployingWithRunningContainer_RedeploysAndBecomesHealthy(t *testing.T) {
 	s := &mockStore{
 		deployments: []store.Deployment{
-			{ID: "d1", Name: "web", Status: store.StatusDeploying},
+			{ID: "d1", Name: "web", Image: "nginx:2", Status: store.StatusDeploying},
 		},
 	}
 	d := &mockDocker{
@@ -165,8 +178,39 @@ func TestReconcile_DeployingWithRunningContainer_BecomesHealthy(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 
+	// StartAndReplace must have been called with the old container ID.
+	if len(d.replaced) != 1 || d.replaced[0] != "c1" {
+		t.Errorf("want StartAndReplace called with c1, got %v", d.replaced)
+	}
 	if s.getStatus("d1") != store.StatusHealthy {
 		t.Errorf("want status healthy, got %s", s.getStatus("d1"))
+	}
+}
+
+func TestReconcile_Redeploy_FailedNewContainer_KeepsOldAndBecomesFailed(t *testing.T) {
+	s := &mockStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Name: "web", Image: "nginx:bad", Status: store.StatusDeploying},
+		},
+	}
+	d := &mockDocker{
+		containers: []docker.ManagedContainer{
+			{ID: "c1", DeploymentID: "d1", Running: true},
+		},
+		startAndReplaceErr: errors.New("new container did not reach running state"),
+	}
+	r := reconciler.New(s, d, nil)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	// Old container must not have been removed.
+	if len(d.removed) != 0 {
+		t.Errorf("want old container untouched, got removed: %v", d.removed)
+	}
+	if s.getStatus("d1") != store.StatusFailed {
+		t.Errorf("want status failed, got %s", s.getStatus("d1"))
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -244,6 +244,51 @@ func (s *JSONStore) Update(d Deployment) (Deployment, error) {
 	return d, nil
 }
 
+// Patch merges the non-zero fields of patch into the stored deployment and persists atomically.
+// Only image, envs, ports, volumes, domain, and status are merged; id and name are immutable.
+// Returns ErrNotFound if no deployment with that ID exists.
+func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
+	var result Deployment
+	err := s.withLock(func() error {
+		data, err := s.read()
+		if err != nil {
+			return err
+		}
+		d, ok := data[id]
+		if !ok {
+			return ErrNotFound
+		}
+		if patch.Image != "" {
+			d.Image = patch.Image
+		}
+		if patch.Envs != nil {
+			d.Envs = patch.Envs
+		}
+		if patch.Ports != nil {
+			d.Ports = patch.Ports
+		}
+		if patch.Volumes != nil {
+			d.Volumes = patch.Volumes
+		}
+		if patch.Domain != "" {
+			d.Domain = patch.Domain
+		}
+		if patch.Status != "" {
+			d.Status = patch.Status
+		}
+		data[id] = d
+		if err := s.persist(data); err != nil {
+			return err
+		}
+		result = d
+		return nil
+	})
+	if err != nil {
+		return Deployment{}, err
+	}
+	return result, nil
+}
+
 // Delete removes the deployment with the given ID.
 // Returns ErrNotFound if no such deployment exists.
 func (s *JSONStore) Delete(id string) error {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -289,6 +289,82 @@ func TestJSONStore_UpdateStatus(t *testing.T) {
 	}
 }
 
+func TestJSONStore_Patch_MergesFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deployments.json")
+	s, err := store.NewJSONStore(path)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	_, err = s.Create(store.Deployment{
+		ID:      "d1",
+		Name:    "web",
+		Image:   "nginx:1",
+		Envs:    map[string]string{"PORT": "80"},
+		Ports:   []string{"80:80"},
+		Volumes: []string{"/data:/data"},
+		Domain:  "example.com",
+		Status:  store.StatusHealthy,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Patch only image and status; all other fields must be preserved.
+	updated, err := s.Patch("d1", store.Deployment{
+		Image:  "nginx:2",
+		Status: store.StatusDeploying,
+	})
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	if updated.Image != "nginx:2" {
+		t.Errorf("want image nginx:2, got %s", updated.Image)
+	}
+	if updated.Status != store.StatusDeploying {
+		t.Errorf("want status deploying, got %s", updated.Status)
+	}
+	// Unspecified fields must be retained.
+	if updated.Name != "web" {
+		t.Errorf("want name web, got %s", updated.Name)
+	}
+	if updated.Envs["PORT"] != "80" {
+		t.Errorf("want PORT=80, got %v", updated.Envs)
+	}
+	if len(updated.Ports) != 1 || updated.Ports[0] != "80:80" {
+		t.Errorf("want ports [80:80], got %v", updated.Ports)
+	}
+	if len(updated.Volumes) != 1 || updated.Volumes[0] != "/data:/data" {
+		t.Errorf("want volumes [/data:/data], got %v", updated.Volumes)
+	}
+	if updated.Domain != "example.com" {
+		t.Errorf("want domain example.com, got %s", updated.Domain)
+	}
+
+	// Verify persistence.
+	reloaded, err := s.Get("d1")
+	if err != nil {
+		t.Fatalf("get after patch: %v", err)
+	}
+	if reloaded.Image != "nginx:2" {
+		t.Errorf("want persisted image nginx:2, got %s", reloaded.Image)
+	}
+}
+
+func TestJSONStore_Patch_NotFound(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deployments.json")
+	s, err := store.NewJSONStore(path)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	_, err = s.Patch("nonexistent", store.Deployment{Image: "nginx:2"})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
 func TestJSONStore_UpdateStatus_MissingID_NoOp(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "deployments.json")
 


### PR DESCRIPTION
## Summary

- **`Store.Patch(id, patch)`** — atomic partial-field merge; only `image`, `envs`, `ports`, `volumes`, `domain`, and `status` are merged; `id` and `name` are immutable; returns `ErrNotFound` if the ID is missing
- **`PATCH /api/deployments/{id}`** — accepts partial body, sets status to `deploying`, returns 202 Accepted with the updated record, and publishes a deploying SSE event to connected subscribers
- **`Docker.StartAndReplace`** — implements start-then-stop: pull new image → start temp container (`<name>-next`) → verify running via `ContainerList` → stop/remove old → rename new to deployment name; if the new container fails to reach running state the old is left intact and an error is returned
- **Reconciler** — `StatusDeploying + running container` now dispatches `StartAndReplace` (redeploy path) rather than optimistically marking healthy; `StatusDeploying + no container` continues to call `Start` (initial deploy path)

## Test plan

- [x] `TestJSONStore_Patch_MergesFields` — partial merge preserves unspecified fields and persists
- [x] `TestJSONStore_Patch_NotFound` — returns `ErrNotFound` for unknown ID
- [x] `TestPatchDeployment` — 202, merged fields, status = deploying
- [x] `TestPatchDeployment_NotFound` — 404
- [x] `TestPatchDeployment_StoreError` — 500
- [x] `TestPatchDeployment_InvalidBody` — 400
- [x] `TestPatchDeployment_EmitsDeployingEvent` — SSE deploying event published
- [x] `TestDocker_StartAndReplace_OK` — old container stopped/removed, new container renamed
- [x] `TestDocker_StartAndReplace_NewContainerNotRunning` — old container untouched, new container cleaned up, error returned
- [x] `TestReconcile_DeployingWithRunningContainer_RedeploysAndBecomesHealthy` — `StartAndReplace` called, status healthy
- [x] `TestReconcile_Redeploy_FailedNewContainer_KeepsOldAndBecomesFailed` — old container untouched, status failed
- [x] All existing tests continue to pass (`go test ./...` across all modules)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)