### PR TITLE
feat(deployments): surface failed deployment diagnostics

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -421,6 +421,7 @@ func (h *Handler) updateDeploymentStatus(w http.ResponseWriter, r *http.Request)
 	}
 
 	d.Status = body.Status
+	d.Error = body.Error
 	updated, err := h.store.Update(d)
 	if err != nil {
 		http.Error(w, "failed to update deployment", http.StatusInternalServerError)

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -951,6 +951,45 @@ func TestUpdateDeploymentStatus(t *testing.T) {
 	if updated.Status != store.StatusHealthy {
 		t.Errorf("want status healthy, got %s", updated.Status)
 	}
+	if updated.Error != "" {
+		t.Errorf("want empty error, got %q", updated.Error)
+	}
+}
+
+func TestUpdateDeploymentStatus_FailedStoresError(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Status: store.StatusDeploying}
+
+	srv := newTestServer(s)
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{
+		"status": "failed",
+		"error":  "image not found",
+	})
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/d1/status", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/deployments/d1/status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var updated store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if updated.Status != store.StatusFailed {
+		t.Errorf("want status failed, got %s", updated.Status)
+	}
+	if updated.Error != "image not found" {
+		t.Errorf("want error image not found, got %q", updated.Error)
+	}
 }
 
 func TestUpdateDeploymentStatus_InvalidStatus(t *testing.T) {

--- a/api/internal/docker/logs.go
+++ b/api/internal/docker/logs.go
@@ -28,17 +28,17 @@ func New(client Client) *LogStreamer {
 }
 
 // StreamLogs returns a reader that emits demultiplexed log lines (stdout and
-// stderr combined) for the running container associated with deploymentID,
+// stderr combined) for the newest container associated with deploymentID,
 // starting from the last tail lines. The caller must close the reader when
 // done; closing it also terminates the underlying Docker log stream.
 //
-// Returns (nil, nil) when no container is currently running for the deployment.
+// Returns (nil, nil) when no managed container exists for the deployment.
 func (s *LogStreamer) StreamLogs(ctx context.Context, deploymentID string, tail int) (io.ReadCloser, error) {
 	f := filters.NewArgs(
 		filters.Arg("label", "dirigent.managed=true"),
 		filters.Arg("label", "dirigent.id="+deploymentID),
 	)
-	containers, err := s.client.ContainerList(ctx, container.ListOptions{Filters: f})
+	containers, err := s.client.ContainerList(ctx, container.ListOptions{All: true, Filters: f})
 	if err != nil {
 		return nil, fmt.Errorf("docker: list containers for deployment %s: %w", deploymentID, err)
 	}
@@ -46,14 +46,21 @@ func (s *LogStreamer) StreamLogs(ctx context.Context, deploymentID string, tail 
 		return nil, nil
 	}
 
-	raw, err := s.client.ContainerLogs(ctx, containers[0].ID, container.LogsOptions{
+	latest := containers[0]
+	for _, c := range containers[1:] {
+		if c.Created > latest.Created {
+			latest = c
+		}
+	}
+
+	raw, err := s.client.ContainerLogs(ctx, latest.ID, container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     true,
 		Tail:       fmt.Sprintf("%d", tail),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("docker: logs for container %s: %w", containers[0].ID, err)
+		return nil, fmt.Errorf("docker: logs for container %s: %w", latest.ID, err)
 	}
 
 	// Docker logs are multiplexed (8-byte header per frame). Demultiplex

--- a/api/internal/docker/logs_test.go
+++ b/api/internal/docker/logs_test.go
@@ -1,0 +1,86 @@
+package docker
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+)
+
+type mockClient struct {
+	containers []dockertypes.Container
+	listErr    error
+	logsErr    error
+
+	listOptions   container.ListOptions
+	logsContainer string
+	logsOptions   container.LogsOptions
+}
+
+func (m *mockClient) ContainerList(_ context.Context, options container.ListOptions) ([]dockertypes.Container, error) {
+	m.listOptions = options
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.containers, nil
+}
+
+func (m *mockClient) ContainerLogs(_ context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error) {
+	m.logsContainer = containerID
+	m.logsOptions = options
+	if m.logsErr != nil {
+		return nil, m.logsErr
+	}
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func TestStreamLogs_UsesNewestContainerIncludingStopped(t *testing.T) {
+	m := &mockClient{
+		containers: []dockertypes.Container{
+			{ID: "old", Created: 100},
+			{ID: "new", Created: 200},
+		},
+	}
+
+	streamer := New(m)
+	rc, err := streamer.StreamLogs(context.Background(), "dep-1", 100)
+	if err != nil {
+		t.Fatalf("StreamLogs: %v", err)
+	}
+	if rc == nil {
+		t.Fatal("want non-nil log stream")
+	}
+	rc.Close()
+
+	if !m.listOptions.All {
+		t.Fatal("want container list to include stopped containers")
+	}
+	if m.logsContainer != "new" {
+		t.Fatalf("want logs from newest container 'new', got %q", m.logsContainer)
+	}
+	if !m.logsOptions.Follow {
+		t.Fatal("want Follow=true")
+	}
+	if m.logsOptions.Tail != "100" {
+		t.Fatalf("want Tail=100, got %q", m.logsOptions.Tail)
+	}
+}
+
+func TestStreamLogs_NoContainers(t *testing.T) {
+	m := &mockClient{}
+	streamer := New(m)
+
+	rc, err := streamer.StreamLogs(context.Background(), "dep-1", 100)
+	if err != nil {
+		t.Fatalf("StreamLogs: %v", err)
+	}
+	if rc != nil {
+		t.Fatal("want nil stream when deployment has no containers")
+	}
+	if m.logsContainer != "" {
+		t.Fatal("did not expect ContainerLogs call")
+	}
+}

--- a/dashboard/src/deployments/DeploymentLogsPanel.test.tsx
+++ b/dashboard/src/deployments/DeploymentLogsPanel.test.tsx
@@ -23,7 +23,7 @@ describe('DeploymentLogsPanel', () => {
   })
 
   it('renders incoming SSE lines and closes stream on unmount', () => {
-    const { unmount } = render(<DeploymentLogsPanel deploymentId="dep-1" />)
+    const { unmount } = render(<DeploymentLogsPanel deploymentId="dep-1" status="healthy" />)
 
     expect(screen.getByText('Waiting for log output...')).toBeInTheDocument()
     expect(MockEventSource.instances[0]?.url).toBe('/api/deployments/dep-1/logs')
@@ -42,5 +42,13 @@ describe('DeploymentLogsPanel', () => {
 
     unmount()
     expect(MockEventSource.instances[0]?.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows failed empty state when no lines are available', () => {
+    render(<DeploymentLogsPanel deploymentId="dep-2" status="failed" error="container exited with code 1" />)
+
+    expect(screen.getByText(/No container logs were captured/)).toHaveTextContent(
+      'No container logs were captured for this failed deployment. Last error: container exited with code 1',
+    )
   })
 })

--- a/dashboard/src/deployments/DeploymentLogsPanel.tsx
+++ b/dashboard/src/deployments/DeploymentLogsPanel.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useRef } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+import type { DeploymentStatus } from '../lib/api'
 import { useDeploymentLogsSSE } from './useDeploymentLogsSSE'
 
 type Props = {
   deploymentId: string
+  status: DeploymentStatus
+  error?: string
 }
 
-export function DeploymentLogsPanel({ deploymentId }: Props) {
+export function DeploymentLogsPanel({ deploymentId, status, error }: Props) {
   const { lines } = useDeploymentLogsSSE(deploymentId)
   const logContainerRef = useRef<HTMLPreElement | null>(null)
+
+  const emptyState =
+    status === 'failed'
+      ? `No container logs were captured for this failed deployment.${error ? ` Last error: ${error}` : ''}`
+      : 'Waiting for log output...'
 
   useEffect(() => {
     if (!logContainerRef.current) return
@@ -26,7 +34,7 @@ export function DeploymentLogsPanel({ deploymentId }: Props) {
           ref={logContainerRef}
           className="h-80 overflow-y-auto rounded-lg border bg-muted/30 p-4 font-mono text-xs leading-5 text-foreground"
         >
-          {lines.length ? lines.join('\n') : 'Waiting for log output...'}
+          {lines.length ? lines.join('\n') : emptyState}
         </pre>
       </CardContent>
     </Card>

--- a/dashboard/src/deployments/DeploymentRow.tsx
+++ b/dashboard/src/deployments/DeploymentRow.tsx
@@ -13,6 +13,8 @@ type Props = {
 }
 
 export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: Props) {
+  const detailsLabel = d.status === 'failed' ? 'Investigate' : 'Details'
+
   return (
     <TableRow className="bg-card">
       <TableCell className="py-3 font-medium text-foreground">
@@ -33,7 +35,7 @@ export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: P
         <div className="flex items-center justify-end gap-1">
           <Button asChild variant="ghost" size="sm" className="h-7 px-2 text-xs">
             <Link to="/deployments/$deploymentId" params={{ deploymentId: d.id }}>
-              Details
+              {detailsLabel}
             </Link>
           </Button>
           <Button

--- a/dashboard/src/pages/DeploymentDetailPage.tsx
+++ b/dashboard/src/pages/DeploymentDetailPage.tsx
@@ -123,7 +123,7 @@ export function DeploymentDetailPage() {
         </CardContent>
       </Card>
 
-      <DeploymentLogsPanel deploymentId={deployment.id} />
+      <DeploymentLogsPanel deploymentId={deployment.id} status={deployment.status} error={deployment.error} />
     </div>
   )
 }

--- a/orchestrator/internal/apiclient/client.go
+++ b/orchestrator/internal/apiclient/client.go
@@ -47,10 +47,11 @@ func New(baseURL string) *Client {
 
 // NotifyStatus calls PATCH /api/deployments/{id}/status so the API's event
 // broker emits an SSE event to all connected clients.
-func (c *Client) NotifyStatus(id string, status store.Status) error {
+func (c *Client) NotifyStatus(id string, status store.Status, errorMessage string) error {
 	body, err := json.Marshal(struct {
 		Status store.Status `json:"status"`
-	}{Status: status})
+		Error  string       `json:"error,omitempty"`
+	}{Status: status, Error: errorMessage})
 	if err != nil {
 		return fmt.Errorf("apiclient: marshal body: %w", err)
 	}

--- a/orchestrator/internal/apiclient/client_test.go
+++ b/orchestrator/internal/apiclient/client_test.go
@@ -127,12 +127,50 @@ func TestClient_NotifyStatus(t *testing.T) {
 		if r.URL.Path != "/api/deployments/d1/status" {
 			t.Fatalf("want path /api/deployments/d1/status, got %s", r.URL.Path)
 		}
+		var body struct {
+			Status store.Status `json:"status"`
+			Error  string       `json:"error"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Status != store.StatusHealthy {
+			t.Fatalf("want healthy status, got %s", body.Status)
+		}
+		if body.Error != "" {
+			t.Fatalf("want empty error, got %q", body.Error)
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyStatus("d1", store.StatusHealthy); err != nil {
+	if err := client.NotifyStatus("d1", store.StatusHealthy, ""); err != nil {
+		t.Fatalf("NotifyStatus: %v", err)
+	}
+}
+
+func TestClient_NotifyStatus_WithError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Status store.Status `json:"status"`
+			Error  string       `json:"error"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Status != store.StatusFailed {
+			t.Fatalf("want failed status, got %s", body.Status)
+		}
+		if body.Error == "" {
+			t.Fatal("want failure error message")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL)
+	if err := client.NotifyStatus("d1", store.StatusFailed, "image not found"); err != nil {
 		t.Fatalf("NotifyStatus: %v", err)
 	}
 }

--- a/orchestrator/internal/reconciler/reconciler.go
+++ b/orchestrator/internal/reconciler/reconciler.go
@@ -21,13 +21,12 @@ type Docker interface {
 type Store interface {
 	List() ([]store.Deployment, error)
 	Patch(id string, patch store.Deployment) (store.Deployment, error)
-	UpdateStatus(id string, status store.Status) error
 }
 
 // Notifier notifies the API of deployment status transitions so the event
 // broker can push real-time updates to SSE subscribers.
 type Notifier interface {
-	NotifyStatus(id string, status store.Status) error
+	NotifyStatus(id string, status store.Status, errorMessage string) error
 }
 
 // Reconciler syncs the desired state in the store with actual Docker containers.
@@ -79,7 +78,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 				runtimePorts, err := r.docker.Start(ctx, d)
 				if err != nil {
 					log.Printf("reconciler: start %s (%s): %v", d.ID, d.Name, err)
-					r.updateStatus(d.ID, store.StatusFailed)
+					r.updateStatus(d.ID, store.StatusFailed, err.Error())
 				} else {
 					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy)
 				}
@@ -88,17 +87,17 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 				runtimePorts, err := r.docker.StartAndReplace(ctx, d, c.ID)
 				if err != nil {
 					log.Printf("reconciler: redeploy %s (%s): %v", d.ID, d.Name, err)
-					r.updateStatus(d.ID, store.StatusFailed)
+					r.updateStatus(d.ID, store.StatusFailed, err.Error())
 				} else {
 					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy)
 				}
 			} else {
-				r.updateStatus(d.ID, store.StatusFailed)
+				r.updateStatus(d.ID, store.StatusFailed, "container is not running")
 			}
 
 		case store.StatusHealthy:
 			if !hasContainer || !c.Running {
-				r.updateStatus(d.ID, store.StatusFailed)
+				r.updateStatus(d.ID, store.StatusFailed, "container is not running")
 			}
 
 		case store.StatusFailed, store.StatusIdle:
@@ -118,27 +117,27 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	return nil
 }
 
-func (r *Reconciler) updateStatus(id string, status store.Status) {
-	if err := r.store.UpdateStatus(id, status); err != nil {
+func (r *Reconciler) updateStatus(id string, status store.Status, errorMessage string) {
+	if _, err := r.store.Patch(id, store.Deployment{Status: status, Error: errorMessage}); err != nil {
 		log.Printf("reconciler: update status %s → %s: %v", id, status, err)
 	}
-	r.notifyStatus(id, status)
+	r.notifyStatus(id, status, errorMessage)
 }
 
 func (r *Reconciler) updatePortsAndStatus(id string, ports []string, status store.Status) {
-	patch := store.Deployment{Status: status}
+	patch := store.Deployment{Status: status, Error: ""}
 	if ports != nil {
 		patch.Ports = ports
 	}
 	if _, err := r.store.Patch(id, patch); err != nil {
 		log.Printf("reconciler: patch deployment %s: %v", id, err)
 	}
-	r.notifyStatus(id, status)
+	r.notifyStatus(id, status, "")
 }
 
-func (r *Reconciler) notifyStatus(id string, status store.Status) {
+func (r *Reconciler) notifyStatus(id string, status store.Status, errorMessage string) {
 	if r.notifier != nil {
-		if err := r.notifier.NotifyStatus(id, status); err != nil {
+		if err := r.notifier.NotifyStatus(id, status, errorMessage); err != nil {
 			log.Printf("reconciler: notify api status %s → %s: %v", id, status, err)
 		}
 	}

--- a/orchestrator/internal/reconciler/reconciler_test.go
+++ b/orchestrator/internal/reconciler/reconciler_test.go
@@ -21,12 +21,13 @@ type mockNotifier struct {
 type notifyCall struct {
 	id     string
 	status store.Status
+	error  string
 }
 
-func (m *mockNotifier) NotifyStatus(id string, status store.Status) error {
+func (m *mockNotifier) NotifyStatus(id string, status store.Status, errorMessage string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.calls = append(m.calls, notifyCall{id: id, status: status})
+	m.calls = append(m.calls, notifyCall{id: id, status: status, error: errorMessage})
 	return m.notifyErr
 }
 
@@ -410,6 +411,9 @@ func TestReconcile_DeployingStartFails_NotifiesFailed(t *testing.T) {
 	calls := n.getCalls()
 	if len(calls) != 1 || calls[0].id != "d1" || calls[0].status != store.StatusFailed {
 		t.Errorf("want notify(d1, failed), got %v", calls)
+	}
+	if calls[0].error == "" {
+		t.Error("want notify call to include failure reason")
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -36,6 +36,7 @@ type Deployment struct {
 	Volumes []string          `json:"volumes"`
 	Domain  string            `json:"domain"`
 	Status  Status            `json:"status"`
+	Error   string            `json:"error,omitempty"`
 }
 
 // JSONStore persists deployments as a JSON array on disk.
@@ -245,7 +246,7 @@ func (s *JSONStore) Update(d Deployment) (Deployment, error) {
 }
 
 // Patch merges the non-zero fields of patch into the stored deployment and persists atomically.
-// Only image, envs, ports, volumes, domain, and status are merged; id and name are immutable.
+// Only image, envs, ports, volumes, domain, status, and error are merged; id and name are immutable.
 // Returns ErrNotFound if no deployment with that ID exists.
 func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
 	var result Deployment
@@ -275,6 +276,9 @@ func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
 		}
 		if patch.Status != "" {
 			d.Status = patch.Status
+			d.Error = patch.Error
+		} else if patch.Error != "" {
+			d.Error = patch.Error
 		}
 		data[id] = d
 		if err := s.persist(data); err != nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -378,3 +378,28 @@ func TestJSONStore_UpdateStatus_MissingID_NoOp(t *testing.T) {
 		t.Errorf("want nil for missing id, got %v", err)
 	}
 }
+
+func TestJSONStore_Patch_StatusClearsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deployments.json")
+	s, err := store.NewJSONStore(path)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	_, err = s.Create(store.Deployment{ID: "d1", Name: "web", Status: store.StatusFailed, Error: "image not found"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	updated, err := s.Patch("d1", store.Deployment{Status: store.StatusHealthy})
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	if updated.Status != store.StatusHealthy {
+		t.Fatalf("want status healthy, got %s", updated.Status)
+	}
+	if updated.Error != "" {
+		t.Fatalf("want error cleared, got %q", updated.Error)
+	}
+}


### PR DESCRIPTION
## Summary
- persist deployment failure reasons from orchestrator to store/api so failed statuses include actionable error context even when Docker emits no logs
- improve log streaming to read from the newest managed container (including exited containers), making failed startup logs available after container exit
- update deployment detail UI to guide investigation with an explicit failed empty-log state and clearer failed-row action labeling

## Testing
- go test ./internal/docker ./internal/api (api)
- go test ./internal/reconciler ./internal/apiclient (orchestrator)
- go test ./... (store)
- bunx vitest --run (dashboard)