### PR TITLE
feat(proxy): HTTP proxy engine & domain routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev build test clean
+.PHONY: setup dev build test clean proxy
 
 AIR := $(shell go env GOPATH)/bin/air
 
@@ -13,6 +13,7 @@ dev:
 	@trap 'kill 0' SIGINT; \
 	(cd api && DIRIGENT_DATA=/tmp/dirigent.json $(AIR)) & \
 	(cd orchestrator && DIRIGENT_DATA=/tmp/dirigent.json $(AIR)) & \
+	(cd proxy && DIRIGENT_DATA=/tmp/dirigent.json DIRIGENT_PROXY_ADDR=:8090 $(AIR)) & \
 	(cd dashboard && bun run dev) & \
 	wait
 
@@ -20,13 +21,15 @@ dev:
 build:
 	cd api && go build -o ../dirigent ./cmd/dirigent
 	cd orchestrator && go build -o ../dirigent-orchestrator ./cmd/orchestrator
+	cd proxy && go build -o ../dirigent-proxy ./cmd/proxy
 
 # Run the Go test suites.
 test:
 	cd api && go test ./...
 	cd orchestrator && go test ./...
+	cd proxy && go test ./...
 
 # Remove build artifacts.
 clean:
-	rm -f dirigent dirigent-orchestrator
-	rm -rf api/tmp orchestrator/tmp
+	rm -f dirigent dirigent-orchestrator dirigent-proxy
+	rm -rf api/tmp orchestrator/tmp proxy/tmp

--- a/go.work
+++ b/go.work
@@ -3,5 +3,6 @@ go 1.24.0
 use (
 	./api
 	./orchestrator
+	./proxy
 	./store
 )

--- a/proxy/.air.toml
+++ b/proxy/.air.toml
@@ -1,0 +1,15 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  cmd = "go build -o ./tmp/proxy ./cmd/proxy"
+  bin = "./tmp/proxy"
+  include_ext = ["go"]
+  exclude_dir = ["tmp"]
+  delay = 1000
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = true

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ercadev/dirigent/proxy/internal/handler"
+	"github.com/ercadev/dirigent/proxy/internal/poller"
+	"github.com/ercadev/dirigent/proxy/internal/routing"
+	"github.com/ercadev/dirigent/store"
+)
+
+const defaultAddr = ":80"
+
+func dataPath() string {
+	if p := os.Getenv("DIRIGENT_DATA"); p != "" {
+		return p
+	}
+	return "/var/lib/dirigent/deployments.json"
+}
+
+func main() {
+	s, err := store.NewJSONStore(dataPath())
+	if err != nil {
+		log.Fatalf("proxy: open store: %v", err)
+	}
+
+	table := routing.NewTable()
+
+	interval := 5 * time.Second
+	if v := os.Getenv("DIRIGENT_POLL_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			interval = d
+		}
+	}
+
+	p := poller.New(s, table, interval)
+
+	mux := http.NewServeMux()
+	handler.New(table).RegisterRoutes(mux)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	go p.Run(ctx)
+
+	addr := defaultAddr
+	if v := os.Getenv("DIRIGENT_PROXY_ADDR"); v != "" {
+		addr = v
+	}
+
+	srv := &http.Server{Addr: addr, Handler: mux}
+
+	go func() {
+		<-ctx.Done()
+		if err := srv.Close(); err != nil {
+			log.Printf("proxy: shutdown: %v", err)
+		}
+	}()
+
+	log.Printf("proxy: listening on %s", addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("proxy: %v", err)
+	}
+}

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,0 +1,7 @@
+module github.com/ercadev/dirigent/proxy
+
+go 1.24.0
+
+require github.com/ercadev/dirigent/store v0.0.0
+
+replace github.com/ercadev/dirigent/store => ../store

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -1,0 +1,96 @@
+package handler
+
+import (
+	"encoding/json"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+// RoutingTable is the interface the handler reads from when proxying requests
+// and the control API writes to when swapping upstreams.
+type RoutingTable interface {
+	Get(domain string) (string, bool)
+	Set(domain, upstream string)
+}
+
+// Handler serves inbound HTTP requests by routing them to the upstream
+// registered for the request's Host header, and exposes a small control API
+// so the orchestrator can trigger upstream swaps during zero-downtime redeploys.
+type Handler struct {
+	table RoutingTable
+}
+
+// New creates a Handler backed by the given routing table.
+func New(table RoutingTable) *Handler {
+	return &Handler{table: table}
+}
+
+// RegisterRoutes wires the proxy catch-all and the internal control API into mux.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /internal/routes", h.setRoute)
+	mux.HandleFunc("/", h.proxy)
+}
+
+// proxy routes inbound requests to the upstream registered for the Host header.
+// Returns 404 for unknown domains and 502 when the upstream is unreachable.
+func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
+	host := r.Host
+	// Strip port if present (e.g. "example.com:80" → "example.com").
+	if bare, _, err := net.SplitHostPort(host); err == nil {
+		host = bare
+	}
+
+	upstream, ok := h.table.Get(host)
+	if !ok {
+		http.Error(w, "unknown domain", http.StatusNotFound)
+		return
+	}
+
+	target := &url.URL{
+		Scheme: "http",
+		Host:   upstream,
+	}
+
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Header.Set("X-Forwarded-Host", req.Host)
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("proxy: upstream %s: %v", upstream, err)
+			http.Error(w, "upstream unavailable", http.StatusBadGateway)
+		},
+	}
+
+	rp.ServeHTTP(w, r)
+}
+
+type routeRequest struct {
+	Domain   string `json:"domain"`
+	Upstream string `json:"upstream"`
+}
+
+// setRoute handles POST /internal/routes. The orchestrator calls this to swap
+// an upstream immediately during a zero-downtime redeploy without waiting for
+// the next store-poll cycle.
+func (h *Handler) setRoute(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+
+	var body routeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if body.Domain == "" || body.Upstream == "" {
+		http.Error(w, "domain and upstream are required", http.StatusBadRequest)
+		return
+	}
+
+	h.table.Set(body.Domain, body.Upstream)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -1,0 +1,224 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/ercadev/dirigent/proxy/internal/handler"
+)
+
+// testTable is an in-memory routing table used only in tests.
+type testTable struct {
+	mu     sync.RWMutex
+	routes map[string]string
+}
+
+func newTestTable() *testTable {
+	return &testTable{routes: make(map[string]string)}
+}
+
+func (t *testTable) Set(domain, upstream string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.routes[domain] = upstream
+}
+
+func (t *testTable) Get(domain string) (string, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	u, ok := t.routes[domain]
+	return u, ok
+}
+
+func newProxyServer(tbl *testTable) *httptest.Server {
+	mux := http.NewServeMux()
+	handler.New(tbl).RegisterRoutes(mux)
+	return httptest.NewServer(mux)
+}
+
+// TestProxy_KnownDomainReachesBackend verifies that a request whose Host header
+// matches a registered domain is forwarded to the correct backend container.
+func TestProxy_KnownDomainReachesBackend(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", backend.Listener.Addr().String())
+
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "example.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestProxy_UnknownDomainReturns404 verifies that requests for unregistered
+// domains are rejected with 404.
+func TestProxy_UnknownDomainReturns404(t *testing.T) {
+	proxy := newProxyServer(newTestTable())
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "unknown.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestProxy_RemovedDeploymentIsUnreachable is an integration test confirming
+// that after a deployment's domain is removed from the table the proxy stops
+// routing requests for that domain.
+func TestProxy_RemovedDeploymentIsUnreachable(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", backend.Listener.Addr().String())
+
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	// First request must succeed.
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "example.com"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("initial GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("initial: want 200, got %d", resp.StatusCode)
+	}
+
+	// Simulate deployment deletion: remove the domain from the table.
+	// (In production the store poller calls table.Delete; here we call it directly.)
+	tbl.mu.Lock()
+	delete(tbl.routes, "example.com")
+	tbl.mu.Unlock()
+
+	// Second request must now return 404.
+	req, _ = http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "example.com"
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post-removal GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("post-removal: want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestSetRoute_SetsUpstream(t *testing.T) {
+	tbl := newTestTable()
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	body, _ := json.Marshal(map[string]string{
+		"domain":   "example.com",
+		"upstream": "localhost:3000",
+	})
+	resp, err := http.Post(proxy.URL+"/internal/routes", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /internal/routes: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", resp.StatusCode)
+	}
+
+	upstream, ok := tbl.Get("example.com")
+	if !ok {
+		t.Fatal("want route registered, got not found")
+	}
+	if upstream != "localhost:3000" {
+		t.Errorf("want upstream localhost:3000, got %s", upstream)
+	}
+}
+
+func TestSetRoute_MissingFields(t *testing.T) {
+	proxy := newProxyServer(newTestTable())
+	defer proxy.Close()
+
+	cases := []map[string]string{
+		{"upstream": "localhost:3000"}, // missing domain
+		{"domain": "example.com"},     // missing upstream
+		{},                            // both missing
+	}
+
+	for _, payload := range cases {
+		body, _ := json.Marshal(payload)
+		resp, err := http.Post(proxy.URL+"/internal/routes", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST /internal/routes: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("payload %v: want 400, got %d", payload, resp.StatusCode)
+		}
+	}
+}
+
+func TestSetRoute_InvalidBody(t *testing.T) {
+	proxy := newProxyServer(newTestTable())
+	defer proxy.Close()
+
+	resp, err := http.Post(proxy.URL+"/internal/routes", "application/json", bytes.NewBufferString("not json"))
+	if err != nil {
+		t.Fatalf("POST /internal/routes: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxy_UpstreamUnavailableReturns502(t *testing.T) {
+	tbl := newTestTable()
+	// Point to a port nobody is listening on.
+	tbl.Set("example.com", "localhost:1")
+
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "example.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("want 502, got %d", resp.StatusCode)
+	}
+}

--- a/proxy/internal/poller/poller.go
+++ b/proxy/internal/poller/poller.go
@@ -1,0 +1,128 @@
+package poller
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/ercadev/dirigent/store"
+)
+
+// Table is the routing table the poller updates as deployments change.
+type Table interface {
+	Set(domain, upstream string)
+	Delete(domain string)
+}
+
+// Store is the persistence interface the poller reads from.
+type Store interface {
+	List() ([]store.Deployment, error)
+}
+
+// Poller watches the JSON store on disk and syncs the routing table whenever
+// deployments are created, updated, or removed.
+type Poller struct {
+	store    Store
+	table    Table
+	interval time.Duration
+	last     map[string]string // domain → upstream from the previous sync
+}
+
+// New creates a Poller that reads from s and updates t every interval.
+func New(s Store, t Table, interval time.Duration) *Poller {
+	return &Poller{
+		store:    s,
+		table:    t,
+		interval: interval,
+		last:     make(map[string]string),
+	}
+}
+
+// Run starts the polling loop and blocks until ctx is cancelled.
+// It performs an initial sync before the first tick so the routing table is
+// populated immediately on startup.
+func (p *Poller) Run(ctx context.Context) {
+	p.sync()
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			p.sync()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *Poller) sync() {
+	deployments, err := p.store.List()
+	if err != nil {
+		log.Printf("proxy poller: list deployments: %v", err)
+		return
+	}
+
+	// Build the current snapshot: domain → upstream for deployments that have
+	// both a domain and at least one port binding.
+	current := make(map[string]string, len(deployments))
+	for _, d := range deployments {
+		if d.Domain == "" {
+			continue
+		}
+		upstream := upstreamFromPorts(d.Ports)
+		if upstream == "" {
+			continue
+		}
+		current[d.Domain] = upstream
+	}
+
+	// Register new routes and update changed upstreams.
+	for domain, upstream := range current {
+		if p.last[domain] != upstream {
+			p.table.Set(domain, upstream)
+		}
+	}
+
+	// Remove routes for deployments that no longer have a domain or were deleted.
+	for domain := range p.last {
+		if _, ok := current[domain]; !ok {
+			p.table.Delete(domain)
+		}
+	}
+
+	p.last = current
+}
+
+// upstreamFromPorts extracts "localhost:<hostPort>" from the first usable
+// Docker port binding in the slice. Returns an empty string if no usable
+// binding is found.
+//
+// Accepted formats (matching Docker port specs):
+//   - "8080:80"              → localhost:8080
+//   - "8080:80/tcp"          → localhost:8080
+//   - "127.0.0.1:8080:80"   → localhost:8080
+func upstreamFromPorts(ports []string) string {
+	for _, p := range ports {
+		// Strip protocol suffix: "8080:80/tcp" → "8080:80"
+		if i := strings.IndexByte(p, '/'); i >= 0 {
+			p = p[:i]
+		}
+		parts := strings.Split(p, ":")
+		switch len(parts) {
+		case 2:
+			// "hostPort:containerPort"
+			if parts[0] != "" {
+				return "localhost:" + parts[0]
+			}
+		case 3:
+			// "ip:hostPort:containerPort"
+			if parts[1] != "" {
+				return "localhost:" + parts[1]
+			}
+		}
+	}
+	return ""
+}

--- a/proxy/internal/poller/poller_test.go
+++ b/proxy/internal/poller/poller_test.go
@@ -1,0 +1,196 @@
+package poller_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ercadev/dirigent/proxy/internal/poller"
+	"github.com/ercadev/dirigent/store"
+)
+
+// memStore is an in-memory store for tests.
+type memStore struct {
+	mu          sync.RWMutex
+	deployments []store.Deployment
+}
+
+func (m *memStore) List() ([]store.Deployment, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]store.Deployment, len(m.deployments))
+	copy(out, m.deployments)
+	return out, nil
+}
+
+// spyTable records Set and Delete calls.
+type spyTable struct {
+	mu      sync.Mutex
+	routes  map[string]string
+	deleted []string
+}
+
+func newSpyTable() *spyTable {
+	return &spyTable{routes: make(map[string]string)}
+}
+
+func (s *spyTable) Set(domain, upstream string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.routes[domain] = upstream
+}
+
+func (s *spyTable) Delete(domain string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.routes, domain)
+	s.deleted = append(s.deleted, domain)
+}
+
+func (s *spyTable) get(domain string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.routes[domain]
+	return u, ok
+}
+
+func (s *spyTable) wasDeleted(domain string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, d := range s.deleted {
+		if d == domain {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPoller_RegistersDeploymentWithDomainAndPort(t *testing.T) {
+	ms := &memStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Domain: "example.com", Ports: []string{"8080:80"}},
+		},
+	}
+	tbl := newSpyTable()
+	p := poller.New(ms, tbl, time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go p.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	u, ok := tbl.get("example.com")
+	if !ok {
+		t.Fatal("want example.com registered, got not found")
+	}
+	if u != "localhost:8080" {
+		t.Errorf("want upstream localhost:8080, got %s", u)
+	}
+}
+
+func TestPoller_SkipsDeploymentWithoutDomain(t *testing.T) {
+	ms := &memStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Ports: []string{"8080:80"}}, // no domain
+		},
+	}
+	tbl := newSpyTable()
+	p := poller.New(ms, tbl, time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go p.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	if len(tbl.routes) != 0 {
+		t.Errorf("want no routes registered, got %d", len(tbl.routes))
+	}
+}
+
+func TestPoller_SkipsDeploymentWithoutPorts(t *testing.T) {
+	ms := &memStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Domain: "example.com"}, // no ports
+		},
+	}
+	tbl := newSpyTable()
+	p := poller.New(ms, tbl, time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go p.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := tbl.get("example.com"); ok {
+		t.Error("want no route without ports, but route was registered")
+	}
+}
+
+func TestPoller_DeletesRemovedDomain(t *testing.T) {
+	ms := &memStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Domain: "example.com", Ports: []string{"8080:80"}},
+		},
+	}
+	tbl := newSpyTable()
+	p := poller.New(ms, tbl, 20*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go p.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := tbl.get("example.com"); !ok {
+		t.Fatal("want example.com registered before removal")
+	}
+
+	// Remove the deployment from the store.
+	ms.mu.Lock()
+	ms.deployments = nil
+	ms.mu.Unlock()
+
+	time.Sleep(100 * time.Millisecond)
+
+	if _, ok := tbl.get("example.com"); ok {
+		t.Error("want example.com deleted after deployment removed, but it is still registered")
+	}
+	if !tbl.wasDeleted("example.com") {
+		t.Error("want Delete called for example.com")
+	}
+}
+
+func TestPoller_UpdatesChangedUpstream(t *testing.T) {
+	ms := &memStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Domain: "example.com", Ports: []string{"8080:80"}},
+		},
+	}
+	tbl := newSpyTable()
+	p := poller.New(ms, tbl, 20*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go p.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	if u, _ := tbl.get("example.com"); u != "localhost:8080" {
+		t.Fatalf("initial upstream: want localhost:8080, got %s", u)
+	}
+
+	// Simulate a port change (e.g. after zero-downtime redeploy).
+	ms.mu.Lock()
+	ms.deployments[0].Ports = []string{"9090:80"}
+	ms.mu.Unlock()
+
+	time.Sleep(100 * time.Millisecond)
+
+	if u, _ := tbl.get("example.com"); u != "localhost:9090" {
+		t.Errorf("updated upstream: want localhost:9090, got %s", u)
+	}
+}

--- a/proxy/internal/routing/table.go
+++ b/proxy/internal/routing/table.go
@@ -1,0 +1,36 @@
+package routing
+
+import "sync"
+
+// Table is an in-memory domain→upstream routing table safe for concurrent use.
+type Table struct {
+	mu     sync.RWMutex
+	routes map[string]string
+}
+
+// NewTable creates an empty Table.
+func NewTable() *Table {
+	return &Table{routes: make(map[string]string)}
+}
+
+// Set registers or replaces the upstream for domain.
+func (t *Table) Set(domain, upstream string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.routes[domain] = upstream
+}
+
+// Get returns the upstream for domain and whether it exists.
+func (t *Table) Get(domain string) (string, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	u, ok := t.routes[domain]
+	return u, ok
+}
+
+// Delete removes domain from the table. No-op if domain is not registered.
+func (t *Table) Delete(domain string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.routes, domain)
+}

--- a/proxy/internal/routing/table_test.go
+++ b/proxy/internal/routing/table_test.go
@@ -1,0 +1,80 @@
+package routing_test
+
+import (
+	"testing"
+
+	"github.com/ercadev/dirigent/proxy/internal/routing"
+)
+
+func TestTable_SetAndGet(t *testing.T) {
+	tbl := routing.NewTable()
+	tbl.Set("example.com", "localhost:8080")
+
+	upstream, ok := tbl.Get("example.com")
+	if !ok {
+		t.Fatal("want route to exist, got not found")
+	}
+	if upstream != "localhost:8080" {
+		t.Errorf("want upstream localhost:8080, got %s", upstream)
+	}
+}
+
+func TestTable_Update(t *testing.T) {
+	tbl := routing.NewTable()
+	tbl.Set("example.com", "localhost:8080")
+	tbl.Set("example.com", "localhost:9090")
+
+	upstream, ok := tbl.Get("example.com")
+	if !ok {
+		t.Fatal("want route to exist, got not found")
+	}
+	if upstream != "localhost:9090" {
+		t.Errorf("want updated upstream localhost:9090, got %s", upstream)
+	}
+}
+
+func TestTable_Delete(t *testing.T) {
+	tbl := routing.NewTable()
+	tbl.Set("example.com", "localhost:8080")
+	tbl.Delete("example.com")
+
+	if _, ok := tbl.Get("example.com"); ok {
+		t.Error("want route deleted, but it still exists")
+	}
+}
+
+func TestTable_DeleteNonExistent(t *testing.T) {
+	tbl := routing.NewTable()
+	// Must not panic.
+	tbl.Delete("nonexistent.com")
+}
+
+func TestTable_UnknownDomain(t *testing.T) {
+	tbl := routing.NewTable()
+
+	if _, ok := tbl.Get("unknown.com"); ok {
+		t.Error("want not found for unknown domain, got found")
+	}
+}
+
+func TestTable_MultipleDomains(t *testing.T) {
+	tbl := routing.NewTable()
+	tbl.Set("foo.com", "localhost:3000")
+	tbl.Set("bar.com", "localhost:4000")
+
+	if u, ok := tbl.Get("foo.com"); !ok || u != "localhost:3000" {
+		t.Errorf("foo.com: want localhost:3000, got %s (ok=%v)", u, ok)
+	}
+	if u, ok := tbl.Get("bar.com"); !ok || u != "localhost:4000" {
+		t.Errorf("bar.com: want localhost:4000, got %s (ok=%v)", u, ok)
+	}
+
+	tbl.Delete("foo.com")
+
+	if _, ok := tbl.Get("foo.com"); ok {
+		t.Error("want foo.com deleted")
+	}
+	if u, ok := tbl.Get("bar.com"); !ok || u != "localhost:4000" {
+		t.Errorf("bar.com must survive after foo.com deleted: got %s (ok=%v)", u, ok)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a standalone `proxy` binary as a fourth Dirigent component alongside `api`, `orchestrator`, and `dashboard`
- In-memory routing table (`sync.RWMutex`) maps domains → upstreams with `Set`, `Get`, `Delete`
- Store poller diffs snapshots on a ticker (default 5s) and syncs the routing table as deployments are created, updated, or removed — deployments without a `domain` or port bindings are never registered
- Reverse proxy routes by `Host` header; returns 404 for unknown domains, 502 for unreachable upstreams; `POST /internal/routes` lets the orchestrator swap upstreams immediately during zero-downtime redeploys
- `go.work` and `Makefile` updated — proxy added to `dev`, `build`, `test`, and `clean`; dev mode uses `DIRIGENT_PROXY_ADDR=:8090` to avoid requiring root

## Test plan

- [x] Unit tests: routing table (add, update, remove, unknown domain)
- [x] Unit tests: poller sync (registers domain+port, skips missing domain/port, deletes removed deployment, updates changed upstream)
- [x] Integration tests: known domain reaches backend, unknown domain returns 404, removed deployment returns 404, `/internal/routes` sets upstream, unavailable upstream returns 502
- [ ] Manual: `make dev` starts proxy alongside other services
- [ ] Manual: deploy a container with a domain and port, verify requests are routed correctly

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)