### PR TITLE
feat(proxy): TLS provisioning and HTTPS enforcement

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -5,5 +5,6 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -2,12 +2,20 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/ercadev/dirigent/proxy/internal/handler"
 	"github.com/ercadev/dirigent/proxy/internal/poller"
@@ -15,7 +23,13 @@ import (
 	"github.com/ercadev/dirigent/store"
 )
 
-const defaultAddr = ":80"
+const (
+	defaultHTTPAddr                = ":80"
+	defaultHTTPSAddr               = ":443"
+	defaultCertCacheDir            = "/var/lib/dirigent/certs"
+	letsencryptProdDirectoryURL    = "https://acme-v02.api.letsencrypt.org/directory"
+	letsencryptStagingDirectoryURL = "https://acme-staging-v02.api.letsencrypt.org/directory"
+)
 
 func dataPath() string {
 	if p := os.Getenv("DIRIGENT_DATA"); p != "" {
@@ -40,31 +54,156 @@ func main() {
 	}
 
 	p := poller.New(s, table, interval)
+	h := handler.New(table)
 
-	mux := http.NewServeMux()
-	handler.New(table).RegisterRoutes(mux)
+	hostPolicy := hostPolicyFromTable(table)
+	cacheDir := envOrDefault("DIRIGENT_CERT_CACHE_DIR", defaultCertCacheDir)
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		log.Fatalf("proxy: create cert cache dir %s: %v", cacheDir, err)
+	}
+	manager := newAutocertManager(
+		cacheDir,
+		os.Getenv("DIRIGENT_ACME_EMAIL"),
+		envOrDefault("DIRIGENT_ACME_DIRECTORY_URL", letsencryptProdDirectoryURL),
+		hostPolicy,
+	)
+
+	httpsAddr := envOrDefault("DIRIGENT_PROXY_HTTPS_ADDR", defaultHTTPSAddr)
+	httpAddr := envOrDefault("DIRIGENT_PROXY_HTTP_ADDR", envOrDefault("DIRIGENT_PROXY_ADDR", defaultHTTPAddr))
+
+	httpMux := newHTTPMux(h, manager.HTTPHandler(http.HandlerFunc(redirectToHTTPS(httpsAddr))))
+	httpsMux := newHTTPSMux(h)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	go p.Run(ctx)
 
-	addr := defaultAddr
-	if v := os.Getenv("DIRIGENT_PROXY_ADDR"); v != "" {
-		addr = v
-	}
-
-	srv := &http.Server{Addr: addr, Handler: mux}
+	httpSrv := &http.Server{Addr: httpAddr, Handler: httpMux}
+	httpsSrv := &http.Server{Addr: httpsAddr, Handler: httpsMux, TLSConfig: manager.TLSConfig()}
 
 	go func() {
 		<-ctx.Done()
-		if err := srv.Close(); err != nil {
-			log.Printf("proxy: shutdown: %v", err)
+		if err := httpSrv.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("proxy: http shutdown: %v", err)
+		}
+		if err := httpsSrv.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("proxy: https shutdown: %v", err)
 		}
 	}()
 
-	log.Printf("proxy: listening on %s", addr)
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	errCh := make(chan error, 2)
+
+	go func() {
+		log.Printf("proxy: listening for HTTP on %s", httpAddr)
+		if err := httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- fmt.Errorf("http server: %w", err)
+		}
+	}()
+
+	go func() {
+		log.Printf("proxy: listening for HTTPS on %s", httpsAddr)
+		if err := httpsSrv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+			errCh <- fmt.Errorf("https server: %w", err)
+		}
+	}()
+
+	select {
+	case err := <-errCh:
 		log.Fatalf("proxy: %v", err)
+	case <-ctx.Done():
 	}
+}
+
+func newHTTPMux(h *handler.Handler, external http.Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	h.RegisterInternalRoutes(mux)
+	mux.Handle("/", external)
+	return mux
+}
+
+func newHTTPSMux(h *handler.Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	h.RegisterProxyRoutes(mux)
+	return mux
+}
+
+func redirectToHTTPS(httpsAddr string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		host := hostWithoutPort(r.Host)
+		if host == "" {
+			http.Error(w, "missing host", http.StatusBadRequest)
+			return
+		}
+		if port := portFromAddr(httpsAddr); port != "" && port != "443" {
+			host = net.JoinHostPort(host, port)
+		}
+		target := &url.URL{
+			Scheme:   "https",
+			Host:     host,
+			Path:     r.URL.Path,
+			RawQuery: r.URL.RawQuery,
+		}
+		http.Redirect(w, r, target.String(), http.StatusMovedPermanently)
+	}
+}
+
+func hostPolicyFromTable(table interface{ Get(string) (string, bool) }) autocert.HostPolicy {
+	return func(_ context.Context, host string) error {
+		host = normalizeDomain(host)
+		if host == "" {
+			return errors.New("empty host")
+		}
+		if _, ok := table.Get(host); !ok {
+			return fmt.Errorf("host %q not configured", host)
+		}
+		return nil
+	}
+}
+
+func newAutocertManager(cacheDir, email, directoryURL string, hostPolicy autocert.HostPolicy) *autocert.Manager {
+	if directoryURL == "" {
+		directoryURL = letsencryptProdDirectoryURL
+	}
+	return &autocert.Manager{
+		Prompt:     autocert.AcceptTOS,
+		Cache:      autocert.DirCache(cacheDir),
+		HostPolicy: hostPolicy,
+		Email:      email,
+		Client: &acme.Client{
+			DirectoryURL: directoryURL,
+		},
+	}
+}
+
+func hostWithoutPort(host string) string {
+	host = strings.TrimSpace(host)
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return normalizeDomain(host)
+}
+
+func normalizeDomain(domain string) string {
+	domain = strings.TrimSpace(domain)
+	domain = strings.TrimSuffix(domain, ".")
+	return strings.ToLower(domain)
+}
+
+func portFromAddr(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if strings.HasPrefix(addr, ":") {
+		return strings.TrimPrefix(addr, ":")
+	}
+	if _, port, err := net.SplitHostPort(addr); err == nil {
+		return port
+	}
+	return ""
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }

--- a/proxy/cmd/proxy/main_test.go
+++ b/proxy/cmd/proxy/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"golang.org/x/crypto/acme/autocert"
+
+	"github.com/ercadev/dirigent/proxy/internal/handler"
+)
+
+type tableStub struct {
+	mu     sync.RWMutex
+	routes map[string]string
+}
+
+func newTableStub() *tableStub {
+	return &tableStub{routes: make(map[string]string)}
+}
+
+func (t *tableStub) Get(domain string) (string, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	u, ok := t.routes[domain]
+	return u, ok
+}
+
+func (t *tableStub) Set(domain, upstream string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.routes[domain] = upstream
+}
+
+func TestRedirectToHTTPS_DefaultPort(t *testing.T) {
+	h := redirectToHTTPS(":443")
+
+	r := httptest.NewRequest(http.MethodGet, "http://example.com/path?q=1", nil)
+	r.Host = "example.com"
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("want 301, got %d", w.Code)
+	}
+	if got := w.Header().Get("Location"); got != "https://example.com/path?q=1" {
+		t.Fatalf("want Location https://example.com/path?q=1, got %s", got)
+	}
+}
+
+func TestRedirectToHTTPS_CustomPort(t *testing.T) {
+	h := redirectToHTTPS(":8443")
+
+	r := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	r.Host = "example.com:80"
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got := w.Header().Get("Location"); got != "https://example.com:8443/" {
+		t.Fatalf("want Location https://example.com:8443/, got %s", got)
+	}
+}
+
+func TestHTTPMux_InternalHealthNotRedirected(t *testing.T) {
+	h := handler.New(newTableStub())
+	mux := newHTTPMux(h, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://example.com/", http.StatusMovedPermanently)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/internal/health", nil)
+	r.Host = "localhost"
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+}
+
+func TestHTTPMux_InternalRoutesCanBeUpdated(t *testing.T) {
+	tbl := newTableStub()
+	h := handler.New(tbl)
+	mux := newHTTPMux(h, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://example.com/", http.StatusMovedPermanently)
+	}))
+
+	r := httptest.NewRequest(http.MethodPost, "/internal/routes", bytes.NewBufferString(`{"domain":"Example.com","upstream":"localhost:3000"}`))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", w.Code)
+	}
+	if _, ok := tbl.Get("example.com"); !ok {
+		t.Fatal("want normalized route to be registered")
+	}
+}
+
+func TestHostPolicyFromTable(t *testing.T) {
+	tbl := newTableStub()
+	tbl.Set("example.com", "localhost:3000")
+	policy := hostPolicyFromTable(tbl)
+
+	if err := policy(context.Background(), "example.com"); err != nil {
+		t.Fatalf("want host allowed, got %v", err)
+	}
+	if err := policy(context.Background(), "missing.example.com"); err == nil {
+		t.Fatal("want missing host rejected")
+	}
+}
+
+func TestNewAutocertManager_UsesDirectoryAndEmail(t *testing.T) {
+	mgr := newAutocertManager("/tmp/dirigent-certs-test", "ops@example.com", letsencryptStagingDirectoryURL, autocert.HostWhitelist("example.com"))
+
+	if mgr.Email != "ops@example.com" {
+		t.Fatalf("want email ops@example.com, got %s", mgr.Email)
+	}
+	if mgr.Client == nil {
+		t.Fatal("want acme client configured")
+	}
+	if mgr.Client.DirectoryURL != letsencryptStagingDirectoryURL {
+		t.Fatalf("want directory %s, got %s", letsencryptStagingDirectoryURL, mgr.Client.DirectoryURL)
+	}
+}

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -4,4 +4,10 @@ go 1.24.0
 
 require github.com/ercadev/dirigent/store v0.0.0
 
+require (
+	golang.org/x/crypto v0.48.0
+	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/text v0.34.0 // indirect
+)
+
 replace github.com/ercadev/dirigent/store => ../store

--- a/proxy/go.sum
+++ b/proxy/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
+golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
+golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
+golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
+golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 )
 
 // RoutingTable is the interface the handler reads from when proxying requests
@@ -30,8 +31,18 @@ func New(table RoutingTable) *Handler {
 
 // RegisterRoutes wires the proxy catch-all and the internal control API into mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	h.RegisterInternalRoutes(mux)
+	h.RegisterProxyRoutes(mux)
+}
+
+// RegisterInternalRoutes wires the internal health/control API into mux.
+func (h *Handler) RegisterInternalRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /internal/health", h.health)
 	mux.HandleFunc("POST /internal/routes", h.setRoute)
+}
+
+// RegisterProxyRoutes wires the proxy catch-all route into mux.
+func (h *Handler) RegisterProxyRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/", h.proxy)
 }
 
@@ -47,6 +58,7 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 	if bare, _, err := net.SplitHostPort(host); err == nil {
 		host = bare
 	}
+	host = normalizeDomain(host)
 
 	upstream, ok := h.table.Get(host)
 	if !ok {
@@ -96,6 +108,12 @@ func (h *Handler) setRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.table.Set(body.Domain, body.Upstream)
+	h.table.Set(normalizeDomain(body.Domain), body.Upstream)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func normalizeDomain(domain string) string {
+	domain = strings.TrimSpace(domain)
+	domain = strings.TrimSuffix(domain, ".")
+	return strings.ToLower(domain)
 }

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -237,3 +237,31 @@ func TestProxy_UpstreamUnavailableReturns502(t *testing.T) {
 		t.Fatalf("want 502, got %d", resp.StatusCode)
 	}
 }
+
+func TestProxy_HTTPSKnownDomainReachesBackend(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", backend.Listener.Addr().String())
+
+	mux := http.NewServeMux()
+	handler.New(tbl).RegisterRoutes(mux)
+	proxy := httptest.NewTLSServer(mux)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "example.com"
+
+	resp, err := proxy.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET / over HTTPS: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+}

--- a/proxy/internal/poller/poller.go
+++ b/proxy/internal/poller/poller.go
@@ -72,11 +72,15 @@ func (p *Poller) sync() {
 		if d.Domain == "" {
 			continue
 		}
+		domain := normalizeDomain(d.Domain)
+		if domain == "" {
+			continue
+		}
 		upstream := upstreamFromPorts(d.Ports)
 		if upstream == "" {
 			continue
 		}
-		current[d.Domain] = upstream
+		current[domain] = upstream
 	}
 
 	// Register new routes and update changed upstreams.
@@ -125,4 +129,10 @@ func upstreamFromPorts(ports []string) string {
 		}
 	}
 	return ""
+}
+
+func normalizeDomain(domain string) string {
+	domain = strings.TrimSpace(domain)
+	domain = strings.TrimSuffix(domain, ".")
+	return strings.ToLower(domain)
 }


### PR DESCRIPTION
## Summary
- add dual HTTP/HTTPS listeners in the proxy and wire automatic ACME certificate management via `autocert`
- enforce HTTP to HTTPS redirects for external traffic while keeping `/internal/health` and `/internal/routes` served over HTTP
- normalize domains across poller/handler lookups and add tests for redirects, HTTPS routing, host policy, and ACME manager configuration

## Testing
- go test ./... (in `proxy`)

Closes #54