### PR TITLE
ci: add release workflow for v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          path: ~/.cache/go/pkg/mod
+          path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('api/go.sum', 'orchestrator/go.sum', 'proxy/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          path: ~/.cache/go/pkg/mod
+          path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('api/go.sum', 'orchestrator/go.sum', 'proxy/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
@@ -144,6 +144,7 @@ jobs:
             dirigent-proxy-linux-amd64
             dirigent-proxy-linux-arm64
             dashboard.tar.gz
+            install.sh
 
   release:
     name: GitHub Release
@@ -172,4 +173,5 @@ jobs:
             dirigent-orchestrator-linux-arm64 \
             dirigent-proxy-linux-amd64 \
             dirigent-proxy-linux-arm64 \
-            dashboard.tar.gz
+            dashboard.tar.gz \
+            install.sh


### PR DESCRIPTION
Closes #75

## Summary
- Adds `.github/workflows/release.yml` triggered on `v*` tags
- CI gate jobs (`ci-go`, `ci-react`) run lint, tests, and dashboard build in parallel before any artifact is produced
- `build` job cross-compiles all six Go binaries (`dirigent`, `dirigent-orchestrator`, `dirigent-proxy` × `amd64`/`arm64`) and packages the dashboard as `dashboard.tar.gz`
- `release` job creates a tagged GitHub Release with all seven assets using only `GITHUB_TOKEN`

## Test plan
- [ ] Push a `v*` tag and verify the workflow triggers
- [ ] Introduce a deliberate test failure and confirm the release job is skipped
- [ ] Confirm all six binaries and `dashboard.tar.gz` appear as release assets
- [ ] Confirm GitHub marks the release as `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)