### PR TITLE
feat(dashboard): redesign system status cards for services and host metrics

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -39,10 +39,22 @@ export type DockerSystemStatus = {
   lastUpdated?: string
 }
 
+export type HostMetricSystemStatus = {
+  state: SystemStatusState
+  usagePercent?: number
+  lastUpdated?: string
+}
+
+export type HostSystemStatus = {
+  cpu: HostMetricSystemStatus
+  ram: HostMetricSystemStatus
+}
+
 export type SystemStatusSnapshot = {
   api: APISystemStatus
   orchestrator: OrchestratorSystemStatus
   docker: DockerSystemStatus
+  host: HostSystemStatus
   error?: string
 }
 

--- a/dashboard/src/system-status/SystemStatusPanel.test.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.test.tsx
@@ -44,22 +44,41 @@ describe('SystemStatusPanel', () => {
         state: 'healthy',
         lastUpdated,
       },
+      host: {
+        cpu: {
+          state: 'healthy',
+          usagePercent: 31.2,
+          lastUpdated,
+        },
+        ram: {
+          state: 'healthy',
+          usagePercent: 45.8,
+          lastUpdated,
+        },
+      },
     })
 
     renderWithQuery(<SystemStatusPanel />)
 
     await waitFor(() => expect(screen.getAllByText('healthy')).toHaveLength(3))
     expect(screen.getByText('API signal')).toBeInTheDocument()
-    expect(screen.getByText('Orchestrator liveness')).toBeInTheDocument()
-    expect(screen.getAllByText('State:')).toHaveLength(2)
-    expect(screen.getByText('Docker state:')).toBeInTheDocument()
-    expect(screen.getByText('Last updated:')).toBeInTheDocument()
-    expect(screen.getByText('Last heartbeat:')).toBeInTheDocument()
-    expect(screen.getByText('Last checked:')).toBeInTheDocument()
-    expect(screen.getByText('Freshness:')).toBeInTheDocument()
-    expect(screen.getByText('Signal:')).toBeInTheDocument()
+    expect(screen.getByText('Orchestrator')).toBeInTheDocument()
+    expect(screen.getByText('Docker connectivity')).toBeInTheDocument()
+    expect(screen.getByText('Services')).toBeInTheDocument()
+    expect(screen.getByText('Host metrics')).toBeInTheDocument()
+    expect(screen.getByText('CPU usage')).toBeInTheDocument()
+    expect(screen.getByText('RAM usage')).toBeInTheDocument()
+    expect(screen.getByText(/Last heartbeat:/)).toBeInTheDocument()
+    expect(screen.getByText(/Last checked:/)).toBeInTheDocument()
+    expect(screen.getByText(/Freshness:/)).toBeInTheDocument()
     expect(screen.getByText('Docker is reachable from orchestrator')).toBeInTheDocument()
-    expect(screen.getAllByText(new Date(lastUpdated).toLocaleString())).toHaveLength(3)
+    expect(screen.getAllByText('healthy pressure')).toHaveLength(2)
+    expect(screen.getByTestId('api-status-icon')).toBeInTheDocument()
+    expect(screen.getByTestId('orchestrator-status-icon')).toBeInTheDocument()
+    expect(screen.getByTestId('docker-status-icon')).toBeInTheDocument()
+    expect(screen.getByText('Reading: 31.2%')).toBeInTheDocument()
+    expect(screen.getByText('Reading: 45.8%')).toBeInTheDocument()
+    expect(screen.getAllByText(new RegExp(new Date(lastUpdated).toLocaleString()), { selector: 'p' })).toHaveLength(5)
   })
 
   it('renders degraded orchestrator and docker states', async () => {
@@ -78,13 +97,26 @@ describe('SystemStatusPanel', () => {
         state: 'degraded',
         lastUpdated: orchestratorUpdated,
       },
+      host: {
+        cpu: {
+          state: 'healthy',
+          usagePercent: 87.2,
+          lastUpdated: orchestratorUpdated,
+        },
+        ram: {
+          state: 'healthy',
+          usagePercent: 82.1,
+          lastUpdated: orchestratorUpdated,
+        },
+      },
     })
 
     renderWithQuery(<SystemStatusPanel />)
 
     await waitFor(() => expect(screen.getAllByText('degraded')).toHaveLength(2))
     expect(screen.getByText('Docker check failed at last probe')).toBeInTheDocument()
-    expect(screen.getAllByText(new Date(orchestratorUpdated).toLocaleString())).toHaveLength(2)
+    expect(screen.getAllByText('degraded pressure')).toHaveLength(2)
+    expect(screen.getAllByText(new RegExp(new Date(orchestratorUpdated).toLocaleString()), { selector: 'p' })).toHaveLength(4)
   })
 
   it('renders stale orchestrator state and freshness', async () => {
@@ -103,13 +135,24 @@ describe('SystemStatusPanel', () => {
         state: 'healthy',
         lastUpdated: apiUpdated,
       },
+      host: {
+        cpu: {
+          state: 'healthy',
+          usagePercent: 52,
+          lastUpdated: apiUpdated,
+        },
+        ram: {
+          state: 'healthy',
+          usagePercent: 65,
+          lastUpdated: apiUpdated,
+        },
+      },
     })
 
     renderWithQuery(<SystemStatusPanel />)
 
     await waitFor(() => expect(screen.getByText('stale')).toBeInTheDocument())
     expect(screen.getByText(/ago|just now/)).toBeInTheDocument()
-
   })
 
   it('renders unavailable docker telemetry explicitly', async () => {
@@ -126,13 +169,24 @@ describe('SystemStatusPanel', () => {
       docker: {
         state: 'unavailable',
       },
+      host: {
+        cpu: {
+          state: 'unavailable',
+        },
+        ram: {
+          state: 'unavailable',
+        },
+      },
     })
 
     renderWithQuery(<SystemStatusPanel />)
 
-    await waitFor(() => expect(screen.getByText('unavailable')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('Docker connectivity')).toBeInTheDocument())
     expect(screen.getByText('No Docker connectivity telemetry yet')).toBeInTheDocument()
-    expect(screen.getByText('No signal yet')).toBeInTheDocument()
+    expect(screen.getByTestId('docker-status-icon')).toBeInTheDocument()
+    expect(screen.getAllByText(/Reading: Unavailable/)).toHaveLength(2)
+    expect(screen.getAllByText('unavailable telemetry')).toHaveLength(2)
+    expect(screen.getAllByText(/No signal yet/, { selector: 'p' })).toHaveLength(3)
   })
 
   it('renders fetch failure UI when endpoint errors', async () => {

--- a/dashboard/src/system-status/SystemStatusPanel.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.tsx
@@ -1,6 +1,7 @@
 import { useSystemStatus } from './useSystemStatus'
 import { Badge } from '../components/ui/badge'
-import type { SystemStatusState } from '../lib/api'
+import { AlertTriangle, CheckCircle2, CircleSlash2, Clock3 } from 'lucide-react'
+import type { HostMetricSystemStatus, SystemStatusState } from '../lib/api'
 
 type BadgeVariant = 'secondary' | 'info' | 'success' | 'destructive' | 'warning'
 
@@ -9,6 +10,22 @@ const STATE_VARIANT: Record<SystemStatusState, BadgeVariant> = {
   degraded: 'warning',
   stale: 'destructive',
   unavailable: 'secondary',
+}
+
+const DEGRADED_PRESSURE_THRESHOLD = 80
+
+const CARD_TONE: Record<SystemStatusState, string> = {
+  healthy: 'border-emerald-200 bg-emerald-50/60 dark:border-emerald-900/60 dark:bg-emerald-950/30',
+  degraded: 'border-amber-200 bg-amber-50/60 dark:border-amber-900/60 dark:bg-amber-950/30',
+  stale: 'border-rose-200 bg-rose-50/60 dark:border-rose-900/60 dark:bg-rose-950/30',
+  unavailable: 'border-slate-200 bg-slate-50/70 dark:border-slate-800 dark:bg-slate-900/40',
+}
+
+const ICON_TONE: Record<SystemStatusState, string> = {
+  healthy: 'text-emerald-600 dark:text-emerald-400',
+  degraded: 'text-amber-600 dark:text-amber-400',
+  stale: 'text-rose-600 dark:text-rose-400',
+  unavailable: 'text-slate-500 dark:text-slate-400',
 }
 
 function formatTimestamp(timestamp?: string) {
@@ -40,11 +57,58 @@ function formatFreshness(timestamp?: string) {
   return `${Math.floor(diffSeconds / 86400)}d ago`
 }
 
+function formatUsagePercent(metric: HostMetricSystemStatus) {
+  if (typeof metric.usagePercent !== 'number') {
+    return 'Unavailable'
+  }
+
+  return `${metric.usagePercent.toFixed(1)}%`
+}
+
+function pressureState(metric: HostMetricSystemStatus): SystemStatusState {
+  if (metric.state === 'unavailable' || typeof metric.usagePercent !== 'number') {
+    return 'unavailable'
+  }
+
+  if (metric.state === 'stale') {
+    return 'stale'
+  }
+
+  if (metric.state === 'degraded' || metric.usagePercent >= DEGRADED_PRESSURE_THRESHOLD) {
+    return 'degraded'
+  }
+
+  return 'healthy'
+}
+
+function pressureLabel(metric: HostMetricSystemStatus) {
+  const state = pressureState(metric)
+  if (state === 'healthy') return 'healthy pressure'
+  if (state === 'degraded') return 'degraded pressure'
+  if (state === 'stale') return 'stale telemetry'
+  return 'unavailable telemetry'
+}
+
+function formatUsageValue(metric: HostMetricSystemStatus) {
+  if (typeof metric.usagePercent !== 'number') {
+    return '--'
+  }
+
+  return `${Math.round(metric.usagePercent)}%`
+}
+
+function statusIcon(state: SystemStatusState) {
+  if (state === 'healthy') return CheckCircle2
+  if (state === 'degraded') return AlertTriangle
+  if (state === 'stale') return Clock3
+  return CircleSlash2
+}
+
 export function SystemStatusPanel() {
   const { status, isLoading, isError } = useSystemStatus()
 
   return (
-    <section className="space-y-4">
+    <section className="space-y-6">
       {isLoading && <p className="text-sm text-muted-foreground">Loading system status…</p>}
 
       {isError && (
@@ -52,57 +116,125 @@ export function SystemStatusPanel() {
       )}
 
       {status && !isLoading && !isError && (
-        <div className="divide-y rounded-lg bg-muted/20 text-sm text-muted-foreground">
-          <section className="space-y-2 p-4">
-            <p className="font-semibold text-foreground">API signal</p>
-            <p className="text-xs text-muted-foreground/90">Control plane availability and response health.</p>
-            <p>
-              State: <Badge variant={STATE_VARIANT[status.api.state]}>{status.api.state}</Badge>
-            </p>
-            <p>
-              Last updated:{' '}
-              <span className="font-medium text-foreground">{formatTimestamp(status.api.lastUpdated)}</span>
-            </p>
-          </section>
+        <div className="space-y-8">
+          <section className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Services</p>
+            <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+              <article className={`rounded-lg border p-5 text-sm text-muted-foreground ${CARD_TONE[status.api.state]}`}>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-foreground">API signal</p>
+                    <p className="mt-1 text-xs">Control plane availability.</p>
+                  </div>
+                  {(() => {
+                    const Icon = statusIcon(status.api.state)
+                    return (
+                      <div className="rounded-md bg-background/70 p-2">
+                        <Icon data-testid="api-status-icon" className={`h-8 w-8 ${ICON_TONE[status.api.state]}`} />
+                      </div>
+                    )
+                  })()}
+                </div>
+                <div className="mt-4 flex items-center justify-between gap-3">
+                  <p className="text-xs uppercase tracking-wide">State</p>
+                  <Badge variant={STATE_VARIANT[status.api.state]}>{status.api.state}</Badge>
+                </div>
+                <p className="mt-3 border-t border-border/50 pt-3 text-xs">Last updated: {formatTimestamp(status.api.lastUpdated)}</p>
+              </article>
 
-          <section className="space-y-2 p-4">
-            <p className="font-semibold text-foreground">Orchestrator liveness</p>
-            <p className="text-xs text-muted-foreground/90">
-              Worker heartbeat and Docker connectivity statuses from the host agent.
-            </p>
-            <ul className="space-y-1.5">
-              <li>
-                State: <Badge variant={STATE_VARIANT[status.orchestrator.state]}>{status.orchestrator.state}</Badge>
-              </li>
-              <li>
-                Last heartbeat:{' '}
-                <span className="font-medium text-foreground">
-                  {formatTimestamp(status.orchestrator.lastUpdated)}
-                </span>
-              </li>
-              <li>
-                Freshness:{' '}
-                <span className="font-medium text-foreground">
-                  {formatFreshness(status.orchestrator.lastUpdated)}
-                </span>
-              </li>
-              <li className="pt-1">
-                Docker state: <Badge variant={STATE_VARIANT[status.docker.state]}>{status.docker.state}</Badge>
-              </li>
-              <li>
-                Last checked:{' '}
-                <span className="font-medium text-foreground">{formatTimestamp(status.docker.lastUpdated)}</span>
-              </li>
-              <li>
-                Signal:{' '}
-                <span className="font-medium text-foreground">
+              <article className={`rounded-lg border p-5 text-sm text-muted-foreground ${CARD_TONE[status.orchestrator.state]}`}>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-foreground">Orchestrator</p>
+                    <p className="mt-1 text-xs">Agent liveness signal.</p>
+                  </div>
+                  {(() => {
+                    const Icon = statusIcon(status.orchestrator.state)
+                    return (
+                      <div className="rounded-md bg-background/70 p-2">
+                        <Icon
+                          data-testid="orchestrator-status-icon"
+                          className={`h-8 w-8 ${ICON_TONE[status.orchestrator.state]}`}
+                        />
+                      </div>
+                    )
+                  })()}
+                </div>
+                <div className="mt-4 flex items-center justify-between gap-3">
+                  <p className="text-xs uppercase tracking-wide">State</p>
+                  <Badge variant={STATE_VARIANT[status.orchestrator.state]}>{status.orchestrator.state}</Badge>
+                </div>
+                <div className="mt-3 space-y-1 border-t border-border/50 pt-3 text-xs">
+                  <p>Last heartbeat: {formatTimestamp(status.orchestrator.lastUpdated)}</p>
+                  <p>Freshness: {formatFreshness(status.orchestrator.lastUpdated)}</p>
+                </div>
+              </article>
+
+              <article className={`rounded-lg border p-5 text-sm text-muted-foreground ${CARD_TONE[status.docker.state]}`}>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-foreground">Docker connectivity</p>
+                    <p className="mt-1 text-xs">Container runtime reachability.</p>
+                  </div>
+                  {(() => {
+                    const Icon = statusIcon(status.docker.state)
+                    return (
+                      <div className="rounded-md bg-background/70 p-2">
+                        <Icon data-testid="docker-status-icon" className={`h-8 w-8 ${ICON_TONE[status.docker.state]}`} />
+                      </div>
+                    )
+                  })()}
+                </div>
+                <div className="mt-4 flex items-center justify-between gap-3">
+                  <p className="text-xs uppercase tracking-wide">State</p>
+                  <Badge variant={STATE_VARIANT[status.docker.state]}>{status.docker.state}</Badge>
+                </div>
+                <p className="mt-3 border-t border-border/50 pt-3 text-xs">Last checked: {formatTimestamp(status.docker.lastUpdated)}</p>
+                <p className="mt-1 text-xs">
                   {status.docker.state === 'healthy' && 'Docker is reachable from orchestrator'}
                   {status.docker.state === 'degraded' && 'Docker check failed at last probe'}
                   {status.docker.state === 'stale' && 'Docker signal is stale'}
                   {status.docker.state === 'unavailable' && 'No Docker connectivity telemetry yet'}
-                </span>
-              </li>
-            </ul>
+                </p>
+              </article>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Host metrics</p>
+            <div className="grid gap-5 sm:grid-cols-2">
+              <article
+                className={`rounded-lg border p-5 text-sm text-muted-foreground ${CARD_TONE[pressureState(status.host.cpu)]}`}
+              >
+                <p className="font-semibold text-foreground">CPU usage</p>
+                <div className="mt-3 flex items-end justify-between">
+                  <p className="text-3xl font-bold text-foreground">{formatUsageValue(status.host.cpu)}</p>
+                  <p className="text-xs uppercase tracking-wide">host load</p>
+                </div>
+                <p className="mt-3">
+                  Pressure{' '}
+                  <Badge variant={STATE_VARIANT[pressureState(status.host.cpu)]}>{pressureLabel(status.host.cpu)}</Badge>
+                </p>
+                <p className="mt-2 text-xs">Reading: {formatUsagePercent(status.host.cpu)}</p>
+                <p className="mt-1 text-xs">Last updated: {formatTimestamp(status.host.cpu.lastUpdated)}</p>
+              </article>
+
+              <article
+                className={`rounded-lg border p-5 text-sm text-muted-foreground ${CARD_TONE[pressureState(status.host.ram)]}`}
+              >
+                <p className="font-semibold text-foreground">RAM usage</p>
+                <div className="mt-3 flex items-end justify-between">
+                  <p className="text-3xl font-bold text-foreground">{formatUsageValue(status.host.ram)}</p>
+                  <p className="text-xs uppercase tracking-wide">memory load</p>
+                </div>
+                <p className="mt-3">
+                  Pressure{' '}
+                  <Badge variant={STATE_VARIANT[pressureState(status.host.ram)]}>{pressureLabel(status.host.ram)}</Badge>
+                </p>
+                <p className="mt-2 text-xs">Reading: {formatUsagePercent(status.host.ram)}</p>
+                <p className="mt-1 text-xs">Last updated: {formatTimestamp(status.host.ram.lastUpdated)}</p>
+              </article>
+            </div>
           </section>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Rework the system status UI into separate `Services` and `Host metrics` sections with clearer card hierarchy and spacing.
- Replace service score numbers with large state icons and status-colored cards for faster at-a-glance scanning.
- Add explicit host CPU/RAM metric rendering (including unavailable fallbacks) and update frontend tests for healthy, degraded, stale, and unavailable states.

Closes #65