### PR TITLE
fix(release): anchor BREAKING CHANGE detection to line start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,9 @@ jobs:
 
           BUMP="none"
           while IFS= read -r line; do
-            if echo "$line" | grep -qiE 'BREAKING CHANGE'; then
+            # Footer token per conventional commits spec (must start the line).
+            # This avoids matching prose like "e.g. BREAKING CHANGE → major".
+            if echo "$line" | grep -qE '^BREAKING[- ]CHANGE:'; then
               BUMP="major"; break
             fi
             if echo "$line" | grep -qE '^[a-z]+(\([^)]+\))?!:'; then


### PR DESCRIPTION
The grep was case-insensitive with no anchor, so commit bodies containing "BREAKING CHANGE" as documentation prose (e.g. in changelogs or bullet points) incorrectly triggered a major bump.

Per the conventional commits spec, the footer token must appear at the start of a line followed by ': '. Use '^BREAKING[- ]CHANGE:' to match only genuine footer declarations.