### PR TITLE
feat(orchestrator): surface container exit diagnostics on dashboard

### DIFF
--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -24,12 +24,21 @@ import (
 // ErrDockerUnavailable is returned when the Docker daemon cannot be reached.
 var ErrDockerUnavailable = errors.New("docker daemon unreachable")
 
-// ManagedContainer represents a running container managed by Dirigent.
+// ExitDetails captures why a stopped container exited.
+// It is nil for containers that are currently running.
+type ExitDetails struct {
+	ExitCode  int
+	OOMKilled bool
+	Error     string
+}
+
+// ManagedContainer represents a container managed by Dirigent.
 type ManagedContainer struct {
 	ID           string
 	Name         string
 	DeploymentID string
 	Running      bool
+	ExitDetails  *ExitDetails // nil when running
 }
 
 // Client is the Docker API surface required by the orchestrator.
@@ -147,12 +156,22 @@ func (d *Docker) ListManagedContainers(ctx context.Context) ([]ManagedContainer,
 		if len(c.Names) > 0 {
 			name = c.Names[0]
 		}
-		result = append(result, ManagedContainer{
+		mc := ManagedContainer{
 			ID:           c.ID,
 			Name:         name,
 			DeploymentID: c.Labels["dirigent.id"],
 			Running:      c.State == "running",
-		})
+		}
+		if !mc.Running {
+			if inspect, err := d.client.ContainerInspect(ctx, c.ID); err == nil && inspect.State != nil {
+				mc.ExitDetails = &ExitDetails{
+					ExitCode:  inspect.State.ExitCode,
+					OOMKilled: inspect.State.OOMKilled,
+					Error:     inspect.State.Error,
+				}
+			}
+		}
+		result = append(result, mc)
 	}
 
 	return result, nil

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -191,6 +191,66 @@ func TestDocker_ListManagedContainers(t *testing.T) {
 	}
 }
 
+func TestDocker_ListManagedContainers_OOMKilled_PopulatesExitDetails(t *testing.T) {
+	mock := &mockClient{
+		listContainers: []dockertypes.Container{
+			{
+				ID:     "c1",
+				Names:  []string{"/web"},
+				State:  "exited",
+				Labels: map[string]string{"dirigent.managed": "true", "dirigent.id": "d1"},
+			},
+		},
+		inspectContainer: inspectWithState(137, true, ""),
+	}
+	d := docker.New(mock)
+	containers, err := d.ListManagedContainers(context.Background())
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if len(containers) != 1 {
+		t.Fatalf("want 1 container, got %d", len(containers))
+	}
+	c := containers[0]
+	if c.Running {
+		t.Error("want running=false")
+	}
+	if c.ExitDetails == nil {
+		t.Fatal("want ExitDetails populated, got nil")
+	}
+	if !c.ExitDetails.OOMKilled {
+		t.Error("want OOMKilled=true")
+	}
+	if c.ExitDetails.ExitCode != 137 {
+		t.Errorf("want exit code 137, got %d", c.ExitDetails.ExitCode)
+	}
+}
+
+func TestDocker_ListManagedContainers_InspectFails_ExitDetailsNil(t *testing.T) {
+	mock := &mockClient{
+		listContainers: []dockertypes.Container{
+			{
+				ID:     "c1",
+				Names:  []string{"/web"},
+				State:  "exited",
+				Labels: map[string]string{"dirigent.managed": "true", "dirigent.id": "d1"},
+			},
+		},
+		inspectErr: errors.New("inspect failed"),
+	}
+	d := docker.New(mock)
+	containers, err := d.ListManagedContainers(context.Background())
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if len(containers) != 1 {
+		t.Fatalf("want 1 container, got %d", len(containers))
+	}
+	if containers[0].ExitDetails != nil {
+		t.Errorf("want ExitDetails nil on inspect failure, got %+v", containers[0].ExitDetails)
+	}
+}
+
 func TestDocker_StopAndRemove(t *testing.T) {
 	mock := &mockClient{}
 	d := docker.New(mock)
@@ -296,6 +356,18 @@ var _ interface {
 
 // Ensure filters package is referenced (avoids unused import if linter checks).
 var _ = filters.NewArgs
+
+func inspectWithState(exitCode int, oomKilled bool, errMsg string) dockertypes.ContainerJSON {
+	return dockertypes.ContainerJSON{
+		ContainerJSONBase: &dockertypes.ContainerJSONBase{
+			State: &dockertypes.ContainerState{
+				ExitCode:  exitCode,
+				OOMKilled: oomKilled,
+				Error:     errMsg,
+			},
+		},
+	}
+}
 
 func inspectWithPort(containerPort, hostPort string) dockertypes.ContainerJSON {
 	return dockertypes.ContainerJSON{

--- a/orchestrator/internal/reconciler/reconciler.go
+++ b/orchestrator/internal/reconciler/reconciler.go
@@ -92,12 +92,12 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy)
 				}
 			} else {
-				r.updateStatus(d.ID, store.StatusFailed, "container is not running")
+				r.updateStatus(d.ID, store.StatusFailed, exitMessage(c.ExitDetails))
 			}
 
 		case store.StatusHealthy:
 			if !hasContainer || !c.Running {
-				r.updateStatus(d.ID, store.StatusFailed, "container is not running")
+				r.updateStatus(d.ID, store.StatusFailed, exitMessage(c.ExitDetails))
 			}
 
 		case store.StatusFailed, store.StatusIdle:
@@ -115,6 +115,24 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// exitMessage produces a human-readable failure reason from container exit details.
+// When d is nil (inspect failed or container missing) the generic fallback is returned.
+func exitMessage(d *docker.ExitDetails) string {
+	if d == nil {
+		return "container is not running"
+	}
+	if d.OOMKilled {
+		return fmt.Sprintf("container killed: out of memory (exit code %d)", d.ExitCode)
+	}
+	if d.Error != "" {
+		return fmt.Sprintf("container exited with error: %s (exit code %d)", d.Error, d.ExitCode)
+	}
+	if d.ExitCode == 0 {
+		return fmt.Sprintf("container exited cleanly (exit code %d)", d.ExitCode)
+	}
+	return fmt.Sprintf("container exited unexpectedly (exit code %d)", d.ExitCode)
 }
 
 func (r *Reconciler) updateStatus(id string, status store.Status, errorMessage string) {

--- a/orchestrator/internal/reconciler/reconciler_test.go
+++ b/orchestrator/internal/reconciler/reconciler_test.go
@@ -437,6 +437,86 @@ func TestReconcile_HealthyContainerGone_NotifiesFailed(t *testing.T) {
 	}
 }
 
+func TestReconcile_DeployingWithStoppedContainer_OOMKilled_ShowsOOMMessage(t *testing.T) {
+	s := &mockStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Name: "web", Status: store.StatusDeploying},
+		},
+	}
+	d := &mockDocker{
+		containers: []docker.ManagedContainer{
+			{ID: "c1", DeploymentID: "d1", Running: false, ExitDetails: &docker.ExitDetails{ExitCode: 137, OOMKilled: true}},
+		},
+	}
+	n := &mockNotifier{}
+	r := reconciler.New(s, d, n)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	calls := n.getCalls()
+	if len(calls) != 1 || calls[0].status != store.StatusFailed {
+		t.Fatalf("want one failed notification, got %v", calls)
+	}
+	want := "container killed: out of memory (exit code 137)"
+	if calls[0].error != want {
+		t.Errorf("want error %q, got %q", want, calls[0].error)
+	}
+}
+
+func TestReconcile_DeployingWithStoppedContainer_NonZeroExit_ShowsExitMessage(t *testing.T) {
+	s := &mockStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Name: "web", Status: store.StatusDeploying},
+		},
+	}
+	d := &mockDocker{
+		containers: []docker.ManagedContainer{
+			{ID: "c1", DeploymentID: "d1", Running: false, ExitDetails: &docker.ExitDetails{ExitCode: 1}},
+		},
+	}
+	n := &mockNotifier{}
+	r := reconciler.New(s, d, n)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	calls := n.getCalls()
+	if len(calls) != 1 || calls[0].status != store.StatusFailed {
+		t.Fatalf("want one failed notification, got %v", calls)
+	}
+	want := "container exited unexpectedly (exit code 1)"
+	if calls[0].error != want {
+		t.Errorf("want error %q, got %q", want, calls[0].error)
+	}
+}
+
+func TestReconcile_HealthyContainerMissing_ShowsFallbackMessage(t *testing.T) {
+	s := &mockStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Name: "web", Status: store.StatusHealthy},
+		},
+	}
+	d := &mockDocker{} // no containers
+	n := &mockNotifier{}
+	r := reconciler.New(s, d, n)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	calls := n.getCalls()
+	if len(calls) != 1 || calls[0].status != store.StatusFailed {
+		t.Fatalf("want one failed notification, got %v", calls)
+	}
+	want := "container is not running"
+	if calls[0].error != want {
+		t.Errorf("want error %q, got %q", want, calls[0].error)
+	}
+}
+
 func TestReconcile_NotifyAPIFailure_DoesNotCrash(t *testing.T) {
 	s := &mockStore{
 		deployments: []store.Deployment{


### PR DESCRIPTION
## Summary

- Adds `ExitDetails` struct (`ExitCode`, `OOMKilled`, `Error`) to `ManagedContainer`; populated via `ContainerInspect` for stopped containers only — zero overhead for healthy deployments
- Adds `exitMessage(*docker.ExitDetails) string` helper in the reconciler that replaces both hardcoded `"container is not running"` strings with meaningful, human-readable messages
- No API or schema changes — the existing `error` field pipeline carries the new messages to the dashboard automatically

## Error message examples

| Scenario | Dashboard shows |
|---|---|
| OOM kill (exit 137) | `container killed: out of memory (exit code 137)` |
| Non-zero crash (exit 1) | `container exited unexpectedly (exit code 1)` |
| Docker error string set | `container exited with error: signal: killed (exit code 137)` |
| Clean exit (exit 0) | `container exited cleanly (exit code 0)` |
| Inspect failed / missing | `container is not running` (existing behaviour preserved) |

## Test plan

- [x] `docker_test.go`: OOM-killed stopped container populates `ExitDetails`; inspect failure leaves `ExitDetails` nil
- [x] `reconciler_test.go`: OOM kill message, non-zero exit message, missing container fallback message
- [x] All existing tests pass

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)