### PR TITLE
feat(api): implement self-update backend for settings upgrade flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,8 +189,8 @@ jobs:
       - name: Build API binaries
         working-directory: api
         run: |
-          GOOS=linux GOARCH=amd64 go build -o ../dirigent-linux-amd64 ./cmd/dirigent
-          GOOS=linux GOARCH=arm64 go build -o ../dirigent-linux-arm64 ./cmd/dirigent
+          GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${{ github.ref_name }}" -o ../dirigent-linux-amd64 ./cmd/dirigent
+          GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=${{ github.ref_name }}" -o ../dirigent-linux-arm64 ./cmd/dirigent
 
       - name: Build orchestrator binaries
         working-directory: orchestrator

--- a/api/cmd/dirigent/main.go
+++ b/api/cmd/dirigent/main.go
@@ -15,6 +15,8 @@ import (
 
 const addr = ":8080"
 
+var version = "dev"
+
 func dataPath() string {
 	if p := os.Getenv("DIRIGENT_DATA"); p != "" {
 		return p
@@ -41,7 +43,7 @@ func main() {
 	logStreamer := docker.New(dc)
 
 	mux := http.NewServeMux()
-	api.New(s, broker, logStreamer).RegisterRoutes(mux)
+	api.NewWithVersion(s, broker, logStreamer, version).RegisterRoutes(mux)
 
 	log.Printf("dirigent API listening on %s", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/ercadev/dirigent/internal/events"
+	"github.com/ercadev/dirigent/internal/upgrade"
+	"github.com/ercadev/dirigent/internal/version"
 	"github.com/ercadev/dirigent/store"
 )
 
@@ -40,6 +42,16 @@ type EventBus interface {
 // container is currently running for the deployment.
 type DockerLogs interface {
 	StreamLogs(ctx context.Context, deploymentID string, tail int) (io.ReadCloser, error)
+}
+
+type VersionInfoProvider interface {
+	Snapshot(ctx context.Context) (version.Snapshot, error)
+}
+
+type UpgradeRunner interface {
+	Start(targetVersion string) error
+	Subscribe() (<-chan string, func(), error)
+	IsRunning() bool
 }
 
 type deploymentRequest struct {
@@ -70,20 +82,47 @@ type Handler struct {
 	loadBalancer LoadBalancerHealthIngestor
 	cpu          CPUUtilizationIngestor
 	ram          RAMUtilizationIngestor
+	versions     VersionInfoProvider
+	upgrade      UpgradeRunner
 }
 
 const defaultOrchestratorStaleAfter = 30 * time.Second
 
 // New creates a Handler backed by the given store, event bus, and Docker log streamer.
 func New(s Store, eb EventBus, dl DockerLogs) *Handler {
-	return NewWithSystemStatus(s, eb, dl, nil)
+	return NewWithVersion(s, eb, dl, "dev")
+}
+
+func NewWithVersion(s Store, eb EventBus, dl DockerLogs, currentVersion string) *Handler {
+	if currentVersion == "" {
+		currentVersion = "dev"
+	}
+
+	return NewWithDependencies(
+		s,
+		eb,
+		dl,
+		nil,
+		version.New(currentVersion),
+		upgrade.New(),
+	)
 }
 
 // NewWithSystemStatus creates a Handler with a custom system-status provider.
 // If statusSource is nil, a default provider is used.
 func NewWithSystemStatus(s Store, eb EventBus, dl DockerLogs, statusSource SystemStatusProvider) *Handler {
+	return NewWithDependencies(s, eb, dl, statusSource, version.New("dev"), upgrade.New())
+}
+
+func NewWithDependencies(s Store, eb EventBus, dl DockerLogs, statusSource SystemStatusProvider, versions VersionInfoProvider, upgrader UpgradeRunner) *Handler {
 	if statusSource == nil {
 		statusSource = newDefaultSystemStatusProvider(time.Now, orchestratorStaleAfterFromEnv(), buildAPIStoreChecker(s))
+	}
+	if versions == nil {
+		versions = version.New("dev")
+	}
+	if upgrader == nil {
+		upgrader = upgrade.New()
 	}
 
 	heartbeatIngestor, _ := statusSource.(OrchestratorHeartbeatIngestor)
@@ -92,7 +131,7 @@ func NewWithSystemStatus(s Store, eb EventBus, dl DockerLogs, statusSource Syste
 	cpuIngestor, _ := statusSource.(CPUUtilizationIngestor)
 	ramIngestor, _ := statusSource.(RAMUtilizationIngestor)
 
-	return &Handler{store: s, events: eb, dockerLogs: dl, statusSource: statusSource, heartbeats: heartbeatIngestor, docker: dockerIngestor, loadBalancer: loadBalancerIngestor, cpu: cpuIngestor, ram: ramIngestor}
+	return &Handler{store: s, events: eb, dockerLogs: dl, statusSource: statusSource, heartbeats: heartbeatIngestor, docker: dockerIngestor, loadBalancer: loadBalancerIngestor, cpu: cpuIngestor, ram: ramIngestor, versions: versions, upgrade: upgrader}
 }
 
 func buildAPIStoreChecker(s Store) func(context.Context) bool {
@@ -111,6 +150,9 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/deployments", h.listDeployments)
 	mux.HandleFunc("GET /api/system-status", h.systemStatus)
 	mux.HandleFunc("POST /api/system-status/orchestrator-heartbeat", h.recordOrchestratorHeartbeat)
+	mux.HandleFunc("GET /api/version", h.getVersion)
+	mux.HandleFunc("POST /api/upgrade", h.startUpgrade)
+	mux.HandleFunc("GET /api/upgrade/logs", h.upgradeLogs)
 	mux.HandleFunc("POST /api/deployments", h.createDeployment)
 	mux.HandleFunc("GET /api/deployments/events", h.deploymentEvents)
 	mux.HandleFunc("GET /api/deployments/{id}/logs", h.deploymentLogs)

--- a/api/internal/api/handler_upgrade.go
+++ b/api/internal/api/handler_upgrade.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/ercadev/dirigent/internal/upgrade"
+)
+
+func (h *Handler) startUpgrade(w http.ResponseWriter, r *http.Request) {
+	targetVersion := "latest"
+	snapshot, err := h.versions.Snapshot(r.Context())
+	if err != nil {
+		log.Printf("startUpgrade: version snapshot failed: %v", err)
+	}
+	if snapshot.LatestVersion != "" {
+		targetVersion = snapshot.LatestVersion
+	}
+
+	if err := h.upgrade.Start(targetVersion); err != nil {
+		if errors.Is(err, upgrade.ErrAlreadyRunning) {
+			http.Error(w, "upgrade already in progress", http.StatusConflict)
+			return
+		}
+		log.Printf("startUpgrade: start failed: %v", err)
+		http.Error(w, "failed to start upgrade", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, map[string]string{"status": "running"})
+}
+
+func (h *Handler) upgradeLogs(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	lines, unsubscribe, err := h.upgrade.Subscribe()
+	if err != nil {
+		if errors.Is(err, upgrade.ErrNotRunning) {
+			http.Error(w, "no upgrade in progress", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to subscribe upgrade logs", http.StatusInternalServerError)
+		return
+	}
+	defer unsubscribe()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	payload := struct {
+		Line string `json:"line"`
+	}{}
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case line, ok := <-lines:
+			if !ok {
+				return
+			}
+			payload.Line = line
+			data, err := json.Marshal(payload)
+			if err != nil {
+				log.Printf("upgradeLogs: marshal line: %v", err)
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+				log.Printf("upgradeLogs: write: %v", err)
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/api/internal/api/handler_upgrade_version_test.go
+++ b/api/internal/api/handler_upgrade_version_test.go
@@ -1,0 +1,215 @@
+package api_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ercadev/dirigent/internal/api"
+	"github.com/ercadev/dirigent/internal/events"
+	"github.com/ercadev/dirigent/internal/upgrade"
+	"github.com/ercadev/dirigent/internal/version"
+)
+
+type versionProviderStub struct {
+	snapshot version.Snapshot
+	err      error
+}
+
+func (s *versionProviderStub) Snapshot(_ context.Context) (version.Snapshot, error) {
+	if s.err != nil {
+		return version.Snapshot{}, s.err
+	}
+	return s.snapshot, nil
+}
+
+type upgradeRunnerStub struct {
+	startErr error
+	lines    chan string
+}
+
+func (s *upgradeRunnerStub) Start(_ string) error {
+	return s.startErr
+}
+
+func (s *upgradeRunnerStub) Subscribe() (<-chan string, func(), error) {
+	if s.lines == nil {
+		return nil, nil, upgrade.ErrNotRunning
+	}
+	unsubscribe := func() {
+	}
+	return s.lines, unsubscribe, nil
+}
+
+func (s *upgradeRunnerStub) IsRunning() bool {
+	return s.lines != nil
+}
+
+func newTestServerWithUpgradeAndVersion(s api.Store, versions api.VersionInfoProvider, upgrader api.UpgradeRunner) *httptest.Server {
+	mux := http.NewServeMux()
+	h := api.NewWithDependencies(s, events.NewBroker(), noopDockerLogs{}, nil, versions, upgrader)
+	h.RegisterRoutes(mux)
+	return httptest.NewServer(mux)
+}
+
+func TestGetVersion_ReturnsExpectedJSON(t *testing.T) {
+	now := time.Date(2026, time.February, 24, 10, 0, 0, 0, time.UTC)
+	publishedAt := time.Date(2026, time.February, 23, 12, 34, 56, 0, time.UTC)
+
+	srv := newTestServerWithUpgradeAndVersion(
+		newMemStore(),
+		&versionProviderStub{snapshot: version.Snapshot{
+			CurrentVersion:   "v1.0.0",
+			LatestVersion:    "v1.1.0",
+			ReleaseNotes:     "notes",
+			PublishedAt:      publishedAt,
+			UpgradeAvailable: true,
+			CachedAt:         now,
+		}},
+		&upgradeRunnerStub{},
+	)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/version")
+	if err != nil {
+		t.Fatalf("GET /api/version: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		CurrentVersion   string    `json:"currentVersion"`
+		LatestVersion    string    `json:"latestVersion"`
+		ReleaseNotes     string    `json:"releaseNotes"`
+		PublishedAt      time.Time `json:"publishedAt"`
+		UpgradeAvailable bool      `json:"upgradeAvailable"`
+		CachedAt         time.Time `json:"cachedAt"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.CurrentVersion != "v1.0.0" {
+		t.Fatalf("currentVersion = %q, want v1.0.0", body.CurrentVersion)
+	}
+	if body.LatestVersion != "v1.1.0" {
+		t.Fatalf("latestVersion = %q, want v1.1.0", body.LatestVersion)
+	}
+	if body.ReleaseNotes != "notes" {
+		t.Fatalf("releaseNotes = %q, want notes", body.ReleaseNotes)
+	}
+	if !body.PublishedAt.Equal(publishedAt) {
+		t.Fatalf("publishedAt = %s, want %s", body.PublishedAt, publishedAt)
+	}
+	if !body.UpgradeAvailable {
+		t.Fatal("upgradeAvailable = false, want true")
+	}
+	if !body.CachedAt.Equal(now) {
+		t.Fatalf("cachedAt = %s, want %s", body.CachedAt, now)
+	}
+}
+
+func TestPostUpgrade_Returns202WhenIdle(t *testing.T) {
+	srv := newTestServerWithUpgradeAndVersion(
+		newMemStore(),
+		&versionProviderStub{snapshot: version.Snapshot{LatestVersion: "v1.1.0"}},
+		&upgradeRunnerStub{},
+	)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/upgrade", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/upgrade: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", resp.StatusCode)
+	}
+}
+
+func TestPostUpgrade_Returns409WhenAlreadyRunning(t *testing.T) {
+	srv := newTestServerWithUpgradeAndVersion(
+		newMemStore(),
+		&versionProviderStub{snapshot: version.Snapshot{LatestVersion: "v1.1.0"}},
+		&upgradeRunnerStub{startErr: upgrade.ErrAlreadyRunning},
+	)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/upgrade", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/upgrade: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("want 409, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpgradeLogs_Returns404WhenNotRunning(t *testing.T) {
+	srv := newTestServerWithUpgradeAndVersion(
+		newMemStore(),
+		&versionProviderStub{},
+		&upgradeRunnerStub{startErr: errors.New("unused")},
+	)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/upgrade/logs")
+	if err != nil {
+		t.Fatalf("GET /api/upgrade/logs: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpgradeLogs_StreamsAndCloses(t *testing.T) {
+	lines := make(chan string, 2)
+	lines <- "line one"
+	lines <- "line two"
+	close(lines)
+
+	srv := newTestServerWithUpgradeAndVersion(
+		newMemStore(),
+		&versionProviderStub{},
+		&upgradeRunnerStub{lines: lines},
+	)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/upgrade/logs")
+	if err != nil {
+		t.Fatalf("GET /api/upgrade/logs: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	readLines := make([]string, 0, 2)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			readLines = append(readLines, line)
+		}
+	}
+
+	if len(readLines) != 2 {
+		t.Fatalf("want 2 SSE lines, got %d (%v)", len(readLines), readLines)
+	}
+}

--- a/api/internal/api/handler_version.go
+++ b/api/internal/api/handler_version.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+type versionResponse struct {
+	CurrentVersion   string     `json:"currentVersion"`
+	LatestVersion    string     `json:"latestVersion"`
+	ReleaseNotes     string     `json:"releaseNotes"`
+	PublishedAt      *time.Time `json:"publishedAt,omitempty"`
+	UpgradeAvailable bool       `json:"upgradeAvailable"`
+	CachedAt         *time.Time `json:"cachedAt,omitempty"`
+}
+
+func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request) {
+	snapshot, err := h.versions.Snapshot(r.Context())
+	if err != nil {
+		log.Printf("getVersion: check latest release: %v", err)
+	}
+
+	resp := versionResponse{
+		CurrentVersion:   snapshot.CurrentVersion,
+		LatestVersion:    snapshot.LatestVersion,
+		ReleaseNotes:     snapshot.ReleaseNotes,
+		UpgradeAvailable: snapshot.UpgradeAvailable,
+	}
+
+	if !snapshot.PublishedAt.IsZero() {
+		publishedAt := snapshot.PublishedAt.UTC()
+		resp.PublishedAt = &publishedAt
+	}
+	if !snapshot.CachedAt.IsZero() {
+		cachedAt := snapshot.CachedAt.UTC()
+		resp.CachedAt = &cachedAt
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/api/internal/upgrade/runner.go
+++ b/api/internal/upgrade/runner.go
@@ -1,0 +1,254 @@
+package upgrade
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type State string
+
+const (
+	StateIdle    State = "idle"
+	StateRunning State = "running"
+	StateDone    State = "done"
+	StateFailed  State = "failed"
+)
+
+const defaultLogPath = "/tmp/dirigent-upgrade.log"
+
+var (
+	ErrAlreadyRunning = errors.New("upgrade already running")
+	ErrNotRunning     = errors.New("upgrade is not running")
+)
+
+type processBuilder func(targetVersion string) (processConfig, error)
+
+type processConfig struct {
+	path    string
+	args    []string
+	env     []string
+	cleanup func()
+}
+
+type Runner struct {
+	mu          sync.Mutex
+	state       State
+	logPath     string
+	build       processBuilder
+	subscribers map[int]chan string
+	nextID      int
+}
+
+func New() *Runner {
+	return NewWithBuilder(defaultLogPath, defaultProcessBuilder)
+}
+
+func NewWithBuilder(logPath string, builder processBuilder) *Runner {
+	if logPath == "" {
+		logPath = defaultLogPath
+	}
+	if builder == nil {
+		builder = defaultProcessBuilder
+	}
+
+	return &Runner{state: StateIdle, logPath: logPath, build: builder, subscribers: make(map[int]chan string)}
+}
+
+func (r *Runner) Start(targetVersion string) error {
+	r.mu.Lock()
+	if r.state == StateRunning {
+		r.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	r.state = StateRunning
+	r.mu.Unlock()
+
+	cfg, err := r.build(targetVersion)
+	if err != nil {
+		r.finish(StateFailed)
+		return err
+	}
+
+	stdin, err := os.Open("/dev/null")
+	if err != nil {
+		r.finish(StateFailed)
+		cfg.cleanup()
+		return fmt.Errorf("open /dev/null: %w", err)
+	}
+
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		stdin.Close()
+		r.finish(StateFailed)
+		cfg.cleanup()
+		return fmt.Errorf("create output pipe: %w", err)
+	}
+
+	logFile, err := os.OpenFile(r.logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		stdin.Close()
+		pipeReader.Close()
+		pipeWriter.Close()
+		r.finish(StateFailed)
+		cfg.cleanup()
+		return fmt.Errorf("open upgrade log file: %w", err)
+	}
+
+	proc, err := os.StartProcess(cfg.path, cfg.args, &os.ProcAttr{
+		Env:   cfg.env,
+		Files: []*os.File{stdin, pipeWriter, pipeWriter},
+		Sys:   &syscall.SysProcAttr{Setsid: true},
+	})
+	stdin.Close()
+	pipeWriter.Close()
+	if err != nil {
+		pipeReader.Close()
+		logFile.Close()
+		r.finish(StateFailed)
+		cfg.cleanup()
+		return fmt.Errorf("start upgrade process: %w", err)
+	}
+
+	go r.collect(proc, pipeReader, logFile, cfg.cleanup)
+	return nil
+}
+
+func (r *Runner) Subscribe() (<-chan string, func(), error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.state != StateRunning {
+		return nil, nil, ErrNotRunning
+	}
+
+	id := r.nextID
+	r.nextID++
+	ch := make(chan string, 32)
+	r.subscribers[id] = ch
+
+	unsubscribe := func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		sub, ok := r.subscribers[id]
+		if !ok {
+			return
+		}
+		delete(r.subscribers, id)
+		close(sub)
+	}
+
+	return ch, unsubscribe, nil
+}
+
+func (r *Runner) IsRunning() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.state == StateRunning
+}
+
+func (r *Runner) collect(proc *os.Process, pipeReader, logFile *os.File, cleanup func()) {
+	defer pipeReader.Close()
+	defer logFile.Close()
+	defer cleanup()
+
+	scanner := bufio.NewScanner(pipeReader)
+	for scanner.Scan() {
+		line := scanner.Text()
+		_, _ = logFile.WriteString(line + "\n")
+		r.broadcast(line)
+	}
+
+	state := StateDone
+	if err := scanner.Err(); err != nil {
+		state = StateFailed
+	}
+
+	ps, err := proc.Wait()
+	if err != nil || !ps.Success() {
+		state = StateFailed
+	}
+
+	r.finish(state)
+}
+
+func (r *Runner) broadcast(line string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, ch := range r.subscribers {
+		select {
+		case ch <- line:
+		default:
+			delete(r.subscribers, id)
+			close(ch)
+		}
+	}
+}
+
+func (r *Runner) finish(state State) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.state = state
+	for id, ch := range r.subscribers {
+		delete(r.subscribers, id)
+		close(ch)
+	}
+}
+
+func defaultProcessBuilder(targetVersion string) (processConfig, error) {
+	if targetVersion == "" {
+		targetVersion = "latest"
+	}
+
+	scriptURL := "https://github.com/ercadev/dirigent-releases/releases/latest/download/install.sh"
+	if targetVersion != "latest" {
+		scriptURL = fmt.Sprintf("https://github.com/ercadev/dirigent-releases/releases/download/%s/install.sh", targetVersion)
+	}
+
+	resp, err := http.Get(scriptURL)
+	if err != nil {
+		return processConfig{}, fmt.Errorf("download install script: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return processConfig{}, fmt.Errorf("download install script status: %d", resp.StatusCode)
+	}
+
+	tmpFile, err := os.CreateTemp("", "dirigent-install-*.sh")
+	if err != nil {
+		return processConfig{}, fmt.Errorf("create temp install script: %w", err)
+	}
+
+	if _, err := bufio.NewReader(resp.Body).WriteTo(tmpFile); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		return processConfig{}, fmt.Errorf("write temp install script: %w", err)
+	}
+	if err := tmpFile.Chmod(0o700); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		return processConfig{}, fmt.Errorf("chmod temp install script: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpFile.Name())
+		return processConfig{}, fmt.Errorf("close temp install script: %w", err)
+	}
+
+	path := "/bin/bash"
+	args := []string{"bash", tmpFile.Name()}
+	env := append(os.Environ(), "DIRIGENT_VERSION="+targetVersion, "DIRIGENT_UPGRADE_STARTED_AT="+time.Now().UTC().Format(time.RFC3339))
+
+	return processConfig{
+		path: path,
+		args: args,
+		env:  env,
+		cleanup: func() {
+			_ = os.Remove(tmpFile.Name())
+		},
+	}, nil
+}

--- a/api/internal/upgrade/runner_test.go
+++ b/api/internal/upgrade/runner_test.go
@@ -1,0 +1,82 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStart_DoubleStartReturnsError(t *testing.T) {
+	scriptPath := writeScript(t, "#!/usr/bin/env bash\necho one\nsleep 0.2\necho two\n")
+	build := func(_ string) (processConfig, error) {
+		return processConfig{
+			path: "/bin/bash",
+			args: []string{"bash", scriptPath},
+			env:  os.Environ(),
+			cleanup: func() {
+			},
+		}, nil
+	}
+
+	r := NewWithBuilder(filepath.Join(t.TempDir(), "upgrade.log"), build)
+
+	if err := r.Start("v1.2.3"); err != nil {
+		t.Fatalf("first Start() error = %v", err)
+	}
+	if err := r.Start("v1.2.3"); err == nil {
+		t.Fatal("second Start() error = nil, want error")
+	}
+}
+
+func TestStart_LogLinesReadableFromChannel(t *testing.T) {
+	scriptPath := writeScript(t, "#!/usr/bin/env bash\necho hello\necho world\n")
+	build := func(_ string) (processConfig, error) {
+		return processConfig{
+			path: "/bin/bash",
+			args: []string{"bash", scriptPath},
+			env:  os.Environ(),
+			cleanup: func() {
+			},
+		}, nil
+	}
+
+	r := NewWithBuilder(filepath.Join(t.TempDir(), "upgrade.log"), build)
+	if err := r.Start("v1.2.3"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	ch, unsubscribe, err := r.Subscribe()
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer unsubscribe()
+
+	lines := make([]string, 0, 2)
+	timeout := time.After(3 * time.Second)
+	for len(lines) < 2 {
+		select {
+		case line, ok := <-ch:
+			if !ok {
+				t.Fatalf("channel closed before receiving all lines: got %v", lines)
+			}
+			lines = append(lines, line)
+		case <-timeout:
+			t.Fatalf("timed out waiting for lines, got %v", lines)
+		}
+	}
+
+	if lines[0] != "hello" || lines[1] != "world" {
+		t.Fatalf("unexpected lines: %v", lines)
+	}
+}
+
+func writeScript(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "dummy.sh")
+	if err := os.WriteFile(path, []byte(contents), 0o700); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+	return path
+}

--- a/api/internal/version/service.go
+++ b/api/internal/version/service.go
@@ -1,0 +1,220 @@
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+var latestReleaseURL = "https://api.github.com/repos/ercadev/dirigent-releases/releases/latest"
+
+type Snapshot struct {
+	CurrentVersion   string
+	LatestVersion    string
+	ReleaseNotes     string
+	PublishedAt      time.Time
+	UpgradeAvailable bool
+	CachedAt         time.Time
+}
+
+type Service struct {
+	currentVersion string
+	client         *http.Client
+	now            func() time.Time
+	ttl            time.Duration
+
+	mu     sync.RWMutex
+	cached cachedRelease
+	hasHit bool
+}
+
+type cachedRelease struct {
+	latestVersion string
+	releaseNotes  string
+	publishedAt   time.Time
+	cachedAt      time.Time
+}
+
+type latestReleaseResponse struct {
+	TagName     string `json:"tag_name"`
+	Body        string `json:"body"`
+	PublishedAt string `json:"published_at"`
+}
+
+type latestRelease struct {
+	TagName     string
+	Body        string
+	PublishedAt time.Time
+}
+
+func New(currentVersion string) *Service {
+	if currentVersion == "" {
+		currentVersion = "dev"
+	}
+
+	return &Service{
+		currentVersion: currentVersion,
+		client:         &http.Client{Timeout: 10 * time.Second},
+		now:            time.Now,
+		ttl:            time.Hour,
+	}
+}
+
+func NewWithOptions(currentVersion string, client *http.Client, now func() time.Time, ttl time.Duration) *Service {
+	if currentVersion == "" {
+		currentVersion = "dev"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	if now == nil {
+		now = time.Now
+	}
+	if ttl <= 0 {
+		ttl = time.Hour
+	}
+
+	return &Service{currentVersion: currentVersion, client: client, now: now, ttl: ttl}
+}
+
+func (s *Service) Snapshot(ctx context.Context) (Snapshot, error) {
+	s.mu.RLock()
+	if s.hasHit && s.now().Sub(s.cached.cachedAt) < s.ttl {
+		snap := s.snapshotFromCache(s.cached)
+		s.mu.RUnlock()
+		return snap, nil
+	}
+	stale := s.cached
+	hasStale := s.hasHit
+	s.mu.RUnlock()
+
+	release, err := s.fetchLatestRelease(ctx)
+	if err != nil {
+		if hasStale {
+			return s.snapshotFromCache(stale), nil
+		}
+		return Snapshot{
+			CurrentVersion:   s.currentVersion,
+			UpgradeAvailable: false,
+		}, err
+	}
+
+	cached := cachedRelease{
+		latestVersion: release.TagName,
+		releaseNotes:  release.Body,
+		publishedAt:   release.PublishedAt,
+		cachedAt:      s.now().UTC(),
+	}
+
+	s.mu.Lock()
+	s.cached = cached
+	s.hasHit = true
+	s.mu.Unlock()
+
+	return s.snapshotFromCache(cached), nil
+}
+
+func (s *Service) snapshotFromCache(cached cachedRelease) Snapshot {
+	return Snapshot{
+		CurrentVersion:   s.currentVersion,
+		LatestVersion:    cached.latestVersion,
+		ReleaseNotes:     cached.releaseNotes,
+		PublishedAt:      cached.publishedAt,
+		UpgradeAvailable: upgradeAvailable(s.currentVersion, cached.latestVersion),
+		CachedAt:         cached.cachedAt,
+	}
+}
+
+func (s *Service) fetchLatestRelease(ctx context.Context) (latestRelease, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return latestRelease{}, fmt.Errorf("new request: %w", err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return latestRelease{}, fmt.Errorf("call github latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return latestRelease{}, fmt.Errorf("unexpected github status: %d", resp.StatusCode)
+	}
+
+	var payload latestReleaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return latestRelease{}, fmt.Errorf("decode github latest release: %w", err)
+	}
+
+	release := latestRelease{
+		TagName: strings.TrimSpace(payload.TagName),
+		Body:    strings.TrimSpace(payload.Body),
+	}
+	if release.TagName == "" {
+		return latestRelease{}, fmt.Errorf("github latest release missing tag_name")
+	}
+
+	if payload.PublishedAt != "" {
+		at, err := time.Parse(time.RFC3339, payload.PublishedAt)
+		if err != nil {
+			return latestRelease{}, fmt.Errorf("parse published_at: %w", err)
+		}
+		release.PublishedAt = at.UTC()
+	}
+
+	return release, nil
+}
+
+func upgradeAvailable(currentVersion, latestVersion string) bool {
+	if currentVersion == "" || latestVersion == "" {
+		return false
+	}
+	if currentVersion == "dev" {
+		return false
+	}
+
+	current, ok := parseSemver(currentVersion)
+	if !ok {
+		return false
+	}
+	latest, ok := parseSemver(latestVersion)
+	if !ok {
+		return false
+	}
+
+	if current[0] != latest[0] {
+		return current[0] < latest[0]
+	}
+	if current[1] != latest[1] {
+		return current[1] < latest[1]
+	}
+	return current[2] < latest[2]
+}
+
+func parseSemver(raw string) ([3]int, bool) {
+	var out [3]int
+	raw = strings.TrimSpace(strings.TrimPrefix(raw, "v"))
+	if raw == "" {
+		return out, false
+	}
+
+	parts := strings.Split(raw, ".")
+	if len(parts) < 3 {
+		return out, false
+	}
+
+	for i := 0; i < 3; i++ {
+		n, err := strconv.Atoi(parts[i])
+		if err != nil || n < 0 {
+			return out, false
+		}
+		out[i] = n
+	}
+
+	return out, true
+}

--- a/api/internal/version/service_test.go
+++ b/api/internal/version/service_test.go
@@ -1,0 +1,113 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSnapshot_UpgradeAvailableComparison(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		latestVersion  string
+		wantUpgrade    bool
+	}{
+		{name: "current lower than latest", currentVersion: "v1.2.2", latestVersion: "v1.2.3", wantUpgrade: true},
+		{name: "current equals latest", currentVersion: "v1.2.3", latestVersion: "v1.2.3", wantUpgrade: false},
+		{name: "dev sentinel", currentVersion: "dev", latestVersion: "v1.2.3", wantUpgrade: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, time.February, 24, 10, 0, 0, 0, time.UTC)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprintf(w, `{"tag_name":"%s","body":"notes","published_at":"2026-02-24T09:00:00Z"}`+"\n", tt.latestVersion)
+			}))
+			defer server.Close()
+
+			oldURL := latestReleaseURL
+			latestReleaseURL = server.URL
+			defer func() { latestReleaseURL = oldURL }()
+
+			svc := NewWithOptions(tt.currentVersion, server.Client(), func() time.Time { return now }, time.Hour)
+
+			snapshot, err := svc.Snapshot(context.Background())
+			if err != nil {
+				t.Fatalf("Snapshot() error = %v", err)
+			}
+			if snapshot.UpgradeAvailable != tt.wantUpgrade {
+				t.Fatalf("UpgradeAvailable = %v, want %v", snapshot.UpgradeAvailable, tt.wantUpgrade)
+			}
+		})
+	}
+}
+
+func TestSnapshot_ParsesGitHubResponse(t *testing.T) {
+	now := time.Date(2026, time.February, 24, 10, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"tag_name":"v1.4.0","body":"release notes","published_at":"2026-02-23T12:34:56Z"}`)
+	}))
+	defer server.Close()
+
+	oldURL := latestReleaseURL
+	latestReleaseURL = server.URL
+	defer func() { latestReleaseURL = oldURL }()
+
+	svc := NewWithOptions("v1.3.0", server.Client(), func() time.Time { return now }, time.Hour)
+
+	snapshot, err := svc.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	if snapshot.CurrentVersion != "v1.3.0" {
+		t.Fatalf("CurrentVersion = %q, want v1.3.0", snapshot.CurrentVersion)
+	}
+	if snapshot.LatestVersion != "v1.4.0" {
+		t.Fatalf("LatestVersion = %q, want v1.4.0", snapshot.LatestVersion)
+	}
+	if snapshot.ReleaseNotes != "release notes" {
+		t.Fatalf("ReleaseNotes = %q, want release notes", snapshot.ReleaseNotes)
+	}
+	if !snapshot.PublishedAt.Equal(time.Date(2026, time.February, 23, 12, 34, 56, 0, time.UTC)) {
+		t.Fatalf("PublishedAt = %s, want 2026-02-23T12:34:56Z", snapshot.PublishedAt)
+	}
+	if !snapshot.CachedAt.Equal(now) {
+		t.Fatalf("CachedAt = %s, want %s", snapshot.CachedAt, now)
+	}
+}
+
+func TestSnapshot_UsesCacheWithinTTL(t *testing.T) {
+	base := time.Date(2026, time.February, 24, 10, 0, 0, 0, time.UTC)
+	currentTime := base
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_, _ = fmt.Fprint(w, `{"tag_name":"v1.0.1","body":"notes","published_at":"2026-02-24T08:00:00Z"}`)
+	}))
+	defer server.Close()
+
+	oldURL := latestReleaseURL
+	latestReleaseURL = server.URL
+	defer func() { latestReleaseURL = oldURL }()
+
+	svc := NewWithOptions("v1.0.0", server.Client(), func() time.Time { return currentTime }, time.Hour)
+
+	if _, err := svc.Snapshot(context.Background()); err != nil {
+		t.Fatalf("first Snapshot() error = %v", err)
+	}
+	currentTime = currentTime.Add(30 * time.Minute)
+	if _, err := svc.Snapshot(context.Background()); err != nil {
+		t.Fatalf("second Snapshot() error = %v", err)
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("GitHub API calls = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add backend self-update modules: `internal/version` (GitHub latest release fetch + 1h cache + semver comparison with `dev` sentinel) and `internal/upgrade` (detached subprocess runner with state guard and log fanout)
- add API endpoints for settings upgrade flow: `GET /api/version`, `POST /api/upgrade`, and `GET /api/upgrade/logs` with route registration and proper `202/409/404` behavior
- inject API binary version at build time in release workflow with `-ldflags \"-X main.version=${{ github.ref_name }}\"` while keeping orchestrator/proxy unchanged
- add tests for version logic/cache, upgrade double-start + log streaming behavior, and handler-level endpoint behavior

## Validation
- `go test ./...` (in `api`) passes

## Issue
- Closes #107