### PR TITLE
feat(dashboard): add edit deployment form

### DIFF
--- a/dashboard/src/deployments/DeploymentRow.tsx
+++ b/dashboard/src/deployments/DeploymentRow.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from 'lucide-react'
+import { Pencil, Trash2 } from 'lucide-react'
 import type { Deployment } from '../lib/api'
 import { StatusBadge } from './StatusBadge'
 
@@ -6,9 +6,10 @@ type Props = {
   deployment: Deployment
   onDelete: (id: string) => void
   isDeleting: boolean
+  onEdit: (deployment: Deployment) => void
 }
 
-export function DeploymentRow({ deployment: d, onDelete, isDeleting }: Props) {
+export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: Props) {
   return (
     <tr className="bg-white hover:bg-gray-50">
       <td className="px-4 py-3 font-medium text-gray-900">{d.name}</td>
@@ -16,7 +17,14 @@ export function DeploymentRow({ deployment: d, onDelete, isDeleting }: Props) {
       <td className="px-4 py-3">
         <StatusBadge status={d.status} error={d.error} />
       </td>
-      <td className="px-4 py-3 text-right">
+      <td className="px-4 py-3 text-right flex items-center justify-end gap-1">
+        <button
+          onClick={() => onEdit(d)}
+          aria-label={`Edit ${d.name}`}
+          className="p-1.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100"
+        >
+          <Pencil size={15} />
+        </button>
         <button
           onClick={() => onDelete(d.id)}
           disabled={isDeleting}

--- a/dashboard/src/deployments/DeploymentTable.tsx
+++ b/dashboard/src/deployments/DeploymentTable.tsx
@@ -7,9 +7,10 @@ type Props = {
   isLoading: boolean
   isError: boolean
   deleteMutation: UseMutationResult<void, Error, string>
+  onEdit: (deployment: Deployment) => void
 }
 
-export function DeploymentTable({ deployments, isLoading, isError, deleteMutation }: Props) {
+export function DeploymentTable({ deployments, isLoading, isError, deleteMutation, onEdit }: Props) {
   if (isLoading) return <p className="text-sm text-gray-500">Loading deployments…</p>
   if (isError) return <p className="text-sm text-red-600">Failed to load deployments.</p>
   if (!deployments?.length) return <p className="text-sm text-gray-500">No deployments yet.</p>
@@ -32,6 +33,7 @@ export function DeploymentTable({ deployments, isLoading, isError, deleteMutatio
               deployment={d}
               onDelete={id => deleteMutation.mutate(id)}
               isDeleting={deleteMutation.isPending}
+              onEdit={onEdit}
             />
           ))}
         </tbody>

--- a/dashboard/src/deployments/EditDeploymentForm.tsx
+++ b/dashboard/src/deployments/EditDeploymentForm.tsx
@@ -1,0 +1,107 @@
+import type { Deployment } from '../lib/api'
+import { useEditDeploymentForm } from './useEditDeploymentForm'
+import { DynamicSection } from './DynamicSection'
+import type { EnvRow, PairRow } from './useCreateDeploymentForm'
+
+const inputCls = 'h-9 rounded-md border border-gray-300 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900 w-full'
+const inputErrCls = 'h-9 rounded-md border border-red-400 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-red-500 w-full'
+
+type Props = {
+  deployment: Deployment
+  onClose: () => void
+}
+
+export default function EditDeploymentForm({ deployment, onClose }: Props) {
+  const {
+    name, setName, image, setImage, domain, setDomain,
+    envRows, portRows, volumeRows,
+    errors, handleSubmit, isPending,
+  } = useEditDeploymentForm(deployment, onClose)
+
+  return (
+    <section className="mb-8 p-6 border border-gray-200 rounded-lg bg-white shadow-sm">
+      <h2 className="text-sm font-medium text-gray-700 mb-4">Edit deployment — {deployment.name}</h2>
+      <form onSubmit={handleSubmit} noValidate className="space-y-5">
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col gap-1">
+            <label htmlFor="edit-dep-name" className="text-xs text-gray-500">Name *</label>
+            <input id="edit-dep-name" type="text" placeholder="my-app" value={name}
+              onChange={e => setName(e.target.value)}
+              className={errors.name ? inputErrCls : inputCls} />
+            {errors.name && <p className="text-xs text-red-600">{errors.name}</p>}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="edit-dep-image" className="text-xs text-gray-500">Image *</label>
+            <input id="edit-dep-image" type="text" placeholder="nginx:latest" value={image}
+              onChange={e => setImage(e.target.value)}
+              className={errors.image ? inputErrCls : inputCls} />
+            {errors.image && <p className="text-xs text-red-600">{errors.image}</p>}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="edit-dep-domain" className="text-xs text-gray-500">Domain (optional)</label>
+          <input id="edit-dep-domain" type="text" placeholder="app.example.com" value={domain}
+            onChange={e => setDomain(e.target.value)} className={inputCls} />
+        </div>
+
+        <DynamicSection<EnvRow>
+          title="Environment variables" addLabel="Add env var" removeLabel="Remove env var"
+          rows={envRows.rows} onAdd={envRows.add} onRemove={envRows.remove}
+          errorFor={row => errors.envs[row.id]}
+          renderRow={row => (<>
+            <input type="text" placeholder="KEY" value={row.key}
+              onChange={e => envRows.update(row.id, { key: e.target.value })}
+              className={`${errors.envs[row.id] ? inputErrCls : inputCls} font-mono`} />
+            <input type="text" placeholder="value" value={row.value}
+              onChange={e => envRows.update(row.id, { value: e.target.value })}
+              className={inputCls} />
+          </>)}
+        />
+
+        <DynamicSection<PairRow>
+          title="Port mappings" addLabel="Add port mapping" removeLabel="Remove port mapping"
+          rows={portRows.rows} onAdd={portRows.add} onRemove={portRows.remove}
+          errorFor={row => errors.ports[row.id]}
+          renderRow={row => (<>
+            <input type="text" placeholder="Host port" value={row.left}
+              onChange={e => portRows.update(row.id, { left: e.target.value })}
+              className={errors.ports[row.id] ? inputErrCls : inputCls} />
+            <span className="text-gray-400 shrink-0 text-sm">:</span>
+            <input type="text" placeholder="Container port" value={row.right}
+              onChange={e => portRows.update(row.id, { right: e.target.value })}
+              className={errors.ports[row.id] ? inputErrCls : inputCls} />
+          </>)}
+        />
+
+        <DynamicSection<PairRow>
+          title="Volume mounts" addLabel="Add volume mount" removeLabel="Remove volume mount"
+          rows={volumeRows.rows} onAdd={volumeRows.add} onRemove={volumeRows.remove}
+          errorFor={row => errors.volumes[row.id]}
+          renderRow={row => (<>
+            <input type="text" placeholder="/host/path" value={row.left}
+              onChange={e => volumeRows.update(row.id, { left: e.target.value })}
+              className={`${errors.volumes[row.id] ? inputErrCls : inputCls} font-mono`} />
+            <span className="text-gray-400 shrink-0 text-sm">:</span>
+            <input type="text" placeholder="/container/path" value={row.right}
+              onChange={e => volumeRows.update(row.id, { right: e.target.value })}
+              className={`${errors.volumes[row.id] ? inputErrCls : inputCls} font-mono`} />
+          </>)}
+        />
+
+        {errors.form && <p className="text-xs text-red-600">{errors.form}</p>}
+        <div className="flex items-center gap-3">
+          <button type="submit" disabled={isPending}
+            className="h-9 px-4 rounded-md bg-gray-900 text-white text-sm font-medium hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed">
+            {isPending ? 'Saving…' : 'Save'}
+          </button>
+          <button type="button" onClick={onClose} disabled={isPending}
+            className="h-9 px-4 rounded-md border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed">
+            Cancel
+          </button>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/dashboard/src/deployments/useDynamicRows.ts
+++ b/dashboard/src/deployments/useDynamicRows.ts
@@ -2,9 +2,9 @@ import { useRef, useState } from 'react'
 
 export type Row = { id: number }
 
-export function useDynamicRows<T extends Row>(factory: (id: number) => T) {
-  const nextId = useRef(0)
-  const [rows, setRows] = useState<T[]>([])
+export function useDynamicRows<T extends Row>(factory: (id: number) => T, initialRows: T[] = []) {
+  const nextId = useRef(initialRows.length > 0 ? Math.max(...initialRows.map(r => r.id)) + 1 : 0)
+  const [rows, setRows] = useState<T[]>(initialRows)
 
   const add = () => {
     const id = nextId.current++

--- a/dashboard/src/deployments/useEditDeploymentForm.ts
+++ b/dashboard/src/deployments/useEditDeploymentForm.ts
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateDeployment, type Deployment } from '../lib/api'
+import { useDynamicRows } from './useDynamicRows'
+import type { EnvRow, FormErrors, PairRow } from './useCreateDeploymentForm'
+
+const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {} }
+
+function toEnvRows(envs: Record<string, string>): EnvRow[] {
+  return Object.entries(envs).map(([key, value], i) => ({ id: i, key, value }))
+}
+
+function toPairRows(items: string[]): PairRow[] {
+  return items.map((item, i) => {
+    const sep = item.indexOf(':')
+    return { id: i, left: sep >= 0 ? item.slice(0, sep) : item, right: sep >= 0 ? item.slice(sep + 1) : '' }
+  })
+}
+
+export function useEditDeploymentForm(deployment: Deployment, onClose: () => void) {
+  const queryClient = useQueryClient()
+
+  const [name, setName] = useState(deployment.name)
+  const [image, setImage] = useState(deployment.image)
+  const [domain, setDomain] = useState(deployment.domain)
+  const [errors, setErrors] = useState<FormErrors>(EMPTY_ERRORS)
+
+  const envRows = useDynamicRows<EnvRow>(id => ({ id, key: '', value: '' }), toEnvRows(deployment.envs))
+  const portRows = useDynamicRows<PairRow>(id => ({ id, left: '', right: '' }), toPairRows(deployment.ports))
+  const volumeRows = useDynamicRows<PairRow>(id => ({ id, left: '', right: '' }), toPairRows(deployment.volumes))
+
+  const mutation = useMutation({
+    mutationFn: (data: Parameters<typeof updateDeployment>[1]) => updateDeployment(deployment.id, data),
+    onSuccess: () => {
+      queryClient.setQueryData<Deployment[]>(['deployments'], prev =>
+        prev?.map(d => d.id === deployment.id ? { ...d, status: 'deploying' } : d)
+      )
+      onClose()
+    },
+    onError: (err: Error) => setErrors(prev => ({ ...prev, form: err.message })),
+  })
+
+  function validate(): boolean {
+    const errs: FormErrors = { envs: {}, ports: {}, volumes: {} }
+    if (!name.trim()) errs.name = 'Name is required'
+    if (!image.trim()) errs.image = 'Image is required'
+    for (const row of envRows.rows) {
+      if (!row.key.trim()) errs.envs[row.id] = 'Key is required'
+    }
+    for (const row of portRows.rows) {
+      if (!row.left.trim() || !row.right.trim())
+        errs.ports[row.id] = 'Both host and container ports are required'
+    }
+    for (const row of volumeRows.rows) {
+      if (!row.left.trim() || !row.right.trim())
+        errs.volumes[row.id] = 'Both host and container paths are required'
+    }
+    setErrors(errs)
+    return (
+      !errs.name &&
+      !errs.image &&
+      Object.keys(errs.envs).length === 0 &&
+      Object.keys(errs.ports).length === 0 &&
+      Object.keys(errs.volumes).length === 0
+    )
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+    const envs: Record<string, string> = {}
+    for (const row of envRows.rows) envs[row.key.trim()] = row.value
+    mutation.mutate({
+      name: name.trim(),
+      image: image.trim(),
+      envs,
+      ports: portRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
+      volumes: volumeRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
+      domain: domain.trim(),
+    })
+  }
+
+  return {
+    name, setName,
+    image, setImage,
+    domain, setDomain,
+    envRows,
+    portRows,
+    volumeRows,
+    errors,
+    handleSubmit,
+    isPending: mutation.isPending,
+  }
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -43,6 +43,25 @@ export async function createDeployment(data: CreateDeploymentInput): Promise<Dep
   return res.json()
 }
 
+export type UpdateDeploymentInput = {
+  name: string
+  image: string
+  envs: Record<string, string>
+  ports: string[]
+  volumes: string[]
+  domain: string
+}
+
+export async function updateDeployment(id: string, data: UpdateDeploymentInput): Promise<Deployment> {
+  const res = await fetch(`/api/deployments/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) throw new Error('Failed to update deployment')
+  return res.json()
+}
+
 export async function deleteDeployment(id: string): Promise<void> {
   const res = await fetch(`/api/deployments/${id}`, { method: 'DELETE' })
   if (!res.ok) throw new Error('Failed to delete deployment')

--- a/dashboard/src/pages/DeploymentList.tsx
+++ b/dashboard/src/pages/DeploymentList.tsx
@@ -1,17 +1,23 @@
+import { useState } from 'react'
 import CreateDeploymentForm from '../deployments/CreateDeploymentForm'
+import EditDeploymentForm from '../deployments/EditDeploymentForm'
 import { DeploymentTable } from '../deployments/DeploymentTable'
 import { useDeploymentList } from '../deployments/useDeploymentList'
 import { useDeploymentSSE } from '../deployments/useDeploymentSSE'
+import type { Deployment } from '../lib/api'
 
 export default function DeploymentList() {
   useDeploymentSSE()
   const listState = useDeploymentList()
+  const [editingDeployment, setEditingDeployment] = useState<Deployment | null>(null)
 
   return (
     <main className="max-w-4xl mx-auto px-6 py-10">
       <h1 className="text-2xl font-semibold text-gray-900 mb-8">Deployments</h1>
-      <CreateDeploymentForm />
-      <DeploymentTable {...listState} />
+      {editingDeployment
+        ? <EditDeploymentForm key={editingDeployment.id} deployment={editingDeployment} onClose={() => setEditingDeployment(null)} />
+        : <CreateDeploymentForm />}
+      <DeploymentTable {...listState} onEdit={setEditingDeployment} />
     </main>
   )
 }


### PR DESCRIPTION
## Summary

- Adds a pre-filled edit form that opens when clicking the pencil icon on any deployment row
- Saving calls `PUT /api/deployments/:id` and immediately transitions the status badge to `deploying`
- Reuses all existing form fields (name, image, domain, env vars, ports, volumes) via a new `useEditDeploymentForm` hook

## Changes

- `lib/api.ts` — added `updateDeployment(id, data)` calling `PUT /api/deployments/:id`
- `useDynamicRows.ts` — added optional `initialRows` param to seed dynamic sections at mount
- `useEditDeploymentForm.ts` — new hook that pre-fills from an existing `Deployment` and optimistically patches the query cache status to `deploying` on success
- `EditDeploymentForm.tsx` — new form component with Save + Cancel buttons
- `DeploymentRow.tsx` — added pencil icon Edit button
- `DeploymentTable.tsx` — threads `onEdit` callback down to rows
- `DeploymentList.tsx` — owns `editingDeployment` state and swaps create/edit form accordingly

## Test plan

- [ ] Click Edit on a deployment row — form opens pre-filled with its current values
- [ ] Change any field and click Save — status badge immediately shows `deploying`
- [ ] Click Cancel — form closes and create form reappears
- [ ] TypeScript build passes: `bun run build`
- [ ] All existing tests pass: `bun run vitest run`

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)