### PR TITLE
feat(api): ingest orchestrator heartbeat for system status

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/ercadev/dirigent/internal/events"
@@ -51,7 +53,10 @@ type Handler struct {
 	store        Store
 	events       EventBus
 	statusSource SystemStatusProvider
+	heartbeats   OrchestratorHeartbeatIngestor
 }
+
+const defaultOrchestratorStaleAfter = 30 * time.Second
 
 // New creates a Handler backed by the given store and event bus.
 func New(s Store, eb EventBus) *Handler {
@@ -62,16 +67,19 @@ func New(s Store, eb EventBus) *Handler {
 // If statusSource is nil, a default provider is used.
 func NewWithSystemStatus(s Store, eb EventBus, statusSource SystemStatusProvider) *Handler {
 	if statusSource == nil {
-		statusSource = newDefaultSystemStatusProvider(time.Now)
+		statusSource = newDefaultSystemStatusProvider(time.Now, orchestratorStaleAfterFromEnv())
 	}
 
-	return &Handler{store: s, events: eb, statusSource: statusSource}
+	heartbeatIngestor, _ := statusSource.(OrchestratorHeartbeatIngestor)
+
+	return &Handler{store: s, events: eb, statusSource: statusSource, heartbeats: heartbeatIngestor}
 }
 
 // RegisterRoutes wires all deployment endpoints into mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/deployments", h.listDeployments)
 	mux.HandleFunc("GET /api/system-status", h.systemStatus)
+	mux.HandleFunc("POST /api/system-status/orchestrator-heartbeat", h.recordOrchestratorHeartbeat)
 	mux.HandleFunc("POST /api/deployments", h.createDeployment)
 	mux.HandleFunc("GET /api/deployments/events", h.deploymentEvents)
 	mux.HandleFunc("GET /api/deployments/{id}", h.getDeployment)
@@ -79,6 +87,36 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE /api/deployments/{id}", h.deleteDeployment)
 	mux.HandleFunc("PATCH /api/deployments/{id}/status", h.updateDeploymentStatus)
 	mux.HandleFunc("PATCH /api/deployments/{id}", h.patchDeployment)
+}
+
+func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Request) {
+	if h.heartbeats == nil {
+		http.Error(w, "system status unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
+
+	var body struct {
+		At *time.Time `json:"at"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	heartbeatAt := time.Time{}
+	if body.At != nil {
+		heartbeatAt = body.At.UTC()
+	}
+
+	if err := h.heartbeats.RecordOrchestratorHeartbeat(r.Context(), heartbeatAt); err != nil {
+		http.Error(w, "failed to record heartbeat", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) listDeployments(w http.ResponseWriter, r *http.Request) {
@@ -373,4 +411,19 @@ func newID() (string, error) {
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
+}
+
+func orchestratorStaleAfterFromEnv() time.Duration {
+	raw := os.Getenv("DIRIGENT_ORCHESTRATOR_STALE_AFTER")
+	if raw == "" {
+		return defaultOrchestratorStaleAfter
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		log.Printf("invalid DIRIGENT_ORCHESTRATOR_STALE_AFTER=%q; using default %s", raw, defaultOrchestratorStaleAfter)
+		return defaultOrchestratorStaleAfter
+	}
+
+	return d
 }

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -227,6 +227,73 @@ func TestSystemStatus_UnavailableOnProviderError(t *testing.T) {
 	if body.Error != "system status unavailable" {
 		t.Errorf("want error system status unavailable, got %q", body.Error)
 	}
+	if body.Orchestrator.State != api.SystemStatusStateUnavailable {
+		t.Errorf("want orchestrator state unavailable, got %s", body.Orchestrator.State)
+	}
+}
+
+func TestRecordOrchestratorHeartbeat_UpdatesSystemStatus(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString("{}"))
+	if err != nil {
+		t.Fatalf("POST heartbeat request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/system-status/orchestrator-heartbeat: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", resp.StatusCode)
+	}
+
+	statusResp, err := http.Get(srv.URL + "/api/system-status")
+	if err != nil {
+		t.Fatalf("GET /api/system-status: %v", err)
+	}
+	defer statusResp.Body.Close()
+
+	if statusResp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", statusResp.StatusCode)
+	}
+
+	var body api.SystemStatusSnapshot
+	if err := json.NewDecoder(statusResp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.Orchestrator.State == api.SystemStatusStateUnavailable {
+		t.Fatalf("want orchestrator heartbeat state to update, got %s", body.Orchestrator.State)
+	}
+	if body.Orchestrator.LastUpdated.IsZero() {
+		t.Fatal("want non-zero orchestrator lastUpdated")
+	}
+}
+
+func TestRecordOrchestratorHeartbeat_InvalidBody(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString("not json"))
+	if err != nil {
+		t.Fatalf("POST heartbeat request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/system-status/orchestrator-heartbeat: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
 }
 
 func TestListDeployments_Empty(t *testing.T) {

--- a/api/internal/api/system_status.go
+++ b/api/internal/api/system_status.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -11,6 +12,8 @@ type SystemStatusState string
 
 const (
 	SystemStatusStateHealthy     SystemStatusState = "healthy"
+	SystemStatusStateDegraded    SystemStatusState = "degraded"
+	SystemStatusStateStale       SystemStatusState = "stale"
 	SystemStatusStateUnavailable SystemStatusState = "unavailable"
 )
 
@@ -20,10 +23,17 @@ type APISystemStatus struct {
 	LastUpdated time.Time         `json:"lastUpdated"`
 }
 
+// OrchestratorSystemStatus carries orchestrator liveness and freshness information.
+type OrchestratorSystemStatus struct {
+	State       SystemStatusState `json:"state"`
+	LastUpdated time.Time         `json:"lastUpdated,omitempty"`
+}
+
 // SystemStatusSnapshot is the typed dashboard-facing system-status contract.
 type SystemStatusSnapshot struct {
-	API   APISystemStatus `json:"api"`
-	Error string          `json:"error,omitempty"`
+	API          APISystemStatus          `json:"api"`
+	Orchestrator OrchestratorSystemStatus `json:"orchestrator"`
+	Error        string                   `json:"error,omitempty"`
 }
 
 // SystemStatusProvider returns an aggregated system-status snapshot.
@@ -31,21 +41,74 @@ type SystemStatusProvider interface {
 	Snapshot(ctx context.Context) (SystemStatusSnapshot, error)
 }
 
-type defaultSystemStatusProvider struct {
-	now func() time.Time
+// OrchestratorHeartbeatIngestor accepts orchestrator heartbeat updates.
+type OrchestratorHeartbeatIngestor interface {
+	RecordOrchestratorHeartbeat(ctx context.Context, at time.Time) error
 }
 
-func newDefaultSystemStatusProvider(now func() time.Time) SystemStatusProvider {
-	return &defaultSystemStatusProvider{now: now}
+type defaultSystemStatusProvider struct {
+	now              func() time.Time
+	staleAfter       time.Duration
+	lastHeartbeatMu  sync.RWMutex
+	lastHeartbeatUTC time.Time
+}
+
+func newDefaultSystemStatusProvider(now func() time.Time, staleAfter time.Duration) SystemStatusProvider {
+	return &defaultSystemStatusProvider{now: now, staleAfter: staleAfter}
 }
 
 func (p *defaultSystemStatusProvider) Snapshot(_ context.Context) (SystemStatusSnapshot, error) {
+	orchestrator := p.orchestratorStatus()
+
 	return SystemStatusSnapshot{
 		API: APISystemStatus{
 			State:       SystemStatusStateHealthy,
 			LastUpdated: p.now().UTC(),
 		},
+		Orchestrator: orchestrator,
 	}, nil
+}
+
+func (p *defaultSystemStatusProvider) RecordOrchestratorHeartbeat(_ context.Context, at time.Time) error {
+	if at.IsZero() {
+		at = p.now()
+	}
+
+	p.lastHeartbeatMu.Lock()
+	p.lastHeartbeatUTC = at.UTC()
+	p.lastHeartbeatMu.Unlock()
+
+	return nil
+}
+
+func (p *defaultSystemStatusProvider) orchestratorStatus() OrchestratorSystemStatus {
+	p.lastHeartbeatMu.RLock()
+	lastHeartbeat := p.lastHeartbeatUTC
+	p.lastHeartbeatMu.RUnlock()
+
+	if lastHeartbeat.IsZero() {
+		return OrchestratorSystemStatus{State: SystemStatusStateUnavailable}
+	}
+
+	age := p.now().UTC().Sub(lastHeartbeat)
+	if age < 0 {
+		age = 0
+	}
+
+	degradedAfter := p.staleAfter / 2
+	state := SystemStatusStateStale
+
+	switch {
+	case age <= degradedAfter:
+		state = SystemStatusStateHealthy
+	case age <= p.staleAfter:
+		state = SystemStatusStateDegraded
+	}
+
+	return OrchestratorSystemStatus{
+		State:       state,
+		LastUpdated: lastHeartbeat,
+	}
 }
 
 func (h *Handler) systemStatus(w http.ResponseWriter, r *http.Request) {
@@ -56,7 +119,8 @@ func (h *Handler) systemStatus(w http.ResponseWriter, r *http.Request) {
 				State:       SystemStatusStateUnavailable,
 				LastUpdated: time.Now().UTC(),
 			},
-			Error: "system status unavailable",
+			Orchestrator: OrchestratorSystemStatus{State: SystemStatusStateUnavailable},
+			Error:        "system status unavailable",
 		})
 		return
 	}

--- a/api/internal/api/system_status_test.go
+++ b/api/internal/api/system_status_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDefaultSystemStatusProvider_OrchestratorStateMapping(t *testing.T) {
+	base := time.Date(2026, time.February, 22, 12, 0, 0, 0, time.UTC)
+	now := base
+
+	provider := newDefaultSystemStatusProvider(func() time.Time { return now }, 10*time.Second)
+	ingestor, ok := provider.(OrchestratorHeartbeatIngestor)
+	if !ok {
+		t.Fatal("default provider must implement OrchestratorHeartbeatIngestor")
+	}
+
+	snapshot, err := provider.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot initial: %v", err)
+	}
+	if snapshot.Orchestrator.State != SystemStatusStateUnavailable {
+		t.Fatalf("want unavailable before first heartbeat, got %s", snapshot.Orchestrator.State)
+	}
+
+	if err := ingestor.RecordOrchestratorHeartbeat(context.Background(), base); err != nil {
+		t.Fatalf("RecordOrchestratorHeartbeat: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		now       time.Time
+		wantState SystemStatusState
+	}{
+		{name: "healthy at heartbeat time", now: base, wantState: SystemStatusStateHealthy},
+		{name: "healthy at half threshold", now: base.Add(5 * time.Second), wantState: SystemStatusStateHealthy},
+		{name: "degraded after half threshold", now: base.Add(6 * time.Second), wantState: SystemStatusStateDegraded},
+		{name: "degraded at stale threshold", now: base.Add(10 * time.Second), wantState: SystemStatusStateDegraded},
+		{name: "stale after threshold", now: base.Add(11 * time.Second), wantState: SystemStatusStateStale},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			now = tc.now
+
+			snapshot, err := provider.Snapshot(context.Background())
+			if err != nil {
+				t.Fatalf("Snapshot: %v", err)
+			}
+
+			if snapshot.Orchestrator.State != tc.wantState {
+				t.Fatalf("want state %s, got %s", tc.wantState, snapshot.Orchestrator.State)
+			}
+			if !snapshot.Orchestrator.LastUpdated.Equal(base) {
+				t.Fatalf("want lastUpdated %s, got %s", base, snapshot.Orchestrator.LastUpdated)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add explicit `POST /api/system-status/orchestrator-heartbeat` ingestion endpoint to record orchestrator liveness updates
- extend the system-status snapshot with an `orchestrator` signal and deterministic `healthy/degraded/stale/unavailable` freshness mapping
- add backend tests for heartbeat ingestion, status-state transitions, and stale threshold behavior

## Testing
- go test ./... (in `api/`)

Closes #60