### PR TITLE
feat(deployments): open create dialog and improve empty state

### DIFF
--- a/dashboard/src/deployments/CreateDeploymentForm.tsx
+++ b/dashboard/src/deployments/CreateDeploymentForm.tsx
@@ -4,22 +4,31 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../co
 import { DynamicSection } from './DynamicSection'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
+import { cn } from '../lib/utils'
 
 const fieldErrorCls = 'text-xs text-destructive'
 
-export default function CreateDeploymentForm() {
+type Props = {
+  onSuccess?: () => void
+  className?: string
+  hideHeader?: boolean
+}
+
+export default function CreateDeploymentForm({ onSuccess, className, hideHeader = false }: Props) {
   const {
     name, setName, image, setImage, domain, setDomain,
     envRows, portRows, volumeRows,
     errors, handleSubmit, isPending,
-  } = useCreateDeploymentForm()
+  } = useCreateDeploymentForm({ onSuccess })
 
   return (
-    <Card className="mb-8">
-      <CardHeader>
-        <CardTitle>New deployment</CardTitle>
-        <CardDescription>Create a new service from an image and runtime settings.</CardDescription>
-      </CardHeader>
+    <Card className={cn('mb-8', className)}>
+      {!hideHeader && (
+        <CardHeader>
+          <CardTitle>New deployment</CardTitle>
+          <CardDescription>Create a new service from an image and runtime settings.</CardDescription>
+        </CardHeader>
+      )}
       <CardContent>
       <form onSubmit={handleSubmit} noValidate className="space-y-5">
 

--- a/dashboard/src/deployments/DeploymentTable.tsx
+++ b/dashboard/src/deployments/DeploymentTable.tsx
@@ -1,5 +1,7 @@
-import { Card, CardContent } from '../components/ui/card'
+import { Box } from 'lucide-react'
 import type { UseMutationResult } from '@tanstack/react-query'
+import { Button } from '../components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '../components/ui/table'
 import type { Deployment } from '../lib/api'
 import { DeploymentRow } from './DeploymentRow'
@@ -10,12 +12,30 @@ type Props = {
   isError: boolean
   deleteMutation: UseMutationResult<void, Error, string>
   onEdit: (deployment: Deployment) => void
+  onCreate: () => void
 }
 
-export function DeploymentTable({ deployments, isLoading, isError, deleteMutation, onEdit }: Props) {
+export function DeploymentTable({ deployments, isLoading, isError, deleteMutation, onEdit, onCreate }: Props) {
   if (isLoading) return <p className="text-sm text-muted-foreground">Loading deployments…</p>
   if (isError) return <p className="text-sm text-destructive">Failed to load deployments.</p>
-  if (!deployments?.length) return <p className="text-sm text-muted-foreground">No deployments yet.</p>
+  if (!deployments?.length) {
+    return (
+      <Card>
+        <CardHeader className="items-center text-center">
+          <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <Box size={18} />
+          </div>
+          <CardTitle>Your workspace is ready</CardTitle>
+          <CardDescription>
+            You do not have any deployments yet. Create your first one to get your app running.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center pt-0">
+          <Button type="button" onClick={onCreate}>Create first deployment</Button>
+        </CardContent>
+      </Card>
+    )
+  }
 
   return (
     <Card className="overflow-hidden py-0">

--- a/dashboard/src/deployments/useCreateDeploymentForm.ts
+++ b/dashboard/src/deployments/useCreateDeploymentForm.ts
@@ -17,7 +17,11 @@ export type FormErrors = {
 
 const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {} }
 
-export function useCreateDeploymentForm() {
+type UseCreateDeploymentFormOptions = {
+  onSuccess?: () => void
+}
+
+export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions = {}) {
   const queryClient = useQueryClient()
 
   const [name, setName] = useState('')
@@ -40,6 +44,7 @@ export function useCreateDeploymentForm() {
       portRows.reset()
       volumeRows.reset()
       setErrors(EMPTY_ERRORS)
+      options.onSuccess?.()
     },
     onError: (err: Error) => setErrors(prev => ({ ...prev, form: err.message })),
   })

--- a/dashboard/src/deployments/useDeploymentDialogs.ts
+++ b/dashboard/src/deployments/useDeploymentDialogs.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react'
+import type { Deployment } from '../lib/api'
+
+export function useDeploymentDialogs() {
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const [editingDeployment, setEditingDeployment] = useState<Deployment | null>(null)
+
+  return {
+    createDialogOpen,
+    openCreateDialog: () => setCreateDialogOpen(true),
+    closeCreateDialog: () => setCreateDialogOpen(false),
+    setCreateDialogOpen,
+    editingDeployment,
+    openEditDialog: (deployment: Deployment) => setEditingDeployment(deployment),
+    closeEditDialog: () => setEditingDeployment(null),
+  }
+}

--- a/dashboard/src/pages/DeploymentList.tsx
+++ b/dashboard/src/pages/DeploymentList.tsx
@@ -1,22 +1,50 @@
-import { useState } from 'react'
+import { Plus } from 'lucide-react'
+import { Button } from '../components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../components/ui/dialog'
 import CreateDeploymentForm from '../deployments/CreateDeploymentForm'
 import EditDeploymentForm from '../deployments/EditDeploymentForm'
 import { DeploymentTable } from '../deployments/DeploymentTable'
+import { useDeploymentDialogs } from '../deployments/useDeploymentDialogs'
 import { useDeploymentList } from '../deployments/useDeploymentList'
 import { useDeploymentSSE } from '../deployments/useDeploymentSSE'
-import type { Deployment } from '../lib/api'
 
 export default function DeploymentList() {
   useDeploymentSSE()
   const listState = useDeploymentList()
-  const [editingDeployment, setEditingDeployment] = useState<Deployment | null>(null)
+  const {
+    createDialogOpen,
+    openCreateDialog,
+    closeCreateDialog,
+    setCreateDialogOpen,
+    editingDeployment,
+    openEditDialog,
+    closeEditDialog,
+  } = useDeploymentDialogs()
 
   return (
     <>
-      <CreateDeploymentForm />
+      <div className="mb-6 flex items-center justify-end">
+        <Button type="button" onClick={openCreateDialog}>
+          <Plus size={16} />
+          Create deployment
+        </Button>
+      </div>
 
-      <Dialog open={editingDeployment !== null} onOpenChange={open => !open && setEditingDeployment(null)}>
+      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>New deployment</DialogTitle>
+            <DialogDescription>Create a new service from an image and runtime settings.</DialogDescription>
+          </DialogHeader>
+          <CreateDeploymentForm
+            onSuccess={closeCreateDialog}
+            className="mb-0 border-0 shadow-none"
+            hideHeader
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={editingDeployment !== null} onOpenChange={open => !open && closeEditDialog()}>
         <DialogContent className="max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit deployment</DialogTitle>
@@ -28,7 +56,7 @@ export default function DeploymentList() {
             <EditDeploymentForm
               key={editingDeployment.id}
               deployment={editingDeployment}
-              onClose={() => setEditingDeployment(null)}
+              onClose={closeEditDialog}
               className="mb-0 border-0 shadow-none"
               hideHeader
             />
@@ -36,7 +64,7 @@ export default function DeploymentList() {
         </DialogContent>
       </Dialog>
 
-      <DeploymentTable {...listState} onEdit={setEditingDeployment} />
+      <DeploymentTable {...listState} onEdit={openEditDialog} onCreate={openCreateDialog} />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Move deployment creation behind a `Create deployment` button that opens a dialog instead of rendering the form inline.
- Add a polished empty state when no deployments exist, including explanatory copy and a primary CTA to create the first deployment.
- Refactor deployment page dialog state into a dedicated hook and close the create dialog automatically after successful creation.

## Validation
- `bunx vitest run src/deployments/CreateDeploymentForm.test.tsx`
- `bun run build`