### PR TITLE
fix: run CI on PR open

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [synchronize]
+    types: [opened, synchronize]
     branches: [main]
 jobs:
   go:


### PR DESCRIPTION
## Summary
- Add `opened` trigger to CI workflow so it runs when PR is first created