### PR TITLE
feat(api): add PUT /api/deployments/{id} for full deployment edit

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -62,6 +62,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/deployments", h.createDeployment)
 	mux.HandleFunc("GET /api/deployments/events", h.deploymentEvents)
 	mux.HandleFunc("GET /api/deployments/{id}", h.getDeployment)
+	mux.HandleFunc("PUT /api/deployments/{id}", h.updateDeployment)
 	mux.HandleFunc("DELETE /api/deployments/{id}", h.deleteDeployment)
 	mux.HandleFunc("PATCH /api/deployments/{id}/status", h.updateDeploymentStatus)
 	mux.HandleFunc("PATCH /api/deployments/{id}", h.patchDeployment)
@@ -152,6 +153,60 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 	})
 
 	writeJSON(w, http.StatusCreated, created)
+}
+
+func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var body deploymentRequest
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if body.Name == "" || body.Image == "" {
+		http.Error(w, "name and image are required", http.StatusBadRequest)
+		return
+	}
+
+	if body.Envs == nil {
+		body.Envs = map[string]string{}
+	}
+	if body.Ports == nil {
+		body.Ports = []string{}
+	}
+	if body.Volumes == nil {
+		body.Volumes = []string{}
+	}
+
+	d := store.Deployment{
+		ID:      id,
+		Name:    body.Name,
+		Image:   body.Image,
+		Envs:    body.Envs,
+		Ports:   body.Ports,
+		Volumes: body.Volumes,
+		Domain:  body.Domain,
+		Status:  store.StatusDeploying,
+	}
+
+	updated, err := h.store.Update(d)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(w, "deployment not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to update deployment", http.StatusInternalServerError)
+		return
+	}
+
+	h.events.Publish(events.StatusEvent{
+		DeploymentID: updated.ID,
+		Status:       string(store.StatusDeploying),
+	})
+
+	writeJSON(w, http.StatusOK, updated)
 }
 
 func (h *Handler) deleteDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -881,3 +881,200 @@ func TestPatchDeployment_EmitsDeployingEvent(t *testing.T) {
 		t.Fatal("timeout: no SSE event received after PATCH")
 	}
 }
+
+func TestUpdateDeployment(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{
+		ID:     "d1",
+		Name:   "web",
+		Image:  "nginx:1",
+		Status: store.StatusHealthy,
+	}
+
+	srv := newTestServer(s)
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"name":  "web",
+		"image": "nginx:2",
+		"ports": []string{"8080:80"},
+	})
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/deployments/d1: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var updated store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if updated.ID != "d1" {
+		t.Errorf("want id d1, got %s", updated.ID)
+	}
+	if updated.Image != "nginx:2" {
+		t.Errorf("want image nginx:2, got %s", updated.Image)
+	}
+	if updated.Status != store.StatusDeploying {
+		t.Errorf("want status deploying, got %s", updated.Status)
+	}
+}
+
+func TestUpdateDeployment_NotFound(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"name": "web", "image": "nginx:2"})
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/nonexistent", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/deployments/nonexistent: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateDeployment_InvalidBody(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/d1", bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/deployments/d1 invalid body: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateDeployment_MissingFields(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	cases := []map[string]string{
+		{"image": "nginx:2"}, // missing name
+		{"name": "web"},      // missing image
+		{},                   // both missing
+	}
+	for _, payload := range cases {
+		body, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("PUT /api/deployments/d1: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("payload %v: want 400, got %d", payload, resp.StatusCode)
+		}
+	}
+}
+
+func TestUpdateDeployment_StoreError(t *testing.T) {
+	srv := newTestServer(&errStore{})
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"name": "web", "image": "nginx:2"})
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/any", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/deployments/any store error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateDeployment_Lifecycle(t *testing.T) {
+	broker := events.NewBroker()
+	srv := newTestServerWithBroker(newMemStore(), broker)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	evtCh := readSSEEvents(ctx, t, srv.URL+"/api/deployments/events")
+	time.Sleep(50 * time.Millisecond)
+
+	// Step 1: create.
+	createBody, _ := json.Marshal(map[string]string{"name": "web", "image": "nginx:1"})
+	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("POST /api/deployments: %v", err)
+	}
+	var created store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+	if created.Status != store.StatusDeploying {
+		t.Fatalf("after create: want status deploying, got %s", created.Status)
+	}
+
+	select {
+	case event := <-evtCh:
+		if event.DeploymentID != created.ID || event.Status != string(store.StatusDeploying) {
+			t.Errorf("create event: want {%s deploying}, got {%s %s}", created.ID, event.DeploymentID, event.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: no SSE event after create")
+	}
+
+	// Step 2: edit (PUT) — triggers redeployment.
+	editBody, _ := json.Marshal(map[string]string{"name": "web", "image": "nginx:2"})
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/"+created.ID, bytes.NewReader(editBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/deployments/%s: %v", created.ID, err)
+	}
+	var edited store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&edited); err != nil {
+		t.Fatalf("decode edit response: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT: want 200, got %d", resp.StatusCode)
+	}
+	if edited.Image != "nginx:2" {
+		t.Errorf("after edit: want image nginx:2, got %s", edited.Image)
+	}
+	if edited.Status != store.StatusDeploying {
+		t.Errorf("after edit: want status deploying, got %s", edited.Status)
+	}
+
+	// Step 3: SSE must emit deploying for the edit.
+	select {
+	case event := <-evtCh:
+		if event.DeploymentID != created.ID {
+			t.Errorf("edit event: want deploymentId %s, got %s", created.ID, event.DeploymentID)
+		}
+		if event.Status != string(store.StatusDeploying) {
+			t.Errorf("edit event: want status deploying, got %s", event.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: no SSE event after PUT")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `PUT /api/deployments/{id}` handler that fully replaces a deployment's configuration and immediately transitions its status to `deploying`, signalling the orchestrator to redeploy the container on its next reconciliation pass
- Validates `name` and `image` as required fields (400 on missing), initialises nil `envs`/`ports`/`volumes` to empty collections, and returns 404 for unknown IDs
- Publishes a `deploying` SSE event on success so connected dashboard clients see the state change in real time

## Test plan

- [x] `TestUpdateDeployment` — happy path: 200, updated image, status `deploying`
- [x] `TestUpdateDeployment_NotFound` — 404 for unknown ID
- [x] `TestUpdateDeployment_InvalidBody` — 400 for malformed JSON
- [x] `TestUpdateDeployment_MissingFields` — 400 when `name` or `image` is absent
- [x] `TestUpdateDeployment_StoreError` — 500 on internal store failure
- [x] `TestUpdateDeployment_Lifecycle` — integration: create → PUT edit → SSE `deploying` event received

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)