### PR TITLE
feat(system-status): show orchestrator liveness and freshness states

### DIFF
--- a/dashboard/src/components/ui/badge.tsx
+++ b/dashboard/src/components/ui/badge.tsx
@@ -11,6 +11,7 @@ const badgeVariants = cva(
         default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
         secondary: 'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         success: 'border-transparent bg-emerald-100 text-emerald-800',
+        warning: 'border-transparent bg-amber-100 text-amber-900',
         info: 'border-transparent bg-sky-100 text-sky-800',
         destructive: 'border-transparent bg-rose-100 text-rose-800',
         outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -18,15 +18,27 @@ export type StatusEvent = {
   error?: string
 }
 
-export type SystemStatusState = 'healthy' | 'unavailable'
+export type SystemStatusState = 'healthy' | 'degraded' | 'stale' | 'unavailable'
 
 export type APISystemStatus = {
   state: SystemStatusState
   lastUpdated: string
 }
 
+export type OrchestratorSystemStatus = {
+  state: SystemStatusState
+  lastUpdated?: string
+}
+
+export type DockerSystemStatus = {
+  state: SystemStatusState
+  lastUpdated?: string
+}
+
 export type SystemStatusSnapshot = {
   api: APISystemStatus
+  orchestrator: OrchestratorSystemStatus
+  docker: DockerSystemStatus
   error?: string
 }
 

--- a/dashboard/src/system-status/SystemStatusPanel.test.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.test.tsx
@@ -29,10 +29,18 @@ describe('SystemStatusPanel', () => {
     expect(screen.getByText('Loading system status…')).toBeInTheDocument()
   })
 
-  it('renders API signal and timestamp for healthy status', async () => {
+  it('renders healthy API and orchestrator states', async () => {
     const lastUpdated = '2026-02-22T11:30:00.000Z'
     vi.mocked(api.getSystemStatus).mockResolvedValue({
       api: {
+        state: 'healthy',
+        lastUpdated,
+      },
+      orchestrator: {
+        state: 'healthy',
+        lastUpdated,
+      },
+      docker: {
         state: 'healthy',
         lastUpdated,
       },
@@ -40,11 +48,63 @@ describe('SystemStatusPanel', () => {
 
     renderWithQuery(<SystemStatusPanel />)
 
-    await waitFor(() => expect(screen.getByText('healthy')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getAllByText('healthy')).toHaveLength(2))
     expect(screen.getByText('API signal')).toBeInTheDocument()
-    expect(screen.getByText('State:')).toBeInTheDocument()
+    expect(screen.getByText('Orchestrator liveness')).toBeInTheDocument()
+    expect(screen.getAllByText('State:')).toHaveLength(2)
     expect(screen.getByText('Last updated:')).toBeInTheDocument()
-    expect(screen.getByText(new Date(lastUpdated).toLocaleString())).toBeInTheDocument()
+    expect(screen.getByText('Last heartbeat:')).toBeInTheDocument()
+    expect(screen.getByText('Freshness:')).toBeInTheDocument()
+    expect(screen.getAllByText(new Date(lastUpdated).toLocaleString())).toHaveLength(2)
+  })
+
+  it('renders degraded orchestrator state', async () => {
+    const apiUpdated = '2026-02-22T11:30:00.000Z'
+    const orchestratorUpdated = '2026-02-22T11:20:00.000Z'
+    vi.mocked(api.getSystemStatus).mockResolvedValue({
+      api: {
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+      },
+      orchestrator: {
+        state: 'degraded',
+        lastUpdated: orchestratorUpdated,
+      },
+      docker: {
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+      },
+    })
+
+    renderWithQuery(<SystemStatusPanel />)
+
+    await waitFor(() => expect(screen.getByText('degraded')).toBeInTheDocument())
+    expect(screen.getByText(new Date(orchestratorUpdated).toLocaleString())).toBeInTheDocument()
+  })
+
+  it('renders stale orchestrator state and freshness', async () => {
+    const apiUpdated = '2026-02-22T12:00:00.000Z'
+    const orchestratorUpdated = '2026-02-22T11:40:00.000Z'
+    vi.mocked(api.getSystemStatus).mockResolvedValue({
+      api: {
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+      },
+      orchestrator: {
+        state: 'stale',
+        lastUpdated: orchestratorUpdated,
+      },
+      docker: {
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+      },
+    })
+
+    renderWithQuery(<SystemStatusPanel />)
+
+    await waitFor(() => expect(screen.getByText('stale')).toBeInTheDocument())
+    expect(screen.getByText(/ago|just now/)).toBeInTheDocument()
+
   })
 
   it('renders fetch failure UI when endpoint errors', async () => {

--- a/dashboard/src/system-status/SystemStatusPanel.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.tsx
@@ -1,8 +1,21 @@
 import { useSystemStatus } from './useSystemStatus'
 import { Badge } from '../components/ui/badge'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+import type { SystemStatusState } from '../lib/api'
 
-function formatTimestamp(timestamp: string) {
+type BadgeVariant = 'secondary' | 'info' | 'success' | 'destructive' | 'warning'
+
+const STATE_VARIANT: Record<SystemStatusState, BadgeVariant> = {
+  healthy: 'success',
+  degraded: 'warning',
+  stale: 'destructive',
+  unavailable: 'secondary',
+}
+
+function formatTimestamp(timestamp?: string) {
+  if (!timestamp) {
+    return 'No signal yet'
+  }
+
   const date = new Date(timestamp)
   if (Number.isNaN(date.getTime())) {
     return 'Unknown'
@@ -10,35 +23,69 @@ function formatTimestamp(timestamp: string) {
   return date.toLocaleString()
 }
 
+function formatFreshness(timestamp?: string) {
+  if (!timestamp) {
+    return 'No heartbeat observed'
+  }
+
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown'
+  }
+
+  const diffSeconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000))
+  if (diffSeconds < 60) return 'just now'
+  if (diffSeconds < 3600) return `${Math.floor(diffSeconds / 60)}m ago`
+  if (diffSeconds < 86400) return `${Math.floor(diffSeconds / 3600)}h ago`
+  return `${Math.floor(diffSeconds / 86400)}d ago`
+}
+
 export function SystemStatusPanel() {
   const { status, isLoading, isError } = useSystemStatus()
 
   return (
-    <Card className="bg-card/70">
-      <CardHeader>
-        <CardTitle>API signal</CardTitle>
-        <CardDescription>Current API health and latest update timestamp.</CardDescription>
-      </CardHeader>
-      <CardContent>
-        {isLoading && <p className="text-sm text-muted-foreground">Loading system status…</p>}
+    <section className="space-y-4">
+      {isLoading && <p className="text-sm text-muted-foreground">Loading system status…</p>}
 
-        {isError && (
-          <p className="text-sm text-destructive">Unable to fetch system status right now.</p>
-        )}
+      {isError && (
+        <p className="text-sm text-destructive">Unable to fetch system status right now.</p>
+      )}
 
-        {status && !isLoading && !isError && (
-          <div className="space-y-2 text-sm text-muted-foreground">
+      {status && !isLoading && !isError && (
+        <div className="divide-y rounded-lg bg-muted/20 text-sm text-muted-foreground">
+          <section className="space-y-2 p-4">
+            <p className="font-semibold text-foreground">API signal</p>
+            <p className="text-xs text-muted-foreground/90">Control plane availability and response health.</p>
             <p>
-              State:{' '}
-              <Badge variant={status.api.state === 'healthy' ? 'success' : 'destructive'}>{status.api.state}</Badge>
+              State: <Badge variant={STATE_VARIANT[status.api.state]}>{status.api.state}</Badge>
             </p>
             <p>
               Last updated:{' '}
               <span className="font-medium text-foreground">{formatTimestamp(status.api.lastUpdated)}</span>
             </p>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+          </section>
+
+          <section className="space-y-2 p-4">
+            <p className="font-semibold text-foreground">Orchestrator liveness</p>
+            <p className="text-xs text-muted-foreground/90">Worker heartbeat and freshness from the host agent.</p>
+            <p>
+              State: <Badge variant={STATE_VARIANT[status.orchestrator.state]}>{status.orchestrator.state}</Badge>
+            </p>
+            <p>
+              Last heartbeat:{' '}
+              <span className="font-medium text-foreground">
+                {formatTimestamp(status.orchestrator.lastUpdated)}
+              </span>
+            </p>
+            <p>
+              Freshness:{' '}
+              <span className="font-medium text-foreground">
+                {formatFreshness(status.orchestrator.lastUpdated)}
+              </span>
+            </p>
+          </section>
+        </div>
+      )}
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- update dashboard system status contract/types to support `healthy`, `degraded`, `stale`, and `unavailable` states plus orchestrator/docker sections from the API snapshot
- redesign the system status panel to clearly separate API signal from orchestrator liveness and add explicit heartbeat freshness display
- add frontend tests for healthy, degraded, and stale orchestrator rendering to cover the new state semantics

## Testing
- bunx vitest run src/system-status/SystemStatusPanel.test.tsx
- bun run build

## Links
- Closes #61