### PR TITLE
fix(deployments): auto-assign host ports and avoid redeploy conflicts

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/ercadev/dirigent/internal/events"
@@ -266,6 +267,21 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 		body.Volumes = []string{}
 	}
 
+	existing, err := h.store.Get(id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(w, "deployment not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to get deployment", http.StatusInternalServerError)
+		return
+	}
+
+	nextStatus := existing.Status
+	if updateRequiresRedeploy(existing, body) {
+		nextStatus = store.StatusDeploying
+	}
+
 	d := store.Deployment{
 		ID:      id,
 		Name:    body.Name,
@@ -274,23 +290,21 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 		Ports:   body.Ports,
 		Volumes: body.Volumes,
 		Domain:  body.Domain,
-		Status:  store.StatusDeploying,
+		Status:  nextStatus,
 	}
 
 	updated, err := h.store.Update(d)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			http.Error(w, "deployment not found", http.StatusNotFound)
-			return
-		}
 		http.Error(w, "failed to update deployment", http.StatusInternalServerError)
 		return
 	}
 
-	h.events.Publish(events.StatusEvent{
-		DeploymentID: updated.ID,
-		Status:       string(store.StatusDeploying),
-	})
+	if nextStatus == store.StatusDeploying {
+		h.events.Publish(events.StatusEvent{
+			DeploymentID: updated.ID,
+			Status:       string(store.StatusDeploying),
+		})
+	}
 
 	writeJSON(w, http.StatusOK, updated)
 }
@@ -368,29 +382,39 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	existing, err := h.store.Get(id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(w, "deployment not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to get deployment", http.StatusInternalServerError)
+		return
+	}
+
 	patch := store.Deployment{
 		Image:   body.Image,
 		Envs:    body.Envs,
 		Ports:   body.Ports,
 		Volumes: body.Volumes,
 		Domain:  body.Domain,
-		Status:  store.StatusDeploying,
+	}
+	if patchRequiresRedeploy(existing, body) {
+		patch.Status = store.StatusDeploying
 	}
 
 	updated, err := h.store.Patch(id, patch)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			http.Error(w, "deployment not found", http.StatusNotFound)
-			return
-		}
 		http.Error(w, "failed to update deployment", http.StatusInternalServerError)
 		return
 	}
 
-	h.events.Publish(events.StatusEvent{
-		DeploymentID: id,
-		Status:       string(store.StatusDeploying),
-	})
+	if patch.Status == store.StatusDeploying {
+		h.events.Publish(events.StatusEvent{
+			DeploymentID: id,
+			Status:       string(store.StatusDeploying),
+		})
+	}
 
 	writeJSON(w, http.StatusAccepted, updated)
 }
@@ -518,4 +542,39 @@ func orchestratorStaleAfterFromEnv() time.Duration {
 	}
 
 	return d
+}
+
+func updateRequiresRedeploy(existing store.Deployment, body deploymentRequest) bool {
+	return existing.Image != body.Image ||
+		!equalStringMap(existing.Envs, body.Envs) ||
+		!slices.Equal(existing.Ports, body.Ports) ||
+		!slices.Equal(existing.Volumes, body.Volumes)
+}
+
+func patchRequiresRedeploy(existing store.Deployment, body patchDeploymentRequest) bool {
+	if body.Image != "" && existing.Image != body.Image {
+		return true
+	}
+	if body.Envs != nil && !equalStringMap(existing.Envs, body.Envs) {
+		return true
+	}
+	if body.Ports != nil && !slices.Equal(existing.Ports, body.Ports) {
+		return true
+	}
+	if body.Volumes != nil && !slices.Equal(existing.Volumes, body.Volumes) {
+		return true
+	}
+	return false
+}
+
+func equalStringMap(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		if bv, ok := b[k]; !ok || bv != av {
+			return false
+		}
+	}
+	return true
 }

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -1110,6 +1110,57 @@ func TestPatchDeployment_EmitsDeployingEvent(t *testing.T) {
 	}
 }
 
+func TestPatchDeployment_DomainOnly_DoesNotRedeploy(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{
+		ID:     "d1",
+		Name:   "web",
+		Image:  "nginx:1",
+		Domain: "old.example.com",
+		Status: store.StatusHealthy,
+	}
+
+	broker := events.NewBroker()
+	srv := newTestServerWithBroker(s, broker)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	evtCh := readSSEEvents(ctx, t, srv.URL+"/api/deployments/events")
+	time.Sleep(50 * time.Millisecond)
+
+	body, _ := json.Marshal(map[string]string{"domain": "new.example.com"})
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/deployments/d1: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", resp.StatusCode)
+	}
+
+	var updated store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if updated.Domain != "new.example.com" {
+		t.Errorf("want domain new.example.com, got %s", updated.Domain)
+	}
+	if updated.Status != store.StatusHealthy {
+		t.Errorf("want status healthy, got %s", updated.Status)
+	}
+
+	select {
+	case event := <-evtCh:
+		t.Fatalf("unexpected SSE event for domain-only patch: %+v", event)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
 func TestUpdateDeployment(t *testing.T) {
 	s := newMemStore()
 	s.deployments["d1"] = store.Deployment{
@@ -1304,6 +1355,68 @@ func TestUpdateDeployment_Lifecycle(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout: no SSE event after PUT")
+	}
+}
+
+func TestUpdateDeployment_DomainOnly_DoesNotRedeploy(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{
+		ID:      "d1",
+		Name:    "web",
+		Image:   "nginx:1",
+		Envs:    map[string]string{"PORT": "80"},
+		Ports:   []string{"80:80"},
+		Volumes: []string{"/data:/data"},
+		Domain:  "old.example.com",
+		Status:  store.StatusHealthy,
+	}
+
+	broker := events.NewBroker()
+	srv := newTestServerWithBroker(s, broker)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	evtCh := readSSEEvents(ctx, t, srv.URL+"/api/deployments/events")
+	time.Sleep(50 * time.Millisecond)
+
+	body, _ := json.Marshal(map[string]any{
+		"name":    "web",
+		"image":   "nginx:1",
+		"envs":    map[string]string{"PORT": "80"},
+		"ports":   []string{"80:80"},
+		"volumes": []string{"/data:/data"},
+		"domain":  "new.example.com",
+	})
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/deployments/d1: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var updated store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if updated.Domain != "new.example.com" {
+		t.Errorf("want domain new.example.com, got %s", updated.Domain)
+	}
+	if updated.Status != store.StatusHealthy {
+		t.Errorf("want status healthy, got %s", updated.Status)
+	}
+
+	select {
+	case event := <-evtCh:
+		t.Fatalf("unexpected SSE event for domain-only update: %+v", event)
+	case <-time.After(250 * time.Millisecond):
 	}
 }
 

--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sort"
+	"strings"
 
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -40,6 +42,7 @@ type Client interface {
 	ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error
 	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
 	ContainerRename(ctx context.Context, containerID string, newName string) error
+	ContainerInspect(ctx context.Context, containerID string) (dockertypes.ContainerJSON, error)
 }
 
 // Docker manages container lifecycle for Dirigent deployments.
@@ -62,17 +65,17 @@ func (d *Docker) Ping(ctx context.Context) error {
 }
 
 // Start pulls the image and creates and starts a container for the deployment.
-func (d *Docker) Start(ctx context.Context, dep store.Deployment) error {
+func (d *Docker) Start(ctx context.Context, dep store.Deployment) ([]string, error) {
 	if _, err := d.client.Ping(ctx); err != nil {
-		return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 	}
 
 	rc, err := d.client.ImagePull(ctx, dep.Image, image.PullOptions{})
 	if err != nil {
 		if dockerclient.IsErrConnectionFailed(err) {
-			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 		}
-		return fmt.Errorf("docker: pull image %s: %w", dep.Image, err)
+		return nil, fmt.Errorf("docker: pull image %s: %w", dep.Image, err)
 	}
 	_, _ = io.Copy(io.Discard, rc)
 	rc.Close()
@@ -81,7 +84,7 @@ func (d *Docker) Start(ctx context.Context, dep store.Deployment) error {
 
 	exposedPorts, portBindings, err := parsePorts(dep.Ports)
 	if err != nil {
-		return fmt.Errorf("docker: parse ports: %w", err)
+		return nil, fmt.Errorf("docker: parse ports: %w", err)
 	}
 
 	cfg := &container.Config{
@@ -102,19 +105,26 @@ func (d *Docker) Start(ctx context.Context, dep store.Deployment) error {
 	resp, err := d.client.ContainerCreate(ctx, cfg, hostCfg, nil, nil, dep.Name)
 	if err != nil {
 		if dockerclient.IsErrConnectionFailed(err) {
-			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 		}
-		return fmt.Errorf("docker: create container %s: %w", dep.Name, err)
+		return nil, fmt.Errorf("docker: create container %s: %w", dep.Name, err)
 	}
 
 	if err := d.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
 		if dockerclient.IsErrConnectionFailed(err) {
-			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 		}
-		return fmt.Errorf("docker: start container %s: %w", resp.ID, err)
+		return nil, fmt.Errorf("docker: start container %s: %w", resp.ID, err)
 	}
 
-	return nil
+	runtimePorts, err := d.resolvedPorts(ctx, resp.ID)
+	if err != nil {
+		_ = d.client.ContainerStop(ctx, resp.ID, container.StopOptions{})
+		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
+		return nil, fmt.Errorf("docker: resolve runtime ports for %s: %w", resp.ID, err)
+	}
+
+	return runtimePorts, nil
 }
 
 // ListManagedContainers returns all containers with the dirigent.managed=true label.
@@ -172,17 +182,28 @@ func (d *Docker) StopAndRemove(ctx context.Context, containerID string) error {
 // and removes the old container before renaming the new one to the deployment name.
 // If the new container fails to reach running state the old container is left intact
 // and an error is returned.
-func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldContainerID string) error {
+func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldContainerID string) ([]string, error) {
 	if _, err := d.client.Ping(ctx); err != nil {
-		return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+	}
+
+	fallback, err := d.shouldStopBeforeStart(ctx, oldContainerID, dep.Ports)
+	if err != nil {
+		return nil, fmt.Errorf("docker: compare port bindings: %w", err)
+	}
+	if fallback {
+		if err := d.StopAndRemove(ctx, oldContainerID); err != nil {
+			return nil, fmt.Errorf("docker: stop old container %s before replace: %w", oldContainerID, err)
+		}
+		return d.Start(ctx, dep)
 	}
 
 	rc, err := d.client.ImagePull(ctx, dep.Image, image.PullOptions{})
 	if err != nil {
 		if dockerclient.IsErrConnectionFailed(err) {
-			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 		}
-		return fmt.Errorf("docker: pull image %s: %w", dep.Image, err)
+		return nil, fmt.Errorf("docker: pull image %s: %w", dep.Image, err)
 	}
 	_, _ = io.Copy(io.Discard, rc)
 	rc.Close()
@@ -191,7 +212,7 @@ func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldC
 
 	exposedPorts, portBindings, err := parsePorts(dep.Ports)
 	if err != nil {
-		return fmt.Errorf("docker: parse ports: %w", err)
+		return nil, fmt.Errorf("docker: parse ports: %w", err)
 	}
 
 	cfg := &container.Config{
@@ -212,17 +233,17 @@ func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldC
 	resp, err := d.client.ContainerCreate(ctx, cfg, hostCfg, nil, nil, nextName)
 	if err != nil {
 		if dockerclient.IsErrConnectionFailed(err) {
-			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 		}
-		return fmt.Errorf("docker: create container %s: %w", nextName, err)
+		return nil, fmt.Errorf("docker: create container %s: %w", nextName, err)
 	}
 
 	if err := d.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
 		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
 		if dockerclient.IsErrConnectionFailed(err) {
-			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 		}
-		return fmt.Errorf("docker: start container %s: %w", resp.ID, err)
+		return nil, fmt.Errorf("docker: start container %s: %w", resp.ID, err)
 	}
 
 	// Verify the new container reached running state.
@@ -231,11 +252,18 @@ func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldC
 	if err != nil {
 		_ = d.client.ContainerStop(ctx, resp.ID, container.StopOptions{})
 		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
-		return fmt.Errorf("docker: inspect new container %s: %w", resp.ID, err)
+		return nil, fmt.Errorf("docker: inspect new container %s: %w", resp.ID, err)
 	}
 	if len(running) == 0 {
 		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
-		return fmt.Errorf("docker: new container %s did not reach running state", resp.ID)
+		return nil, fmt.Errorf("docker: new container %s did not reach running state", resp.ID)
+	}
+
+	runtimePorts, err := d.resolvedPorts(ctx, resp.ID)
+	if err != nil {
+		_ = d.client.ContainerStop(ctx, resp.ID, container.StopOptions{})
+		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
+		return nil, fmt.Errorf("docker: resolve runtime ports for %s: %w", resp.ID, err)
 	}
 
 	// New container is healthy; tear down the old one.
@@ -248,7 +276,7 @@ func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldC
 		log.Printf("docker: rename %s to %s: %v", resp.ID, dep.Name, err)
 	}
 
-	return nil
+	return runtimePorts, nil
 }
 
 // envsToSlice converts a map of environment variables to the KEY=VALUE slice
@@ -261,15 +289,128 @@ func envsToSlice(envs map[string]string) []string {
 	return out
 }
 
-// parsePorts converts Dirigent port strings ("hostPort:containerPort") to the
-// Docker port set and binding map required by HostConfig.
+// parsePorts converts Dirigent port strings to the Docker port set and binding
+// map required by HostConfig. Container-only declarations (for example "3001")
+// are rewritten to "0:3001" so Docker assigns an available host port.
 func parsePorts(ports []string) (nat.PortSet, nat.PortMap, error) {
 	if len(ports) == 0 {
 		return nat.PortSet{}, nat.PortMap{}, nil
 	}
-	exposed, bindings, err := nat.ParsePortSpecs(ports)
+	normalized := make([]string, 0, len(ports))
+	for _, p := range ports {
+		if p != "" && !strings.Contains(p, ":") {
+			normalized = append(normalized, "0:"+p)
+			continue
+		}
+		normalized = append(normalized, p)
+	}
+
+	exposed, bindings, err := nat.ParsePortSpecs(normalized)
 	if err != nil {
 		return nil, nil, err
 	}
 	return nat.PortSet(exposed), bindings, nil
+}
+
+func (d *Docker) resolvedPorts(ctx context.Context, containerID string) ([]string, error) {
+	inspect, err := d.client.ContainerInspect(ctx, containerID)
+	if err != nil {
+		if dockerclient.IsErrConnectionFailed(err) {
+			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		}
+		return nil, err
+	}
+	if inspect.NetworkSettings == nil {
+		return nil, fmt.Errorf("network settings not available")
+	}
+
+	ports := make([]string, 0, len(inspect.NetworkSettings.Ports))
+	keys := make([]string, 0, len(inspect.NetworkSettings.Ports))
+	byKey := make(map[string]nat.Port, len(inspect.NetworkSettings.Ports))
+	for p := range inspect.NetworkSettings.Ports {
+		key := string(p)
+		keys = append(keys, key)
+		byKey[key] = p
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		p := byKey[key]
+		bindings := inspect.NetworkSettings.Ports[p]
+		for _, b := range bindings {
+			if b.HostPort == "" {
+				continue
+			}
+			ports = append(ports, b.HostPort+":"+p.Port())
+			break
+		}
+	}
+
+	return ports, nil
+}
+
+func (d *Docker) shouldStopBeforeStart(ctx context.Context, oldContainerID string, desiredPorts []string) (bool, error) {
+	desired, err := desiredExplicitHostPorts(desiredPorts)
+	if err != nil {
+		return false, err
+	}
+	if len(desired) == 0 {
+		return false, nil
+	}
+
+	inspect, err := d.client.ContainerInspect(ctx, oldContainerID)
+	if err != nil {
+		if dockerclient.IsErrConnectionFailed(err) {
+			return false, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		}
+		return false, err
+	}
+	if inspect.NetworkSettings == nil {
+		return false, nil
+	}
+
+	current := make(map[string]string, len(inspect.NetworkSettings.Ports))
+	for p, bindings := range inspect.NetworkSettings.Ports {
+		for _, b := range bindings {
+			if b.HostPort == "" {
+				continue
+			}
+			current[p.Port()] = b.HostPort
+			break
+		}
+	}
+
+	if len(current) != len(desired) {
+		return false, nil
+	}
+	for containerPort, hostPort := range desired {
+		if current[containerPort] != hostPort {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func desiredExplicitHostPorts(ports []string) (map[string]string, error) {
+	if len(ports) == 0 {
+		return map[string]string{}, nil
+	}
+
+	_, bindings, err := parsePorts(ports)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string, len(bindings))
+	for p, b := range bindings {
+		if len(b) == 0 {
+			continue
+		}
+		hostPort := b[0].HostPort
+		if hostPort == "" || hostPort == "0" {
+			continue
+		}
+		result[p.Port()] = hostPort
+	}
+	return result, nil
 }

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/ercadev/dirigent/orchestrator/internal/docker"
@@ -19,19 +20,22 @@ import (
 )
 
 type mockClient struct {
-	pingErr         error
-	imagePullErr    error
-	containerCreate container.CreateResponse
-	createErr       error
-	startErr        error
-	listContainers  []dockertypes.Container
-	listErr         error
-	stopErr         error
-	removeErr       error
-	renameErr       error
-	stopped         []string
-	removed         []string
-	renamed         []string
+	pingErr          error
+	imagePullErr     error
+	containerCreate  container.CreateResponse
+	createErr        error
+	startErr         error
+	listContainers   []dockertypes.Container
+	listErr          error
+	stopErr          error
+	removeErr        error
+	renameErr        error
+	inspectContainer dockertypes.ContainerJSON
+	inspectErr       error
+	createdHostCfg   *container.HostConfig
+	stopped          []string
+	removed          []string
+	renamed          []string
 }
 
 func (m *mockClient) Ping(_ context.Context) (dockertypes.Ping, error) {
@@ -45,7 +49,8 @@ func (m *mockClient) ImagePull(_ context.Context, _ string, _ image.PullOptions)
 	return io.NopCloser(strings.NewReader("")), nil
 }
 
-func (m *mockClient) ContainerCreate(_ context.Context, _ *container.Config, _ *container.HostConfig, _ *network.NetworkingConfig, _ *ocispec.Platform, _ string) (container.CreateResponse, error) {
+func (m *mockClient) ContainerCreate(_ context.Context, _ *container.Config, hostCfg *container.HostConfig, _ *network.NetworkingConfig, _ *ocispec.Platform, _ string) (container.CreateResponse, error) {
+	m.createdHostCfg = hostCfg
 	return m.containerCreate, m.createErr
 }
 
@@ -70,6 +75,13 @@ func (m *mockClient) ContainerRemove(_ context.Context, id string, _ container.R
 func (m *mockClient) ContainerRename(_ context.Context, id string, _ string) error {
 	m.renamed = append(m.renamed, id)
 	return m.renameErr
+}
+
+func (m *mockClient) ContainerInspect(_ context.Context, _ string) (dockertypes.ContainerJSON, error) {
+	if m.inspectErr != nil {
+		return dockertypes.ContainerJSON{}, m.inspectErr
+	}
+	return m.inspectContainer, nil
 }
 
 func deployment() store.Deployment {
@@ -100,17 +112,48 @@ func TestDocker_Ping_Unavailable(t *testing.T) {
 }
 
 func TestDocker_Start_OK(t *testing.T) {
-	mock := &mockClient{containerCreate: container.CreateResponse{ID: "c1"}}
+	mock := &mockClient{
+		containerCreate:  container.CreateResponse{ID: "c1"},
+		inspectContainer: inspectWithPort("80/tcp", "80"),
+	}
 	d := docker.New(mock)
-	if err := d.Start(context.Background(), deployment()); err != nil {
+	if _, err := d.Start(context.Background(), deployment()); err != nil {
 		t.Fatalf("want nil, got %v", err)
+	}
+}
+
+func TestDocker_Start_ContainerOnlyPort_AssignsHostPort(t *testing.T) {
+	mock := &mockClient{
+		containerCreate:  container.CreateResponse{ID: "c1"},
+		inspectContainer: inspectWithPort("3001/tcp", "49123"),
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.Ports = []string{"3001"}
+
+	ports, err := d.Start(context.Background(), dep)
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+
+	if len(ports) != 1 || ports[0] != "49123:3001" {
+		t.Fatalf("want runtime ports [49123:3001], got %v", ports)
+	}
+
+	if mock.createdHostCfg == nil {
+		t.Fatal("want ContainerCreate called with host config")
+	}
+	b := mock.createdHostCfg.PortBindings["3001/tcp"]
+	if len(b) != 1 || b[0].HostPort != "0" {
+		t.Fatalf("want host port auto-assigned (0), got %v", b)
 	}
 }
 
 func TestDocker_Start_ImagePullError(t *testing.T) {
 	mock := &mockClient{imagePullErr: errors.New("manifest unknown")}
 	d := docker.New(mock)
-	err := d.Start(context.Background(), deployment())
+	_, err := d.Start(context.Background(), deployment())
 	if err == nil {
 		t.Fatal("want error, got nil")
 	}
@@ -169,11 +212,13 @@ func TestDocker_StartAndReplace_OK(t *testing.T) {
 		listContainers: []dockertypes.Container{
 			{ID: "new-c1", State: "running"},
 		},
+		inspectContainer: inspectWithPort("3001/tcp", "49123"),
 	}
 	d := docker.New(mock)
 
 	dep := deployment()
-	if err := d.StartAndReplace(context.Background(), dep, "old-c1"); err != nil {
+	dep.Ports = []string{"3001"}
+	if _, err := d.StartAndReplace(context.Background(), dep, "old-c1"); err != nil {
 		t.Fatalf("want nil, got %v", err)
 	}
 
@@ -200,7 +245,7 @@ func TestDocker_StartAndReplace_NewContainerNotRunning(t *testing.T) {
 	d := docker.New(mock)
 
 	dep := deployment()
-	err := d.StartAndReplace(context.Background(), dep, "old-c1")
+	_, err := d.StartAndReplace(context.Background(), dep, "old-c1")
 	if err == nil {
 		t.Fatal("want error when new container is not running, got nil")
 	}
@@ -214,6 +259,35 @@ func TestDocker_StartAndReplace_NewContainerNotRunning(t *testing.T) {
 	}
 }
 
+func TestDocker_StartAndReplace_SameExplicitPorts_FallsBackToStopThenStart(t *testing.T) {
+	mock := &mockClient{
+		containerCreate:  container.CreateResponse{ID: "new-c1"},
+		inspectContainer: inspectWithPort("80/tcp", "80"),
+		// No running-container list required on fallback path.
+		listContainers: []dockertypes.Container{},
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.Ports = []string{"80:80"}
+
+	ports, err := d.StartAndReplace(context.Background(), dep, "old-c1")
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+
+	if len(ports) != 1 || ports[0] != "80:80" {
+		t.Fatalf("want runtime ports [80:80], got %v", ports)
+	}
+
+	if len(mock.stopped) != 1 || mock.stopped[0] != "old-c1" {
+		t.Fatalf("want old-c1 stopped first, got %v", mock.stopped)
+	}
+	if len(mock.removed) != 1 || mock.removed[0] != "old-c1" {
+		t.Fatalf("want old-c1 removed first, got %v", mock.removed)
+	}
+}
+
 // Ensure the mock satisfies the docker.Client interface at compile time.
 var _ interface {
 	ContainerList(context.Context, container.ListOptions) ([]dockertypes.Container, error)
@@ -222,3 +296,15 @@ var _ interface {
 
 // Ensure filters package is referenced (avoids unused import if linter checks).
 var _ = filters.NewArgs
+
+func inspectWithPort(containerPort, hostPort string) dockertypes.ContainerJSON {
+	return dockertypes.ContainerJSON{
+		NetworkSettings: &dockertypes.NetworkSettings{
+			NetworkSettingsBase: dockertypes.NetworkSettingsBase{
+				Ports: nat.PortMap{
+					nat.Port(containerPort): []nat.PortBinding{{HostPort: hostPort}},
+				},
+			},
+		},
+	}
+}

--- a/orchestrator/internal/reconciler/reconciler.go
+++ b/orchestrator/internal/reconciler/reconciler.go
@@ -11,8 +11,8 @@ import (
 
 // Docker is the container management interface required by the reconciler.
 type Docker interface {
-	Start(ctx context.Context, d store.Deployment) error
-	StartAndReplace(ctx context.Context, d store.Deployment, oldContainerID string) error
+	Start(ctx context.Context, d store.Deployment) ([]string, error)
+	StartAndReplace(ctx context.Context, d store.Deployment, oldContainerID string) ([]string, error)
 	ListManagedContainers(ctx context.Context) ([]docker.ManagedContainer, error)
 	StopAndRemove(ctx context.Context, containerID string) error
 }
@@ -20,6 +20,7 @@ type Docker interface {
 // Store is the persistence interface required by the reconciler.
 type Store interface {
 	List() ([]store.Deployment, error)
+	Patch(id string, patch store.Deployment) (store.Deployment, error)
 	UpdateStatus(id string, status store.Status) error
 }
 
@@ -75,19 +76,21 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		case store.StatusDeploying:
 			if !hasContainer {
 				// Fresh deploy: no container exists yet — start one.
-				if err := r.docker.Start(ctx, d); err != nil {
+				runtimePorts, err := r.docker.Start(ctx, d)
+				if err != nil {
 					log.Printf("reconciler: start %s (%s): %v", d.ID, d.Name, err)
 					r.updateStatus(d.ID, store.StatusFailed)
 				} else {
-					r.updateStatus(d.ID, store.StatusHealthy)
+					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy)
 				}
 			} else if c.Running {
 				// Container already running — this is a redeploy; apply start-then-stop.
-				if err := r.docker.StartAndReplace(ctx, d, c.ID); err != nil {
+				runtimePorts, err := r.docker.StartAndReplace(ctx, d, c.ID)
+				if err != nil {
 					log.Printf("reconciler: redeploy %s (%s): %v", d.ID, d.Name, err)
 					r.updateStatus(d.ID, store.StatusFailed)
 				} else {
-					r.updateStatus(d.ID, store.StatusHealthy)
+					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy)
 				}
 			} else {
 				r.updateStatus(d.ID, store.StatusFailed)
@@ -119,6 +122,21 @@ func (r *Reconciler) updateStatus(id string, status store.Status) {
 	if err := r.store.UpdateStatus(id, status); err != nil {
 		log.Printf("reconciler: update status %s → %s: %v", id, status, err)
 	}
+	r.notifyStatus(id, status)
+}
+
+func (r *Reconciler) updatePortsAndStatus(id string, ports []string, status store.Status) {
+	patch := store.Deployment{Status: status}
+	if ports != nil {
+		patch.Ports = ports
+	}
+	if _, err := r.store.Patch(id, patch); err != nil {
+		log.Printf("reconciler: patch deployment %s: %v", id, err)
+	}
+	r.notifyStatus(id, status)
+}
+
+func (r *Reconciler) notifyStatus(id string, status store.Status) {
 	if r.notifier != nil {
 		if err := r.notifier.NotifyStatus(id, status); err != nil {
 			log.Printf("reconciler: notify api status %s → %s: %v", id, status, err)

--- a/orchestrator/internal/reconciler/reconciler_test.go
+++ b/orchestrator/internal/reconciler/reconciler_test.go
@@ -13,8 +13,8 @@ import (
 
 // mockNotifier records NotifyStatus calls and can be configured to fail.
 type mockNotifier struct {
-	mu      sync.Mutex
-	calls   []notifyCall
+	mu        sync.Mutex
+	calls     []notifyCall
 	notifyErr error
 }
 
@@ -64,6 +64,24 @@ func (m *mockStore) UpdateStatus(id string, status store.Status) error {
 	return nil
 }
 
+func (m *mockStore) Patch(id string, patch store.Deployment) (store.Deployment, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, d := range m.deployments {
+		if d.ID != id {
+			continue
+		}
+		if patch.Ports != nil {
+			m.deployments[i].Ports = patch.Ports
+		}
+		if patch.Status != "" {
+			m.deployments[i].Status = patch.Status
+		}
+		return m.deployments[i], nil
+	}
+	return store.Deployment{}, nil
+}
+
 func (m *mockStore) getStatus(id string) store.Status {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -75,36 +93,57 @@ func (m *mockStore) getStatus(id string) store.Status {
 	return ""
 }
 
-// mockDocker is a controllable Docker client for testing.
-type mockDocker struct {
-	mu                    sync.Mutex
-	containers            []docker.ManagedContainer
-	startErr              error
-	startAndReplaceErr    error
-	started               []string
-	replaced              []string // old container IDs passed to StartAndReplace
-	removed               []string
+func (m *mockStore) getPorts(id string) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, d := range m.deployments {
+		if d.ID == id {
+			out := make([]string, len(d.Ports))
+			copy(out, d.Ports)
+			return out
+		}
+	}
+	return nil
 }
 
-func (m *mockDocker) Start(_ context.Context, d store.Deployment) error {
+// mockDocker is a controllable Docker client for testing.
+type mockDocker struct {
+	mu                   sync.Mutex
+	containers           []docker.ManagedContainer
+	startErr             error
+	startAndReplaceErr   error
+	startPorts           []string
+	startAndReplacePorts []string
+	started              []string
+	replaced             []string // old container IDs passed to StartAndReplace
+	removed              []string
+}
+
+func (m *mockDocker) Start(_ context.Context, d store.Deployment) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.startErr != nil {
-		return m.startErr
+		return nil, m.startErr
 	}
 	m.started = append(m.started, d.ID)
-	return nil
+	if m.startPorts != nil {
+		return m.startPorts, nil
+	}
+	return d.Ports, nil
 }
 
-func (m *mockDocker) StartAndReplace(_ context.Context, d store.Deployment, oldContainerID string) error {
+func (m *mockDocker) StartAndReplace(_ context.Context, d store.Deployment, oldContainerID string) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.startAndReplaceErr != nil {
-		return m.startAndReplaceErr
+		return nil, m.startAndReplaceErr
 	}
 	m.started = append(m.started, d.ID)
 	m.replaced = append(m.replaced, oldContainerID)
-	return nil
+	if m.startAndReplacePorts != nil {
+		return m.startAndReplacePorts, nil
+	}
+	return d.Ports, nil
 }
 
 func (m *mockDocker) ListManagedContainers(_ context.Context) ([]docker.ManagedContainer, error) {
@@ -184,6 +223,47 @@ func TestReconcile_DeployingWithRunningContainer_RedeploysAndBecomesHealthy(t *t
 	}
 	if s.getStatus("d1") != store.StatusHealthy {
 		t.Errorf("want status healthy, got %s", s.getStatus("d1"))
+	}
+}
+
+func TestReconcile_DeployingNoContainer_StoresRuntimePorts(t *testing.T) {
+	s := &mockStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Name: "web", Image: "nginx:latest", Ports: []string{"3001"}, Status: store.StatusDeploying},
+		},
+	}
+	d := &mockDocker{startPorts: []string{"49123:3001"}}
+	r := reconciler.New(s, d, nil)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	ports := s.getPorts("d1")
+	if len(ports) != 1 || ports[0] != "49123:3001" {
+		t.Fatalf("want ports [49123:3001], got %v", ports)
+	}
+}
+
+func TestReconcile_Redeploy_StoresRuntimePorts(t *testing.T) {
+	s := &mockStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Name: "web", Image: "nginx:2", Ports: []string{"3001"}, Status: store.StatusDeploying},
+		},
+	}
+	d := &mockDocker{
+		containers:           []docker.ManagedContainer{{ID: "c1", DeploymentID: "d1", Running: true}},
+		startAndReplacePorts: []string{"49124:3001"},
+	}
+	r := reconciler.New(s, d, nil)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	ports := s.getPorts("d1")
+	if len(ports) != 1 || ports[0] != "49124:3001" {
+		t.Fatalf("want ports [49124:3001], got %v", ports)
 	}
 }
 


### PR DESCRIPTION
## Summary
- support container-only port declarations (for example `3001`) by letting Docker auto-assign a host port and persisting resolved runtime bindings back to the deployment
- avoid unnecessary redeploys for domain-only updates by setting `deploying` only when container-affecting fields change
- make redeploys resilient when explicit host ports are unchanged by falling back to stop-then-start to prevent bind conflicts

## Testing
- make test

Closes #82
Closes #83