### PR TITLE
feat(dashboard): add deployment detail page with live log streaming

### DIFF
--- a/dashboard/src/components/ui/sidebar.tsx
+++ b/dashboard/src/components/ui/sidebar.tsx
@@ -96,7 +96,10 @@ export function Sidebar({
     return (
       <div
         data-slot="sidebar"
-        className={cn('hidden h-svh w-[var(--sidebar-width)] flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground md:flex', className)}
+        className={cn(
+          'hidden h-svh w-[var(--sidebar-width)] flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground md:sticky md:top-0 md:flex md:self-start',
+          className
+        )}
         {...props}
       >
         {children}

--- a/dashboard/src/deployments/DeploymentLogsPanel.test.tsx
+++ b/dashboard/src/deployments/DeploymentLogsPanel.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import { DeploymentLogsPanel } from './DeploymentLogsPanel'
+
+class MockEventSource {
+  static instances: MockEventSource[] = []
+  onmessage: ((event: MessageEvent) => void) | null = null
+  close = vi.fn()
+
+  constructor(public readonly url: string) {
+    MockEventSource.instances.push(this)
+  }
+}
+
+describe('DeploymentLogsPanel', () => {
+  beforeEach(() => {
+    MockEventSource.instances = []
+    vi.stubGlobal('EventSource', MockEventSource)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders incoming SSE lines and closes stream on unmount', () => {
+    const { unmount } = render(<DeploymentLogsPanel deploymentId="dep-1" />)
+
+    expect(screen.getByText('Waiting for log output...')).toBeInTheDocument()
+    expect(MockEventSource.instances[0]?.url).toBe('/api/deployments/dep-1/logs')
+
+    act(() => {
+      MockEventSource.instances[0]?.onmessage?.({
+        data: JSON.stringify({ line: 'server started' }),
+      } as MessageEvent)
+      MockEventSource.instances[0]?.onmessage?.({
+        data: JSON.stringify({ line: 'listening on :8080' }),
+      } as MessageEvent)
+    })
+
+    expect(screen.getByText(/server started/)).toHaveTextContent('server started')
+    expect(screen.getByText(/server started/)).toHaveTextContent('listening on :8080')
+
+    unmount()
+    expect(MockEventSource.instances[0]?.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/src/deployments/DeploymentLogsPanel.tsx
+++ b/dashboard/src/deployments/DeploymentLogsPanel.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+import { useDeploymentLogsSSE } from './useDeploymentLogsSSE'
+
+type Props = {
+  deploymentId: string
+}
+
+export function DeploymentLogsPanel({ deploymentId }: Props) {
+  const { lines } = useDeploymentLogsSSE(deploymentId)
+  const logContainerRef = useRef<HTMLPreElement | null>(null)
+
+  useEffect(() => {
+    if (!logContainerRef.current) return
+    logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight
+  }, [lines])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Live logs</CardTitle>
+        <CardDescription>Last 100 lines are shown immediately, then new lines stream live.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <pre
+          ref={logContainerRef}
+          className="h-80 overflow-y-auto rounded-lg border bg-muted/30 p-4 font-mono text-xs leading-5 text-foreground"
+        >
+          {lines.length ? lines.join('\n') : 'Waiting for log output...'}
+        </pre>
+      </CardContent>
+    </Card>
+  )
+}

--- a/dashboard/src/deployments/DeploymentRow.tsx
+++ b/dashboard/src/deployments/DeploymentRow.tsx
@@ -1,4 +1,5 @@
-import { Pencil, Trash2 } from 'lucide-react'
+import { ArrowUpRight, Pencil, Trash2 } from 'lucide-react'
+import { Link } from '@tanstack/react-router'
 import { Button } from '../components/ui/button'
 import { TableCell, TableRow } from '../components/ui/table'
 import type { Deployment } from '../lib/api'
@@ -14,13 +15,27 @@ type Props = {
 export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: Props) {
   return (
     <TableRow className="bg-card">
-      <TableCell className="py-3 font-medium text-foreground">{d.name}</TableCell>
+      <TableCell className="py-3 font-medium text-foreground">
+        <Link
+          to="/deployments/$deploymentId"
+          params={{ deploymentId: d.id }}
+          className="inline-flex items-center gap-1.5 hover:text-primary hover:underline"
+        >
+          {d.name}
+          <ArrowUpRight size={14} className="text-muted-foreground" />
+        </Link>
+      </TableCell>
       <TableCell className="py-3 font-mono text-xs text-muted-foreground">{d.image}</TableCell>
       <TableCell className="py-3">
         <StatusBadge status={d.status} error={d.error} />
       </TableCell>
       <TableCell className="py-3 text-right">
         <div className="flex items-center justify-end gap-1">
+          <Button asChild variant="ghost" size="sm" className="h-7 px-2 text-xs">
+            <Link to="/deployments/$deploymentId" params={{ deploymentId: d.id }}>
+              Details
+            </Link>
+          </Button>
           <Button
             type="button"
             variant="ghost"

--- a/dashboard/src/deployments/DeploymentTable.tsx
+++ b/dashboard/src/deployments/DeploymentTable.tsx
@@ -46,7 +46,7 @@ export function DeploymentTable({ deployments, isLoading, isError, deleteMutatio
               <TableHead>Name</TableHead>
               <TableHead>Image</TableHead>
               <TableHead>Status</TableHead>
-              <TableHead className="w-[110px]" />
+              <TableHead className="w-[190px] text-right">Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/dashboard/src/deployments/useDeploymentLogsSSE.ts
+++ b/dashboard/src/deployments/useDeploymentLogsSSE.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+import type { DeploymentLogEvent } from '../lib/api'
+
+export function useDeploymentLogsSSE(deploymentId: string) {
+  const [lines, setLines] = useState<string[]>([])
+
+  useEffect(() => {
+    setLines([])
+
+    const es = new EventSource(`/api/deployments/${deploymentId}/logs`)
+
+    es.onmessage = (event: MessageEvent) => {
+      try {
+        const { line }: DeploymentLogEvent = JSON.parse(event.data)
+        setLines(prev => [...prev, line])
+      } catch {
+        // ignore malformed events
+      }
+    }
+
+    return () => es.close()
+  }, [deploymentId])
+
+  return { lines }
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -18,6 +18,10 @@ export type StatusEvent = {
   error?: string
 }
 
+export type DeploymentLogEvent = {
+  line: string
+}
+
 export type SystemStatusState = 'healthy' | 'degraded' | 'stale' | 'unavailable'
 
 export type APISystemStatus = {

--- a/dashboard/src/pages/DeploymentDetailPage.tsx
+++ b/dashboard/src/pages/DeploymentDetailPage.tsx
@@ -1,0 +1,129 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link, useParams } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '../components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+import { DeploymentLogsPanel } from '../deployments/DeploymentLogsPanel'
+import { StatusBadge } from '../deployments/StatusBadge'
+import { getDeployments } from '../lib/api'
+
+export function DeploymentDetailPage() {
+  const { deploymentId } = useParams({ from: '/deployments/$deploymentId' })
+  const { data: deployments, isLoading, isError } = useQuery({
+    queryKey: ['deployments'],
+    queryFn: getDeployments,
+  })
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">Loading deployment...</p>
+  if (isError) return <p className="text-sm text-destructive">Failed to load deployment details.</p>
+
+  const deployment = deployments?.find(item => item.id === deploymentId)
+  if (!deployment) {
+    return (
+      <div className="space-y-3">
+        <Button asChild variant="outline" size="sm" className="w-fit">
+          <Link to="/deployments">
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Back to deployments
+          </Link>
+        </Button>
+        <p className="text-sm text-muted-foreground">Deployment not found.</p>
+      </div>
+    )
+  }
+
+  const envEntries = Object.entries(deployment.envs)
+
+  const renderList = (values: string[], emptyText: string) => {
+    if (!values.length) return <p className="text-sm text-muted-foreground">{emptyText}</p>
+
+    return (
+      <ul className="space-y-1 text-xs text-muted-foreground">
+        {values.map(value => (
+          <li key={value} className="rounded bg-muted/40 px-2 py-1 font-mono">
+            {value}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <Button asChild variant="outline" size="sm" className="w-fit">
+        <Link to="/deployments">
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          Back to deployments
+        </Link>
+      </Button>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle>{deployment.name}</CardTitle>
+          <CardDescription>All available deployment data and live logs.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 text-sm sm:grid-cols-2">
+          <p>
+            Deployment ID:{' '}
+            <span className="font-mono text-xs text-muted-foreground">{deployment.id}</span>
+          </p>
+          <p>
+            Status: <StatusBadge status={deployment.status} error={deployment.error} />
+          </p>
+          <p className="sm:col-span-2">
+            Image: <span className="font-mono text-xs text-muted-foreground">{deployment.image}</span>
+          </p>
+          <p className="sm:col-span-2">
+            Domain:{' '}
+            <span className="font-mono text-xs text-muted-foreground">
+              {deployment.domain || 'No domain configured'}
+            </span>
+          </p>
+          {deployment.error ? (
+            <p className="sm:col-span-2 text-sm text-destructive">Last error: {deployment.error}</p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Ports</CardTitle>
+          </CardHeader>
+          <CardContent>{renderList(deployment.ports, 'No ports configured.')}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Volumes</CardTitle>
+          </CardHeader>
+          <CardContent>{renderList(deployment.volumes, 'No volumes configured.')}</CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Environment variables</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {envEntries.length ? (
+            <div className="space-y-1">
+              {envEntries.map(([key, value]) => (
+                <div
+                  key={key}
+                  className="grid grid-cols-[minmax(120px,220px)_1fr] gap-2 rounded bg-muted/30 px-3 py-2 text-xs"
+                >
+                  <span className="font-mono text-foreground">{key}</span>
+                  <span className="font-mono text-muted-foreground break-all">{value || '(empty)'}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No environment variables configured.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <DeploymentLogsPanel deploymentId={deployment.id} />
+    </div>
+  )
+}

--- a/dashboard/src/router.tsx
+++ b/dashboard/src/router.tsx
@@ -23,12 +23,22 @@ import {
   SidebarProvider,
 } from './components/ui/sidebar'
 import DeploymentList from './pages/DeploymentList'
+import { DeploymentDetailPage } from './pages/DeploymentDetailPage'
 import { SystemStatusPage } from './pages/SystemStatusPage'
 import { useTheme } from './theme'
 
 function DashboardLayout() {
   const pathname = useRouterState({ select: state => state.location.pathname })
   const { theme, toggleTheme } = useTheme()
+  const isSystemStatusPage = pathname === '/system-status'
+  const isDeploymentPage = pathname.startsWith('/deployments')
+  const isDeploymentDetailPage = isDeploymentPage && pathname !== '/deployments'
+  const pageTitle = isSystemStatusPage ? 'System status' : isDeploymentDetailPage ? 'Deployment detail' : 'Deployments'
+  const pageDescription = isSystemStatusPage
+    ? 'Observe API health and freshness.'
+    : isDeploymentDetailPage
+      ? 'Inspect deployment details and stream live logs.'
+      : 'Create, edit, and monitor your active deployments.'
 
   return (
     <SidebarProvider>
@@ -55,7 +65,7 @@ function DashboardLayout() {
               <SidebarGroupContent>
                 <SidebarMenu>
                   <SidebarMenuItem>
-                    <SidebarMenuButton asChild isActive={pathname === '/deployments'} size="lg" className="rounded-lg">
+                    <SidebarMenuButton asChild isActive={pathname.startsWith('/deployments')} size="lg" className="rounded-lg">
                       <Link to="/deployments">
                         <Boxes className="h-4 w-4 shrink-0" />
                         <span>Deployments</span>
@@ -78,20 +88,26 @@ function DashboardLayout() {
       </Sidebar>
 
       <SidebarInset>
-        <p className="mb-4 text-sm text-muted-foreground">{pathname === '/system-status' ? 'Observability' : 'Deployments'}</p>
-        <Card className="mx-auto w-full max-w-5xl">
-          <CardHeader>
-            <CardTitle>{pathname === '/system-status' ? 'System status' : 'Deployments'}</CardTitle>
-            <CardDescription>
-              {pathname === '/system-status'
-                ? 'Observe API health and freshness.'
-                : 'Create, edit, and monitor your active deployments.'}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+        <p className="mb-4 text-sm text-muted-foreground">{isSystemStatusPage ? 'Observability' : 'Deployments'}</p>
+        {isDeploymentDetailPage ? (
+          <div className="mx-auto w-full max-w-5xl space-y-4">
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight">{pageTitle}</h1>
+              <p className="text-sm text-muted-foreground">{pageDescription}</p>
+            </div>
             <Outlet />
-          </CardContent>
-        </Card>
+          </div>
+        ) : (
+          <Card className="mx-auto w-full max-w-5xl">
+            <CardHeader>
+              <CardTitle>{pageTitle}</CardTitle>
+              <CardDescription>{pageDescription}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Outlet />
+            </CardContent>
+          </Card>
+        )}
       </SidebarInset>
     </SidebarProvider>
   )
@@ -115,13 +131,19 @@ const deploymentsRoute = createRoute({
   component: DeploymentList,
 })
 
+const deploymentDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/deployments/$deploymentId',
+  component: DeploymentDetailPage,
+})
+
 const systemStatusRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/system-status',
   component: SystemStatusPage,
 })
 
-const routeTree = rootRoute.addChildren([indexRoute, deploymentsRoute, systemStatusRoute])
+const routeTree = rootRoute.addChildren([indexRoute, deploymentsRoute, deploymentDetailRoute, systemStatusRoute])
 
 export const router = createRouter({ routeTree })
 


### PR DESCRIPTION
## Summary
- add a deployment detail route and page that streams logs from the backend SSE endpoint
- improve discoverability and navigation with explicit Details actions and back navigation to the deployment list
- surface full deployment metadata (id, image, domain, ports, volumes, env vars, status/error) and keep the desktop sidebar sticky while main content scrolls

## Testing
- bun x vitest run (dashboard)
- bun run build (dashboard)

Closes #25