### PR TITLE
feat(api): add system status tracer-bullet snapshot endpoint

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/ercadev/dirigent/internal/events"
 	"github.com/ercadev/dirigent/store"
@@ -47,18 +48,30 @@ type patchDeploymentRequest struct {
 
 // Handler holds the dependencies for the API layer.
 type Handler struct {
-	store  Store
-	events EventBus
+	store        Store
+	events       EventBus
+	statusSource SystemStatusProvider
 }
 
 // New creates a Handler backed by the given store and event bus.
 func New(s Store, eb EventBus) *Handler {
-	return &Handler{store: s, events: eb}
+	return NewWithSystemStatus(s, eb, nil)
+}
+
+// NewWithSystemStatus creates a Handler with a custom system-status provider.
+// If statusSource is nil, a default provider is used.
+func NewWithSystemStatus(s Store, eb EventBus, statusSource SystemStatusProvider) *Handler {
+	if statusSource == nil {
+		statusSource = newDefaultSystemStatusProvider(time.Now)
+	}
+
+	return &Handler{store: s, events: eb, statusSource: statusSource}
 }
 
 // RegisterRoutes wires all deployment endpoints into mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/deployments", h.listDeployments)
+	mux.HandleFunc("GET /api/system-status", h.systemStatus)
 	mux.HandleFunc("POST /api/deployments", h.createDeployment)
 	mux.HandleFunc("GET /api/deployments/events", h.deploymentEvents)
 	mux.HandleFunc("GET /api/deployments/{id}", h.getDeployment)

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -139,6 +139,96 @@ func newTestServerWithBroker(s api.Store, b *events.Broker) *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
+type statusProviderStub struct {
+	snapshot api.SystemStatusSnapshot
+	err      error
+}
+
+func (s *statusProviderStub) Snapshot(_ context.Context) (api.SystemStatusSnapshot, error) {
+	if s.err != nil {
+		return api.SystemStatusSnapshot{}, s.err
+	}
+	return s.snapshot, nil
+}
+
+func newTestServerWithStatusProvider(s api.Store, provider api.SystemStatusProvider) *httptest.Server {
+	mux := http.NewServeMux()
+	api.NewWithSystemStatus(s, events.NewBroker(), provider).RegisterRoutes(mux)
+	return httptest.NewServer(mux)
+}
+
+func TestSystemStatus_Healthy(t *testing.T) {
+	lastUpdated := time.Date(2026, time.February, 22, 10, 0, 0, 0, time.UTC)
+	provider := &statusProviderStub{
+		snapshot: api.SystemStatusSnapshot{
+			API: api.APISystemStatus{
+				State:       api.SystemStatusStateHealthy,
+				LastUpdated: lastUpdated,
+			},
+		},
+	}
+
+	srv := newTestServerWithStatusProvider(newMemStore(), provider)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/system-status")
+	if err != nil {
+		t.Fatalf("GET /api/system-status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body api.SystemStatusSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.API.State != api.SystemStatusStateHealthy {
+		t.Errorf("want api state healthy, got %s", body.API.State)
+	}
+	if !body.API.LastUpdated.Equal(lastUpdated) {
+		t.Errorf("want lastUpdated %s, got %s", lastUpdated, body.API.LastUpdated)
+	}
+	if body.Error != "" {
+		t.Errorf("want empty error, got %q", body.Error)
+	}
+}
+
+func TestSystemStatus_UnavailableOnProviderError(t *testing.T) {
+	provider := &statusProviderStub{err: errors.New("status backend down")}
+
+	srv := newTestServerWithStatusProvider(newMemStore(), provider)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/system-status")
+	if err != nil {
+		t.Fatalf("GET /api/system-status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", resp.StatusCode)
+	}
+
+	var body api.SystemStatusSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.API.State != api.SystemStatusStateUnavailable {
+		t.Errorf("want api state unavailable, got %s", body.API.State)
+	}
+	if body.API.LastUpdated.IsZero() {
+		t.Error("want non-zero lastUpdated")
+	}
+	if body.Error != "system status unavailable" {
+		t.Errorf("want error system status unavailable, got %q", body.Error)
+	}
+}
+
 func TestListDeployments_Empty(t *testing.T) {
 	srv := newTestServer(newMemStore())
 	defer srv.Close()

--- a/api/internal/api/system_status.go
+++ b/api/internal/api/system_status.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// SystemStatusState is the normalized state enum used by status signals.
+type SystemStatusState string
+
+const (
+	SystemStatusStateHealthy     SystemStatusState = "healthy"
+	SystemStatusStateUnavailable SystemStatusState = "unavailable"
+)
+
+// APISystemStatus carries API availability and freshness information.
+type APISystemStatus struct {
+	State       SystemStatusState `json:"state"`
+	LastUpdated time.Time         `json:"lastUpdated"`
+}
+
+// SystemStatusSnapshot is the typed dashboard-facing system-status contract.
+type SystemStatusSnapshot struct {
+	API   APISystemStatus `json:"api"`
+	Error string          `json:"error,omitempty"`
+}
+
+// SystemStatusProvider returns an aggregated system-status snapshot.
+type SystemStatusProvider interface {
+	Snapshot(ctx context.Context) (SystemStatusSnapshot, error)
+}
+
+type defaultSystemStatusProvider struct {
+	now func() time.Time
+}
+
+func newDefaultSystemStatusProvider(now func() time.Time) SystemStatusProvider {
+	return &defaultSystemStatusProvider{now: now}
+}
+
+func (p *defaultSystemStatusProvider) Snapshot(_ context.Context) (SystemStatusSnapshot, error) {
+	return SystemStatusSnapshot{
+		API: APISystemStatus{
+			State:       SystemStatusStateHealthy,
+			LastUpdated: p.now().UTC(),
+		},
+	}, nil
+}
+
+func (h *Handler) systemStatus(w http.ResponseWriter, r *http.Request) {
+	snapshot, err := h.statusSource.Snapshot(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, SystemStatusSnapshot{
+			API: APISystemStatus{
+				State:       SystemStatusStateUnavailable,
+				LastUpdated: time.Now().UTC(),
+			},
+			Error: "system status unavailable",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, snapshot)
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/system-status` with a typed JSON snapshot contract focused on API signal state and `lastUpdated` freshness semantics.
- Introduce a `SystemStatusProvider` boundary with a default provider and predictable error behavior (`503` + explicit `unavailable` state) for dashboard consumption.
- Add handler tests for both success and provider-error responses of the new endpoint contract.

## Testing
- go test ./... (from `api/` module)