### PR TITLE
feat(system-status): add per-service check breakdown and load balancer health

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ setup:
 dev:
 	@trap 'kill 0' SIGINT; \
 	(cd api && DIRIGENT_DATA=/tmp/dirigent.json $(AIR)) & \
-	(cd orchestrator && DIRIGENT_DATA=/tmp/dirigent.json $(AIR)) & \
+	(cd orchestrator && DIRIGENT_DATA=/tmp/dirigent.json DIRIGENT_PROXY_HEALTH_URL=http://localhost:8090/internal/health $(AIR)) & \
 	(cd proxy && DIRIGENT_DATA=/tmp/dirigent.json DIRIGENT_PROXY_ADDR=:8090 $(AIR)) & \
 	(cd dashboard && bun run dev) & \
 	wait

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -69,6 +69,7 @@ type Handler struct {
 	statusSource SystemStatusProvider
 	heartbeats   OrchestratorHeartbeatIngestor
 	docker       DockerConnectivityIngestor
+	loadBalancer LoadBalancerHealthIngestor
 	cpu          CPUUtilizationIngestor
 	ram          RAMUtilizationIngestor
 }
@@ -84,15 +85,27 @@ func New(s Store, eb EventBus, dl DockerLogs) *Handler {
 // If statusSource is nil, a default provider is used.
 func NewWithSystemStatus(s Store, eb EventBus, dl DockerLogs, statusSource SystemStatusProvider) *Handler {
 	if statusSource == nil {
-		statusSource = newDefaultSystemStatusProvider(time.Now, orchestratorStaleAfterFromEnv())
+		statusSource = newDefaultSystemStatusProvider(time.Now, orchestratorStaleAfterFromEnv(), buildAPIStoreChecker(s))
 	}
 
 	heartbeatIngestor, _ := statusSource.(OrchestratorHeartbeatIngestor)
 	dockerIngestor, _ := statusSource.(DockerConnectivityIngestor)
+	loadBalancerIngestor, _ := statusSource.(LoadBalancerHealthIngestor)
 	cpuIngestor, _ := statusSource.(CPUUtilizationIngestor)
 	ramIngestor, _ := statusSource.(RAMUtilizationIngestor)
 
-	return &Handler{store: s, events: eb, dockerLogs: dl, statusSource: statusSource, heartbeats: heartbeatIngestor, docker: dockerIngestor, cpu: cpuIngestor, ram: ramIngestor}
+	return &Handler{store: s, events: eb, dockerLogs: dl, statusSource: statusSource, heartbeats: heartbeatIngestor, docker: dockerIngestor, loadBalancer: loadBalancerIngestor, cpu: cpuIngestor, ram: ramIngestor}
+}
+
+func buildAPIStoreChecker(s Store) func(context.Context) bool {
+	if s == nil {
+		return nil
+	}
+
+	return func(_ context.Context) bool {
+		_, err := s.List()
+		return err == nil
+	}
 }
 
 // RegisterRoutes wires all deployment endpoints into mux.
@@ -119,11 +132,18 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
 
 	var body struct {
-		At     *time.Time `json:"at"`
+		At           *time.Time `json:"at"`
+		Orchestrator *struct {
+			StoreAccessible *bool `json:"storeAccessible"`
+		} `json:"orchestrator"`
 		Docker *struct {
 			Reachable *bool      `json:"reachable"`
 			CheckedAt *time.Time `json:"checkedAt"`
 		} `json:"docker"`
+		LoadBalancer *struct {
+			Responding *bool      `json:"responding"`
+			CheckedAt  *time.Time `json:"checkedAt"`
+		} `json:"loadBalancer"`
 		Host *struct {
 			CPU *struct {
 				UsagePercent *float64   `json:"usagePercent"`
@@ -146,7 +166,12 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 		heartbeatAt = body.At.UTC()
 	}
 
-	if err := h.heartbeats.RecordOrchestratorHeartbeat(r.Context(), heartbeatAt); err != nil {
+	storeAccessible := true
+	if body.Orchestrator != nil && body.Orchestrator.StoreAccessible != nil {
+		storeAccessible = *body.Orchestrator.StoreAccessible
+	}
+
+	if err := h.heartbeats.RecordOrchestratorHeartbeat(r.Context(), heartbeatAt, storeAccessible); err != nil {
 		http.Error(w, "failed to record heartbeat", http.StatusInternalServerError)
 		return
 	}
@@ -164,6 +189,23 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 
 		if err := h.docker.RecordDockerConnectivity(r.Context(), *body.Docker.Reachable, dockerCheckedAt); err != nil {
 			http.Error(w, "failed to record docker connectivity", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if body.LoadBalancer != nil && body.LoadBalancer.Responding != nil {
+		if h.loadBalancer == nil {
+			http.Error(w, "system status unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		checkedAt := heartbeatAt
+		if body.LoadBalancer.CheckedAt != nil {
+			checkedAt = body.LoadBalancer.CheckedAt.UTC()
+		}
+
+		if err := h.loadBalancer.RecordLoadBalancerHealth(r.Context(), *body.LoadBalancer.Responding, checkedAt); err != nil {
+			http.Error(w, "failed to record load balancer health", http.StatusInternalServerError)
 			return
 		}
 	}

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -258,6 +258,9 @@ func TestSystemStatus_UnavailableOnProviderError(t *testing.T) {
 	if body.Docker.State != api.SystemStatusStateUnavailable {
 		t.Errorf("want docker state unavailable, got %s", body.Docker.State)
 	}
+	if body.LoadBalancer.State != api.SystemStatusStateUnavailable {
+		t.Errorf("want load balancer state unavailable, got %s", body.LoadBalancer.State)
+	}
 	if body.Host.CPU.State != api.SystemStatusStateUnavailable {
 		t.Errorf("want cpu state unavailable, got %s", body.Host.CPU.State)
 	}
@@ -428,6 +431,50 @@ func TestRecordOrchestratorHeartbeat_UpdatesHostMetrics(t *testing.T) {
 	}
 	if body.Host.RAM.LastUpdated.IsZero() {
 		t.Fatal("want non-zero ram lastUpdated")
+	}
+}
+
+func TestRecordOrchestratorHeartbeat_UpdatesLoadBalancerHealth(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	reqBody := `{"loadBalancer":{"responding":false}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString(reqBody))
+	if err != nil {
+		t.Fatalf("POST heartbeat request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/system-status/orchestrator-heartbeat: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", resp.StatusCode)
+	}
+
+	statusResp, err := http.Get(srv.URL + "/api/system-status")
+	if err != nil {
+		t.Fatalf("GET /api/system-status: %v", err)
+	}
+	defer statusResp.Body.Close()
+
+	if statusResp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", statusResp.StatusCode)
+	}
+
+	var body api.SystemStatusSnapshot
+	if err := json.NewDecoder(statusResp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.LoadBalancer.State != api.SystemStatusStateDegraded {
+		t.Fatalf("want load balancer state degraded, got %s", body.LoadBalancer.State)
+	}
+	if body.LoadBalancer.LastUpdated == nil || body.LoadBalancer.LastUpdated.IsZero() {
+		t.Fatal("want non-zero load balancer lastUpdated")
 	}
 }
 

--- a/api/internal/api/system_status.go
+++ b/api/internal/api/system_status.go
@@ -13,26 +13,55 @@ type SystemStatusState string
 const (
 	SystemStatusStateHealthy     SystemStatusState = "healthy"
 	SystemStatusStateDegraded    SystemStatusState = "degraded"
-	SystemStatusStateStale       SystemStatusState = "stale"
 	SystemStatusStateUnavailable SystemStatusState = "unavailable"
 )
 
+type APISystemStatusChecks struct {
+	ProcessRunning     bool `json:"processRunning"`
+	DashboardReachable bool `json:"dashboardReachable"`
+	StoreAccessible    bool `json:"storeAccessible"`
+}
+
 // APISystemStatus carries API availability and freshness information.
 type APISystemStatus struct {
-	State       SystemStatusState `json:"state"`
-	LastUpdated time.Time         `json:"lastUpdated"`
+	State       SystemStatusState     `json:"state"`
+	LastUpdated time.Time             `json:"lastUpdated"`
+	Checks      APISystemStatusChecks `json:"checks"`
+}
+
+type OrchestratorSystemStatusChecks struct {
+	ProcessRunning  bool `json:"processRunning"`
+	DockerReachable bool `json:"dockerReachable"`
+	StoreAccessible bool `json:"storeAccessible"`
 }
 
 // OrchestratorSystemStatus carries orchestrator liveness and freshness information.
 type OrchestratorSystemStatus struct {
-	State       SystemStatusState `json:"state"`
-	LastUpdated *time.Time        `json:"lastUpdated,omitempty"`
+	State       SystemStatusState              `json:"state"`
+	LastUpdated *time.Time                     `json:"lastUpdated,omitempty"`
+	Checks      OrchestratorSystemStatusChecks `json:"checks"`
+}
+
+type LoadBalancerSystemStatusChecks struct {
+	ProcessRunning        bool `json:"processRunning"`
+	HealthcheckResponding bool `json:"healthcheckResponding"`
+}
+
+type LoadBalancerSystemStatus struct {
+	State       SystemStatusState              `json:"state"`
+	LastUpdated *time.Time                     `json:"lastUpdated,omitempty"`
+	Checks      LoadBalancerSystemStatusChecks `json:"checks"`
+}
+
+type DockerSystemStatusChecks struct {
+	DaemonHealthy bool `json:"daemonHealthy"`
 }
 
 // DockerSystemStatus carries Docker connectivity information as observed by the orchestrator.
 type DockerSystemStatus struct {
-	State       SystemStatusState `json:"state"`
-	LastUpdated *time.Time        `json:"lastUpdated,omitempty"`
+	State       SystemStatusState        `json:"state"`
+	LastUpdated *time.Time               `json:"lastUpdated,omitempty"`
+	Checks      DockerSystemStatusChecks `json:"checks"`
 }
 
 // HostMetricSystemStatus carries a host metric signal value and freshness information.
@@ -52,6 +81,7 @@ type HostSystemStatus struct {
 type SystemStatusSnapshot struct {
 	API          APISystemStatus          `json:"api"`
 	Orchestrator OrchestratorSystemStatus `json:"orchestrator"`
+	LoadBalancer LoadBalancerSystemStatus `json:"loadBalancer"`
 	Docker       DockerSystemStatus       `json:"docker"`
 	Host         HostSystemStatus         `json:"host"`
 	Error        string                   `json:"error,omitempty"`
@@ -64,12 +94,16 @@ type SystemStatusProvider interface {
 
 // OrchestratorHeartbeatIngestor accepts orchestrator heartbeat updates.
 type OrchestratorHeartbeatIngestor interface {
-	RecordOrchestratorHeartbeat(ctx context.Context, at time.Time) error
+	RecordOrchestratorHeartbeat(ctx context.Context, at time.Time, storeAccessible bool) error
 }
 
 // DockerConnectivityIngestor accepts Docker connectivity observations.
 type DockerConnectivityIngestor interface {
 	RecordDockerConnectivity(ctx context.Context, reachable bool, at time.Time) error
+}
+
+type LoadBalancerHealthIngestor interface {
+	RecordLoadBalancerHealth(ctx context.Context, responding bool, at time.Time) error
 }
 
 // CPUUtilizationIngestor accepts host CPU utilization observations.
@@ -83,20 +117,35 @@ type RAMUtilizationIngestor interface {
 }
 
 type defaultSystemStatusProvider struct {
-	now              func() time.Time
-	staleAfter       time.Duration
-	lastHeartbeatMu  sync.RWMutex
+	now                func() time.Time
+	staleAfter         time.Duration
+	apiStoreCheck      func(context.Context) bool
+	lastHeartbeatMu    sync.RWMutex
+	orchestratorSignal orchestratorHeartbeatSignal
+	dockerSignalMu     sync.RWMutex
+	dockerSignal       dockerConnectivitySignal
+	loadBalancerMu     sync.RWMutex
+	loadBalancerSignal loadBalancerHealthSignal
+	hostSignalMu       sync.RWMutex
+	cpuSignal          hostMetricSignal
+	ramSignal          hostMetricSignal
+}
+
+type orchestratorHeartbeatSignal struct {
 	lastHeartbeatUTC time.Time
-	dockerSignalMu   sync.RWMutex
-	dockerSignal     dockerConnectivitySignal
-	hostSignalMu     sync.RWMutex
-	cpuSignal        hostMetricSignal
-	ramSignal        hostMetricSignal
+	storeAccessible  bool
+	hasSignal        bool
 }
 
 type dockerConnectivitySignal struct {
 	lastCheckedUTC time.Time
 	reachable      bool
+	hasSignal      bool
+}
+
+type loadBalancerHealthSignal struct {
+	lastCheckedUTC time.Time
+	responding     bool
 	hasSignal      bool
 }
 
@@ -106,19 +155,34 @@ type hostMetricSignal struct {
 	hasSignal      bool
 }
 
-func newDefaultSystemStatusProvider(now func() time.Time, staleAfter time.Duration) SystemStatusProvider {
-	return &defaultSystemStatusProvider{now: now, staleAfter: staleAfter}
+func newDefaultSystemStatusProvider(now func() time.Time, staleAfter time.Duration, apiStoreCheck func(context.Context) bool) SystemStatusProvider {
+	if apiStoreCheck == nil {
+		apiStoreCheck = func(context.Context) bool { return true }
+	}
+
+	return &defaultSystemStatusProvider{now: now, staleAfter: staleAfter, apiStoreCheck: apiStoreCheck}
 }
 
-func (p *defaultSystemStatusProvider) Snapshot(_ context.Context) (SystemStatusSnapshot, error) {
+func (p *defaultSystemStatusProvider) Snapshot(ctx context.Context) (SystemStatusSnapshot, error) {
 	orchestrator := p.orchestratorStatus()
+	storeAccessible := p.apiStoreCheck(ctx)
+	apiState := SystemStatusStateHealthy
+	if !storeAccessible {
+		apiState = SystemStatusStateDegraded
+	}
 
 	return SystemStatusSnapshot{
 		API: APISystemStatus{
-			State:       SystemStatusStateHealthy,
+			State:       apiState,
 			LastUpdated: p.now().UTC(),
+			Checks: APISystemStatusChecks{
+				ProcessRunning:     true,
+				DashboardReachable: true,
+				StoreAccessible:    storeAccessible,
+			},
 		},
 		Orchestrator: orchestrator,
+		LoadBalancer: p.loadBalancerStatus(),
 		Docker:       p.dockerStatus(),
 		Host: HostSystemStatus{
 			CPU: p.cpuStatus(),
@@ -127,13 +191,17 @@ func (p *defaultSystemStatusProvider) Snapshot(_ context.Context) (SystemStatusS
 	}, nil
 }
 
-func (p *defaultSystemStatusProvider) RecordOrchestratorHeartbeat(_ context.Context, at time.Time) error {
+func (p *defaultSystemStatusProvider) RecordOrchestratorHeartbeat(_ context.Context, at time.Time, storeAccessible bool) error {
 	if at.IsZero() {
 		at = p.now()
 	}
 
 	p.lastHeartbeatMu.Lock()
-	p.lastHeartbeatUTC = at.UTC()
+	p.orchestratorSignal = orchestratorHeartbeatSignal{
+		lastHeartbeatUTC: at.UTC(),
+		storeAccessible:  storeAccessible,
+		hasSignal:        true,
+	}
 	p.lastHeartbeatMu.Unlock()
 
 	return nil
@@ -141,31 +209,35 @@ func (p *defaultSystemStatusProvider) RecordOrchestratorHeartbeat(_ context.Cont
 
 func (p *defaultSystemStatusProvider) orchestratorStatus() OrchestratorSystemStatus {
 	p.lastHeartbeatMu.RLock()
-	lastHeartbeat := p.lastHeartbeatUTC
+	signal := p.orchestratorSignal
 	p.lastHeartbeatMu.RUnlock()
 
-	if lastHeartbeat.IsZero() {
+	if !signal.hasSignal {
 		return OrchestratorSystemStatus{State: SystemStatusStateUnavailable}
 	}
+	lastHeartbeat := signal.lastHeartbeatUTC
+
+	dockerState := p.dockerStatus()
+	dockerReachable := dockerState.Checks.DaemonHealthy
 
 	age := p.now().UTC().Sub(lastHeartbeat)
 	if age < 0 {
 		age = 0
 	}
 
-	degradedAfter := p.staleAfter / 2
-	state := SystemStatusStateStale
-
-	switch {
-	case age <= degradedAfter:
-		state = SystemStatusStateHealthy
-	case age <= p.staleAfter:
+	state := SystemStatusStateHealthy
+	if age > p.staleAfter || !signal.storeAccessible || !dockerReachable {
 		state = SystemStatusStateDegraded
 	}
 
 	return OrchestratorSystemStatus{
 		State:       state,
 		LastUpdated: &lastHeartbeat,
+		Checks: OrchestratorSystemStatusChecks{
+			ProcessRunning:  true,
+			DockerReachable: dockerReachable,
+			StoreAccessible: signal.storeAccessible,
+		},
 	}
 }
 
@@ -201,8 +273,9 @@ func (p *defaultSystemStatusProvider) dockerStatus() DockerSystemStatus {
 	checkedAt := signal.lastCheckedUTC
 	if age > p.staleAfter {
 		return DockerSystemStatus{
-			State:       SystemStatusStateStale,
+			State:       SystemStatusStateDegraded,
 			LastUpdated: &checkedAt,
+			Checks:      DockerSystemStatusChecks{DaemonHealthy: false},
 		}
 	}
 
@@ -214,6 +287,53 @@ func (p *defaultSystemStatusProvider) dockerStatus() DockerSystemStatus {
 	return DockerSystemStatus{
 		State:       state,
 		LastUpdated: &checkedAt,
+		Checks:      DockerSystemStatusChecks{DaemonHealthy: signal.reachable},
+	}
+}
+
+func (p *defaultSystemStatusProvider) RecordLoadBalancerHealth(_ context.Context, responding bool, at time.Time) error {
+	if at.IsZero() {
+		at = p.now()
+	}
+
+	p.loadBalancerMu.Lock()
+	p.loadBalancerSignal = loadBalancerHealthSignal{
+		lastCheckedUTC: at.UTC(),
+		responding:     responding,
+		hasSignal:      true,
+	}
+	p.loadBalancerMu.Unlock()
+
+	return nil
+}
+
+func (p *defaultSystemStatusProvider) loadBalancerStatus() LoadBalancerSystemStatus {
+	p.loadBalancerMu.RLock()
+	signal := p.loadBalancerSignal
+	p.loadBalancerMu.RUnlock()
+
+	if !signal.hasSignal {
+		return LoadBalancerSystemStatus{State: SystemStatusStateUnavailable}
+	}
+
+	age := p.now().UTC().Sub(signal.lastCheckedUTC)
+	if age < 0 {
+		age = 0
+	}
+
+	state := SystemStatusStateHealthy
+	if age > p.staleAfter || !signal.responding {
+		state = SystemStatusStateDegraded
+	}
+
+	checkedAt := signal.lastCheckedUTC
+	return LoadBalancerSystemStatus{
+		State:       state,
+		LastUpdated: &checkedAt,
+		Checks: LoadBalancerSystemStatusChecks{
+			ProcessRunning:        true,
+			HealthcheckResponding: signal.responding,
+		},
 	}
 }
 
@@ -259,8 +379,12 @@ func (p *defaultSystemStatusProvider) cpuStatus() HostMetricSystemStatus {
 	}
 
 	cpuCheckedAt := signal.lastCheckedUTC
+	state := SystemStatusStateHealthy
+	if p.now().UTC().Sub(cpuCheckedAt) > p.staleAfter {
+		state = SystemStatusStateDegraded
+	}
 	return HostMetricSystemStatus{
-		State:        SystemStatusStateHealthy,
+		State:        state,
 		UsagePercent: signal.usagePercent,
 		LastUpdated:  &cpuCheckedAt,
 	}
@@ -276,8 +400,12 @@ func (p *defaultSystemStatusProvider) ramStatus() HostMetricSystemStatus {
 	}
 
 	ramCheckedAt := signal.lastCheckedUTC
+	state := SystemStatusStateHealthy
+	if p.now().UTC().Sub(ramCheckedAt) > p.staleAfter {
+		state = SystemStatusStateDegraded
+	}
 	return HostMetricSystemStatus{
-		State:        SystemStatusStateHealthy,
+		State:        state,
 		UsagePercent: signal.usagePercent,
 		LastUpdated:  &ramCheckedAt,
 	}
@@ -292,6 +420,7 @@ func (h *Handler) systemStatus(w http.ResponseWriter, r *http.Request) {
 				LastUpdated: time.Now().UTC(),
 			},
 			Orchestrator: OrchestratorSystemStatus{State: SystemStatusStateUnavailable},
+			LoadBalancer: LoadBalancerSystemStatus{State: SystemStatusStateUnavailable},
 			Docker:       DockerSystemStatus{State: SystemStatusStateUnavailable},
 			Host: HostSystemStatus{
 				CPU: HostMetricSystemStatus{State: SystemStatusStateUnavailable},

--- a/api/internal/api/system_status_test.go
+++ b/api/internal/api/system_status_test.go
@@ -10,7 +10,7 @@ func TestDefaultSystemStatusProvider_OrchestratorStateMapping(t *testing.T) {
 	base := time.Date(2026, time.February, 22, 12, 0, 0, 0, time.UTC)
 	now := base
 
-	provider := newDefaultSystemStatusProvider(func() time.Time { return now }, 10*time.Second)
+	provider := newDefaultSystemStatusProvider(func() time.Time { return now }, 10*time.Second, func(context.Context) bool { return true })
 	ingestor, ok := provider.(OrchestratorHeartbeatIngestor)
 	if !ok {
 		t.Fatal("default provider must implement OrchestratorHeartbeatIngestor")
@@ -45,8 +45,11 @@ func TestDefaultSystemStatusProvider_OrchestratorStateMapping(t *testing.T) {
 		t.Fatalf("want ram unavailable before first signal, got %s", snapshot.Host.RAM.State)
 	}
 
-	if err := ingestor.RecordOrchestratorHeartbeat(context.Background(), base); err != nil {
+	if err := ingestor.RecordOrchestratorHeartbeat(context.Background(), base, true); err != nil {
 		t.Fatalf("RecordOrchestratorHeartbeat: %v", err)
+	}
+	if err := dockerIngestor.RecordDockerConnectivity(context.Background(), true, base); err != nil {
+		t.Fatalf("RecordDockerConnectivity baseline: %v", err)
 	}
 
 	tests := []struct {
@@ -55,10 +58,8 @@ func TestDefaultSystemStatusProvider_OrchestratorStateMapping(t *testing.T) {
 		wantState SystemStatusState
 	}{
 		{name: "healthy at heartbeat time", now: base, wantState: SystemStatusStateHealthy},
-		{name: "healthy at half threshold", now: base.Add(5 * time.Second), wantState: SystemStatusStateHealthy},
-		{name: "degraded after half threshold", now: base.Add(6 * time.Second), wantState: SystemStatusStateDegraded},
-		{name: "degraded at stale threshold", now: base.Add(10 * time.Second), wantState: SystemStatusStateDegraded},
-		{name: "stale after threshold", now: base.Add(11 * time.Second), wantState: SystemStatusStateStale},
+		{name: "healthy at threshold", now: base.Add(10 * time.Second), wantState: SystemStatusStateHealthy},
+		{name: "degraded after stale threshold", now: base.Add(11 * time.Second), wantState: SystemStatusStateDegraded},
 	}
 
 	for _, tc := range tests {
@@ -110,18 +111,17 @@ func TestDefaultSystemStatusProvider_OrchestratorStateMapping(t *testing.T) {
 		t.Fatalf("want docker lastUpdated %s, got %v", base.Add(3*time.Second), snapshot.Docker.LastUpdated)
 	}
 
-	// Advance time past the stale threshold — Docker signal should go stale even if last
-	// signal said reachable, because the orchestrator has stopped reporting.
+	// Advance time past the stale threshold — Docker signal should degrade when old.
 	if err := dockerIngestor.RecordDockerConnectivity(context.Background(), true, base.Add(4*time.Second)); err != nil {
 		t.Fatalf("RecordDockerConnectivity healthy again: %v", err)
 	}
-	now = base.Add(4*time.Second + 10*time.Second + 1) // signal at +4s, staleAfter=10s → stale at +14s+1ns
+	now = base.Add(4*time.Second + 10*time.Second + 1)
 	snapshot, err = provider.Snapshot(context.Background())
 	if err != nil {
-		t.Fatalf("Snapshot after stale docker signal: %v", err)
+		t.Fatalf("Snapshot after degraded docker signal: %v", err)
 	}
-	if snapshot.Docker.State != SystemStatusStateStale {
-		t.Fatalf("want docker state stale when signal is old, got %s", snapshot.Docker.State)
+	if snapshot.Docker.State != SystemStatusStateDegraded {
+		t.Fatalf("want docker state degraded when signal is old, got %s", snapshot.Docker.State)
 	}
 	now = base // reset for subsequent assertions
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -22,21 +22,43 @@ export type DeploymentLogEvent = {
   line: string
 }
 
-export type SystemStatusState = 'healthy' | 'degraded' | 'stale' | 'unavailable'
+export type SystemStatusState = 'healthy' | 'degraded' | 'unavailable'
 
 export type APISystemStatus = {
   state: SystemStatusState
   lastUpdated: string
+  checks?: {
+    processRunning: boolean
+    dashboardReachable: boolean
+    storeAccessible: boolean
+  }
 }
 
 export type OrchestratorSystemStatus = {
   state: SystemStatusState
   lastUpdated?: string
+  checks?: {
+    processRunning: boolean
+    dockerReachable: boolean
+    storeAccessible: boolean
+  }
+}
+
+export type LoadBalancerSystemStatus = {
+  state: SystemStatusState
+  lastUpdated?: string
+  checks?: {
+    processRunning: boolean
+    healthcheckResponding: boolean
+  }
 }
 
 export type DockerSystemStatus = {
   state: SystemStatusState
   lastUpdated?: string
+  checks?: {
+    daemonHealthy: boolean
+  }
 }
 
 export type HostMetricSystemStatus = {
@@ -53,6 +75,7 @@ export type HostSystemStatus = {
 export type SystemStatusSnapshot = {
   api: APISystemStatus
   orchestrator: OrchestratorSystemStatus
+  loadBalancer: LoadBalancerSystemStatus
   docker: DockerSystemStatus
   host: HostSystemStatus
   error?: string

--- a/dashboard/src/system-status/SystemStatusPanel.test.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.test.tsx
@@ -35,14 +35,35 @@ describe('SystemStatusPanel', () => {
       api: {
         state: 'healthy',
         lastUpdated,
+        checks: {
+          processRunning: true,
+          dashboardReachable: true,
+          storeAccessible: true,
+        },
       },
       orchestrator: {
         state: 'healthy',
         lastUpdated,
+        checks: {
+          processRunning: true,
+          dockerReachable: true,
+          storeAccessible: true,
+        },
+      },
+      loadBalancer: {
+        state: 'healthy',
+        lastUpdated,
+        checks: {
+          processRunning: true,
+          healthcheckResponding: true,
+        },
       },
       docker: {
         state: 'healthy',
         lastUpdated,
+        checks: {
+          daemonHealthy: true,
+        },
       },
       host: {
         cpu: {
@@ -60,25 +81,31 @@ describe('SystemStatusPanel', () => {
 
     renderWithQuery(<SystemStatusPanel />)
 
-    await waitFor(() => expect(screen.getAllByText('healthy')).toHaveLength(3))
+    await waitFor(() => expect(screen.getAllByText('healthy')).toHaveLength(4))
     expect(screen.getByText('API signal')).toBeInTheDocument()
     expect(screen.getByText('Orchestrator')).toBeInTheDocument()
     expect(screen.getByText('Docker connectivity')).toBeInTheDocument()
+    expect(screen.getByText('Load balancer')).toBeInTheDocument()
     expect(screen.getByText('Services')).toBeInTheDocument()
     expect(screen.getByText('Host metrics')).toBeInTheDocument()
     expect(screen.getByText('CPU usage')).toBeInTheDocument()
     expect(screen.getByText('RAM usage')).toBeInTheDocument()
     expect(screen.getByText(/Last heartbeat:/)).toBeInTheDocument()
-    expect(screen.getByText(/Last checked:/)).toBeInTheDocument()
+    expect(screen.getAllByText(/Last checked:/)).toHaveLength(2)
     expect(screen.getByText(/Freshness:/)).toBeInTheDocument()
     expect(screen.getByText('Docker is reachable from orchestrator')).toBeInTheDocument()
     expect(screen.getAllByText('healthy pressure')).toHaveLength(2)
     expect(screen.getByTestId('api-status-icon')).toBeInTheDocument()
     expect(screen.getByTestId('orchestrator-status-icon')).toBeInTheDocument()
     expect(screen.getByTestId('docker-status-icon')).toBeInTheDocument()
+    expect(screen.getByTestId('load-balancer-status-icon')).toBeInTheDocument()
     expect(screen.getByText('Reading: 31.2%')).toBeInTheDocument()
     expect(screen.getByText('Reading: 45.8%')).toBeInTheDocument()
-    expect(screen.getAllByText(new RegExp(new Date(lastUpdated).toLocaleString()), { selector: 'p' })).toHaveLength(5)
+    expect(screen.getAllByText('Checks')).toHaveLength(4)
+    expect(screen.getByTestId('api-check-0-pass')).toBeInTheDocument()
+    expect(screen.getByTestId('docker-check-0-pass')).toBeInTheDocument()
+    expect(screen.getByTestId('load-balancer-check-1-pass')).toBeInTheDocument()
+    expect(screen.getAllByText(new RegExp(new Date(lastUpdated).toLocaleString()), { selector: 'p' })).toHaveLength(6)
   })
 
   it('renders degraded orchestrator and docker states', async () => {
@@ -88,14 +115,35 @@ describe('SystemStatusPanel', () => {
       api: {
         state: 'healthy',
         lastUpdated: apiUpdated,
+        checks: {
+          processRunning: true,
+          dashboardReachable: true,
+          storeAccessible: true,
+        },
       },
       orchestrator: {
         state: 'degraded',
         lastUpdated: orchestratorUpdated,
+        checks: {
+          processRunning: true,
+          dockerReachable: false,
+          storeAccessible: false,
+        },
+      },
+      loadBalancer: {
+        state: 'degraded',
+        lastUpdated: orchestratorUpdated,
+        checks: {
+          processRunning: true,
+          healthcheckResponding: false,
+        },
       },
       docker: {
         state: 'degraded',
         lastUpdated: orchestratorUpdated,
+        checks: {
+          daemonHealthy: false,
+        },
       },
       host: {
         cpu: {
@@ -113,23 +161,29 @@ describe('SystemStatusPanel', () => {
 
     renderWithQuery(<SystemStatusPanel />)
 
-    await waitFor(() => expect(screen.getAllByText('degraded')).toHaveLength(2))
+    await waitFor(() => expect(screen.getAllByText('degraded')).toHaveLength(3))
     expect(screen.getByText('Docker check failed at last probe')).toBeInTheDocument()
+    expect(screen.getByText('Load balancer healthcheck failed at last probe')).toBeInTheDocument()
+    expect(screen.getByTestId('orchestrator-check-1-fail')).toBeInTheDocument()
+    expect(screen.getByTestId('orchestrator-check-2-fail')).toBeInTheDocument()
+    expect(screen.getByTestId('docker-check-0-fail')).toBeInTheDocument()
     expect(screen.getAllByText('degraded pressure')).toHaveLength(2)
-    expect(screen.getAllByText(new RegExp(new Date(orchestratorUpdated).toLocaleString()), { selector: 'p' })).toHaveLength(4)
+    expect(screen.getAllByText(new RegExp(new Date(orchestratorUpdated).toLocaleString()), { selector: 'p' })).toHaveLength(5)
   })
 
-  it('renders stale orchestrator state and freshness', async () => {
+  it('renders unavailable load balancer telemetry explicitly', async () => {
     const apiUpdated = '2026-02-22T12:00:00.000Z'
-    const orchestratorUpdated = '2026-02-22T11:40:00.000Z'
     vi.mocked(api.getSystemStatus).mockResolvedValue({
       api: {
         state: 'healthy',
         lastUpdated: apiUpdated,
       },
       orchestrator: {
-        state: 'stale',
-        lastUpdated: orchestratorUpdated,
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+      },
+      loadBalancer: {
+        state: 'unavailable',
       },
       docker: {
         state: 'healthy',
@@ -151,8 +205,8 @@ describe('SystemStatusPanel', () => {
 
     renderWithQuery(<SystemStatusPanel />)
 
-    await waitFor(() => expect(screen.getByText('stale')).toBeInTheDocument())
-    expect(screen.getByText(/ago|just now/)).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('Load balancer')).toBeInTheDocument())
+    expect(screen.getByText('No load balancer telemetry yet')).toBeInTheDocument()
   })
 
   it('renders unavailable docker telemetry explicitly', async () => {
@@ -163,6 +217,10 @@ describe('SystemStatusPanel', () => {
         lastUpdated: apiUpdated,
       },
       orchestrator: {
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+      },
+      loadBalancer: {
         state: 'healthy',
         lastUpdated: apiUpdated,
       },

--- a/dashboard/src/system-status/SystemStatusPanel.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.tsx
@@ -1,14 +1,14 @@
 import { useSystemStatus } from './useSystemStatus'
 import { Badge } from '../components/ui/badge'
-import { AlertTriangle, CheckCircle2, CircleSlash2, Clock3 } from 'lucide-react'
+import { AlertTriangle, Check, CheckCircle2, CircleHelp, CircleSlash2, X } from 'lucide-react'
 import type { HostMetricSystemStatus, SystemStatusState } from '../lib/api'
 
 type BadgeVariant = 'secondary' | 'info' | 'success' | 'destructive' | 'warning'
+type CheckValue = boolean | undefined
 
 const STATE_VARIANT: Record<SystemStatusState, BadgeVariant> = {
   healthy: 'success',
   degraded: 'warning',
-  stale: 'destructive',
   unavailable: 'secondary',
 }
 
@@ -17,14 +17,12 @@ const DEGRADED_PRESSURE_THRESHOLD = 80
 const CARD_TONE: Record<SystemStatusState, string> = {
   healthy: 'border-emerald-200 bg-emerald-50/60 dark:border-emerald-900/60 dark:bg-emerald-950/30',
   degraded: 'border-amber-200 bg-amber-50/60 dark:border-amber-900/60 dark:bg-amber-950/30',
-  stale: 'border-rose-200 bg-rose-50/60 dark:border-rose-900/60 dark:bg-rose-950/30',
   unavailable: 'border-slate-200 bg-slate-50/70 dark:border-slate-800 dark:bg-slate-900/40',
 }
 
 const ICON_TONE: Record<SystemStatusState, string> = {
   healthy: 'text-emerald-600 dark:text-emerald-400',
   degraded: 'text-amber-600 dark:text-amber-400',
-  stale: 'text-rose-600 dark:text-rose-400',
   unavailable: 'text-slate-500 dark:text-slate-400',
 }
 
@@ -70,10 +68,6 @@ function pressureState(metric: HostMetricSystemStatus): SystemStatusState {
     return 'unavailable'
   }
 
-  if (metric.state === 'stale') {
-    return 'stale'
-  }
-
   if (metric.state === 'degraded' || metric.usagePercent >= DEGRADED_PRESSURE_THRESHOLD) {
     return 'degraded'
   }
@@ -85,7 +79,6 @@ function pressureLabel(metric: HostMetricSystemStatus) {
   const state = pressureState(metric)
   if (state === 'healthy') return 'healthy pressure'
   if (state === 'degraded') return 'degraded pressure'
-  if (state === 'stale') return 'stale telemetry'
   return 'unavailable telemetry'
 }
 
@@ -100,8 +93,64 @@ function formatUsageValue(metric: HostMetricSystemStatus) {
 function statusIcon(state: SystemStatusState) {
   if (state === 'healthy') return CheckCircle2
   if (state === 'degraded') return AlertTriangle
-  if (state === 'stale') return Clock3
   return CircleSlash2
+}
+
+function checkVariant(value: CheckValue): BadgeVariant {
+  if (value === true) return 'success'
+  if (value === false) return 'destructive'
+  return 'secondary'
+}
+
+function checkIcon(value: CheckValue) {
+  if (value === true) return Check
+  if (value === false) return X
+  return CircleHelp
+}
+
+function checkIconTone(value: CheckValue) {
+  if (value === true) return 'text-emerald-600 dark:text-emerald-400'
+  if (value === false) return 'text-rose-600 dark:text-rose-400'
+  return 'text-slate-500 dark:text-slate-400'
+}
+
+function checkLabel(value: CheckValue) {
+  if (value === true) return 'pass'
+  if (value === false) return 'fail'
+  return 'unknown'
+}
+
+function ServiceChecks({
+  serviceId,
+  checks,
+}: {
+  serviceId: string
+  checks: Array<{ label: string; value: CheckValue }>
+}) {
+  return (
+    <div className="mt-3 border-t border-border/50 pt-3">
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Checks</p>
+      <ul className="mt-2 space-y-1.5 text-xs">
+        {checks.map((check, index) => (
+          <li key={check.label} className="flex items-center justify-between gap-3">
+            <span>{check.label}</span>
+            <Badge variant={checkVariant(check.value)}>
+              {(() => {
+                const Icon = checkIcon(check.value)
+                return (
+                  <Icon
+                    data-testid={`${serviceId}-check-${index}-${checkLabel(check.value)}`}
+                    aria-label={checkLabel(check.value)}
+                    className={`h-3.5 w-3.5 ${checkIconTone(check.value)}`}
+                  />
+                )
+              })()}
+            </Badge>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }
 
 export function SystemStatusPanel() {
@@ -119,7 +168,7 @@ export function SystemStatusPanel() {
         <div className="space-y-8">
           <section className="space-y-3">
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Services</p>
-            <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+            <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
               <article className={`rounded-lg border p-5 text-sm text-muted-foreground ${CARD_TONE[status.api.state]}`}>
                 <div className="flex items-start justify-between gap-3">
                   <div>
@@ -139,6 +188,14 @@ export function SystemStatusPanel() {
                   <p className="text-xs uppercase tracking-wide">State</p>
                   <Badge variant={STATE_VARIANT[status.api.state]}>{status.api.state}</Badge>
                 </div>
+                <ServiceChecks
+                  serviceId="api"
+                  checks={[
+                    { label: 'Process running', value: status.api.checks?.processRunning },
+                    { label: 'Dashboard reachability', value: status.api.checks?.dashboardReachable },
+                    { label: 'Store access', value: status.api.checks?.storeAccessible },
+                  ]}
+                />
                 <p className="mt-3 border-t border-border/50 pt-3 text-xs">Last updated: {formatTimestamp(status.api.lastUpdated)}</p>
               </article>
 
@@ -164,6 +221,14 @@ export function SystemStatusPanel() {
                   <p className="text-xs uppercase tracking-wide">State</p>
                   <Badge variant={STATE_VARIANT[status.orchestrator.state]}>{status.orchestrator.state}</Badge>
                 </div>
+                <ServiceChecks
+                  serviceId="orchestrator"
+                  checks={[
+                    { label: 'Process running', value: status.orchestrator.checks?.processRunning },
+                    { label: 'Docker daemon reachability', value: status.orchestrator.checks?.dockerReachable },
+                    { label: 'Store access', value: status.orchestrator.checks?.storeAccessible },
+                  ]}
+                />
                 <div className="mt-3 space-y-1 border-t border-border/50 pt-3 text-xs">
                   <p>Last heartbeat: {formatTimestamp(status.orchestrator.lastUpdated)}</p>
                   <p>Freshness: {formatFreshness(status.orchestrator.lastUpdated)}</p>
@@ -189,12 +254,54 @@ export function SystemStatusPanel() {
                   <p className="text-xs uppercase tracking-wide">State</p>
                   <Badge variant={STATE_VARIANT[status.docker.state]}>{status.docker.state}</Badge>
                 </div>
+                <ServiceChecks
+                  serviceId="docker"
+                  checks={[{ label: 'Daemon healthy', value: status.docker.checks?.daemonHealthy }]}
+                />
                 <p className="mt-3 border-t border-border/50 pt-3 text-xs">Last checked: {formatTimestamp(status.docker.lastUpdated)}</p>
                 <p className="mt-1 text-xs">
                   {status.docker.state === 'healthy' && 'Docker is reachable from orchestrator'}
                   {status.docker.state === 'degraded' && 'Docker check failed at last probe'}
-                  {status.docker.state === 'stale' && 'Docker signal is stale'}
                   {status.docker.state === 'unavailable' && 'No Docker connectivity telemetry yet'}
+                </p>
+              </article>
+
+              <article className={`rounded-lg border p-5 text-sm text-muted-foreground ${CARD_TONE[status.loadBalancer.state]}`}>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-foreground">Load balancer</p>
+                    <p className="mt-1 text-xs">Reverse proxy health signal.</p>
+                  </div>
+                  {(() => {
+                    const Icon = statusIcon(status.loadBalancer.state)
+                    return (
+                      <div className="rounded-md bg-background/70 p-2">
+                        <Icon
+                          data-testid="load-balancer-status-icon"
+                          className={`h-8 w-8 ${ICON_TONE[status.loadBalancer.state]}`}
+                        />
+                      </div>
+                    )
+                  })()}
+                </div>
+                <div className="mt-4 flex items-center justify-between gap-3">
+                  <p className="text-xs uppercase tracking-wide">State</p>
+                  <Badge variant={STATE_VARIANT[status.loadBalancer.state]}>{status.loadBalancer.state}</Badge>
+                </div>
+                <ServiceChecks
+                  serviceId="load-balancer"
+                  checks={[
+                    { label: 'Process running', value: status.loadBalancer.checks?.processRunning },
+                    { label: 'Healthcheck response', value: status.loadBalancer.checks?.healthcheckResponding },
+                  ]}
+                />
+                <p className="mt-3 border-t border-border/50 pt-3 text-xs">
+                  Last checked: {formatTimestamp(status.loadBalancer.lastUpdated)}
+                </p>
+                <p className="mt-1 text-xs">
+                  {status.loadBalancer.state === 'healthy' && 'Load balancer healthcheck is responding'}
+                  {status.loadBalancer.state === 'degraded' && 'Load balancer healthcheck failed at last probe'}
+                  {status.loadBalancer.state === 'unavailable' && 'No load balancer telemetry yet'}
                 </p>
               </article>
             </div>

--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -58,6 +60,10 @@ func main() {
 	if v := os.Getenv("DIRIGENT_API_URL"); v != "" {
 		apiURL = v
 	}
+	proxyHealthURL := "http://localhost/internal/health"
+	if v := os.Getenv("DIRIGENT_PROXY_HEALTH_URL"); v != "" {
+		proxyHealthURL = v
+	}
 	notifier := apiclient.New(apiURL)
 	metrics := hostmetrics.NewCollector()
 
@@ -76,6 +82,8 @@ func main() {
 		case <-ticker.C:
 			now := time.Now().UTC()
 			dockerReachable := true
+			loadBalancerResponding := false
+			storeAccessible := true
 			var cpuUsagePercent *float64
 			var ramUsagePercent *float64
 
@@ -86,6 +94,17 @@ func main() {
 				log.Printf("orchestrator: docker unreachable: %v", err)
 			}
 			pingCancel()
+
+			if _, err := s.List(); err != nil {
+				storeAccessible = false
+				log.Printf("orchestrator: store unavailable: %v", err)
+			}
+
+			if err := probeProxyHealth(ctx, proxyHealthURL); err != nil {
+				log.Printf("orchestrator: load balancer healthcheck failed: %v", err)
+			} else {
+				loadBalancerResponding = true
+			}
 
 			if usage, ok, err := metrics.CPUUsagePercent(); err != nil {
 				log.Printf("orchestrator: collect cpu telemetry: %v", err)
@@ -100,7 +119,7 @@ func main() {
 			}
 
 			// Heartbeat is always sent, regardless of Docker state.
-			if err := notifier.NotifyHeartbeat(dockerReachable, now, cpuUsagePercent, ramUsagePercent); err != nil {
+			if err := notifier.NotifyHeartbeat(dockerReachable, loadBalancerResponding, storeAccessible, now, cpuUsagePercent, ramUsagePercent); err != nil {
 				log.Printf("orchestrator: notify heartbeat: %v", err)
 			}
 
@@ -115,4 +134,26 @@ func main() {
 			return
 		}
 	}
+}
+
+func probeProxyHealth(ctx context.Context, healthURL string) error {
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, healthURL, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	return nil
 }

--- a/orchestrator/internal/apiclient/client.go
+++ b/orchestrator/internal/apiclient/client.go
@@ -17,14 +17,25 @@ type Client struct {
 }
 
 type heartbeatRequest struct {
-	At     time.Time            `json:"at"`
-	Docker heartbeatDockerState `json:"docker"`
-	Host   *heartbeatHostState  `json:"host,omitempty"`
+	At           time.Time                  `json:"at"`
+	Orchestrator heartbeatOrchestratorState `json:"orchestrator"`
+	Docker       heartbeatDockerState       `json:"docker"`
+	LoadBalancer heartbeatLoadBalancerState `json:"loadBalancer"`
+	Host         *heartbeatHostState        `json:"host,omitempty"`
+}
+
+type heartbeatOrchestratorState struct {
+	StoreAccessible bool `json:"storeAccessible"`
 }
 
 type heartbeatDockerState struct {
 	Reachable bool      `json:"reachable"`
 	CheckedAt time.Time `json:"checkedAt"`
+}
+
+type heartbeatLoadBalancerState struct {
+	Responding bool      `json:"responding"`
+	CheckedAt  time.Time `json:"checkedAt"`
 }
 
 type heartbeatHostState struct {
@@ -78,7 +89,7 @@ func (c *Client) NotifyStatus(id string, status store.Status, errorMessage strin
 
 // NotifyHeartbeat calls POST /api/system-status/orchestrator-heartbeat so the
 // API can update orchestrator liveness, Docker connectivity, and host metrics.
-func (c *Client) NotifyHeartbeat(dockerReachable bool, checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64) error {
+func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bool, storeAccessible bool, checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64) error {
 	if checkedAt.IsZero() {
 		checkedAt = time.Now().UTC()
 	} else {
@@ -89,9 +100,16 @@ func (c *Client) NotifyHeartbeat(dockerReachable bool, checkedAt time.Time, cpuU
 
 	body, err := json.Marshal(heartbeatRequest{
 		At: checkedAt,
+		Orchestrator: heartbeatOrchestratorState{
+			StoreAccessible: storeAccessible,
+		},
 		Docker: heartbeatDockerState{
 			Reachable: dockerReachable,
 			CheckedAt: checkedAt,
+		},
+		LoadBalancer: heartbeatLoadBalancerState{
+			Responding: loadBalancerResponding,
+			CheckedAt:  checkedAt,
 		},
 		Host: host,
 	})

--- a/orchestrator/internal/apiclient/client_test.go
+++ b/orchestrator/internal/apiclient/client_test.go
@@ -24,11 +24,18 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 		}
 
 		var body struct {
-			At     time.Time `json:"at"`
+			At           time.Time `json:"at"`
+			Orchestrator struct {
+				StoreAccessible bool `json:"storeAccessible"`
+			} `json:"orchestrator"`
 			Docker struct {
 				Reachable bool      `json:"reachable"`
 				CheckedAt time.Time `json:"checkedAt"`
 			} `json:"docker"`
+			LoadBalancer struct {
+				Responding bool      `json:"responding"`
+				CheckedAt  time.Time `json:"checkedAt"`
+			} `json:"loadBalancer"`
 			Host *struct {
 				CPU *struct {
 					UsagePercent float64   `json:"usagePercent"`
@@ -53,6 +60,15 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 		if !body.Docker.CheckedAt.Equal(checkedAt) {
 			t.Fatalf("want checkedAt %s, got %s", checkedAt, body.Docker.CheckedAt)
 		}
+		if body.Orchestrator.StoreAccessible {
+			t.Fatal("want orchestrator store accessible false")
+		}
+		if body.LoadBalancer.Responding {
+			t.Fatal("want load balancer responding false")
+		}
+		if !body.LoadBalancer.CheckedAt.Equal(checkedAt) {
+			t.Fatalf("want load balancer checkedAt %s, got %s", checkedAt, body.LoadBalancer.CheckedAt)
+		}
 		if body.Host == nil || body.Host.CPU == nil || body.Host.RAM == nil {
 			t.Fatal("want host cpu and ram metrics in heartbeat")
 		}
@@ -74,7 +90,7 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(false, checkedAt, &cpu, &ram); err != nil {
+	if err := client.NotifyHeartbeat(false, false, false, checkedAt, &cpu, &ram); err != nil {
 		t.Fatalf("NotifyHeartbeat: %v", err)
 	}
 }
@@ -102,7 +118,7 @@ func TestClient_NotifyHeartbeat_WithoutHostMetrics(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(false, checkedAt, nil, nil); err != nil {
+	if err := client.NotifyHeartbeat(false, true, true, checkedAt, nil, nil); err != nil {
 		t.Fatalf("NotifyHeartbeat: %v", err)
 	}
 }
@@ -114,7 +130,7 @@ func TestClient_NotifyHeartbeat_UnexpectedResponse(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(true, time.Time{}, nil, nil); err == nil {
+	if err := client.NotifyHeartbeat(true, true, true, time.Time{}, nil, nil); err == nil {
 		t.Fatal("want error for non-204 heartbeat response")
 	}
 }

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -30,8 +30,13 @@ func New(table RoutingTable) *Handler {
 
 // RegisterRoutes wires the proxy catch-all and the internal control API into mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /internal/health", h.health)
 	mux.HandleFunc("POST /internal/routes", h.setRoute)
 	mux.HandleFunc("/", h.proxy)
+}
+
+func (h *Handler) health(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }
 
 // proxy routes inbound requests to the upstream registered for the Host header.

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -169,8 +169,8 @@ func TestSetRoute_MissingFields(t *testing.T) {
 
 	cases := []map[string]string{
 		{"upstream": "localhost:3000"}, // missing domain
-		{"domain": "example.com"},     // missing upstream
-		{},                            // both missing
+		{"domain": "example.com"},      // missing upstream
+		{},                             // both missing
 	}
 
 	for _, payload := range cases {
@@ -198,6 +198,21 @@ func TestSetRoute_InvalidBody(t *testing.T) {
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHealth_Returns200(t *testing.T) {
+	proxy := newProxyServer(newTestTable())
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/internal/health")
+	if err != nil {
+		t.Fatalf("GET /internal/health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace system status states with `healthy`, `degraded`, and `unavailable`, and map stale telemetry to degraded.
- Add end-to-end load balancer health reporting: proxy `/internal/health`, orchestrator probe + heartbeat payload, API snapshot contract, and dashboard service card.
- Show sub-check results on each service card in the dashboard using check icons so users can see exactly which checks are passing or failing.
- Update dev wiring to probe proxy health on `:8090` during `make dev`.

## Validation
- `go test ./api/internal/api ./orchestrator/internal/apiclient ./proxy/internal/handler`
- `bunx vitest run src/system-status/SystemStatusPanel.test.tsx`

Closes #99