### PR TITLE
feat(dashboard): implement self-update settings workflow

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -46,7 +46,11 @@ DIRIGENT_VERSION=v0.1.0 curl -fsSL https://github.com/ercadev/dirigent/releases/
 
 ### Upgrade
 
-Re-run the same install command. The installer stops all services, replaces the binaries, and restarts cleanly.
+Use the dashboard upgrade flow: open **Settings** and click **Upgrade** when a newer version is available.
+The dashboard streams installer logs in real time and prompts you to reload once the API is back online.
+
+If dashboard access is unavailable, you can still run the manual installer command. The installer stops all services,
+replaces the binaries, and restarts cleanly.
 
 ### Manage services
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -22,6 +22,19 @@ export type DeploymentLogEvent = {
   line: string
 }
 
+export type VersionInfo = {
+  currentVersion: string
+  latestVersion?: string
+  releaseNotes?: string
+  publishedAt?: string
+  upgradeAvailable: boolean
+  cachedAt?: string
+}
+
+export type UpgradeLogEvent = {
+  line: string
+}
+
 export type SystemStatusState = 'healthy' | 'degraded' | 'unavailable'
 
 export type APISystemStatus = {
@@ -134,4 +147,16 @@ export async function getSystemStatus(): Promise<SystemStatusSnapshot> {
   const res = await fetch('/api/system-status')
   if (!res.ok) throw new Error('Failed to fetch system status')
   return res.json()
+}
+
+export async function getVersionInfo(): Promise<VersionInfo> {
+  const res = await fetch('/api/version')
+  if (!res.ok) throw new Error('Failed to fetch version info')
+  return res.json()
+}
+
+export async function triggerUpgrade(): Promise<void> {
+  const res = await fetch('/api/upgrade', { method: 'POST' })
+  if (res.status === 409) throw new Error('Upgrade already in progress')
+  if (!res.ok) throw new Error('Failed to start upgrade')
 }

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { AlertTriangle, RefreshCw } from 'lucide-react'
+import { Button } from '../components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog'
+import { getVersionInfo, triggerUpgrade } from '../lib/api'
+import { UpgradeLogPanel } from '../settings/UpgradeLogPanel'
+import { useUpgradeLogsSSE } from '../settings/useUpgradeLogsSSE'
+import { useVersionCheck } from '../settings/useVersionCheck'
+
+function formatDate(value?: string) {
+  if (!value) return 'Unavailable'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return 'Unknown'
+  return parsed.toLocaleString()
+}
+
+export function SettingsPage() {
+  const queryClient = useQueryClient()
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [isUpgradeRunning, setIsUpgradeRunning] = useState(false)
+  const [awaitingReconnect, setAwaitingReconnect] = useState(false)
+  const [reconnectSawOffline, setReconnectSawOffline] = useState(false)
+  const [reconnectReady, setReconnectReady] = useState(false)
+  const [targetVersion, setTargetVersion] = useState<string | null>(null)
+  const [upgradeError, setUpgradeError] = useState<string | null>(null)
+  const [attemptId, setAttemptId] = useState(0)
+
+  const { currentVersion, latestVersion, publishedAt, releaseNotes, upgradeAvailable, cachedAt, isLoading, isError } =
+    useVersionCheck()
+  const { lines, streamClosed } = useUpgradeLogsSSE(isUpgradeRunning)
+
+  const reconnectProbe = useQuery({
+    queryKey: ['upgrade-reconnect-probe', attemptId],
+    queryFn: getVersionInfo,
+    enabled: awaitingReconnect,
+    retry: false,
+    refetchInterval: 3000,
+    refetchIntervalInBackground: true,
+  })
+
+  const finishUpgradeRun = (reconnectedVersion?: string) => {
+    setAwaitingReconnect(false)
+    setIsUpgradeRunning(false)
+    setReconnectReady(true)
+
+    if (reconnectProbe.data) {
+      queryClient.setQueryData(['version-check'], reconnectProbe.data)
+    }
+
+    if (targetVersion && reconnectedVersion && reconnectedVersion !== targetVersion) {
+      const lastLines = lines.slice(-8).join('\n')
+      setUpgradeError(
+        lastLines
+          ? `Upgrade did not reach ${targetVersion}. Last log lines:\n${lastLines}`
+          : `Upgrade did not reach ${targetVersion}.`,
+      )
+      return
+    }
+
+    setUpgradeError(null)
+  }
+
+  useEffect(() => {
+    if (!awaitingReconnect) return
+
+    if (reconnectProbe.isError) {
+      setReconnectSawOffline(true)
+      return
+    }
+
+    if (reconnectProbe.isSuccess && reconnectSawOffline) {
+      finishUpgradeRun(reconnectProbe.data.currentVersion)
+      return
+    }
+
+  }, [awaitingReconnect, reconnectProbe.isError, reconnectProbe.isSuccess, reconnectSawOffline, reconnectProbe.data])
+
+  const startUpgrade = useMutation({
+    mutationFn: triggerUpgrade,
+    onSuccess: () => {
+      setConfirmOpen(false)
+      setUpgradeError(null)
+      setReconnectReady(false)
+      setReconnectSawOffline(false)
+      setAwaitingReconnect(true)
+      setIsUpgradeRunning(true)
+      setTargetVersion(latestVersion ?? null)
+      setAttemptId(prev => prev + 1)
+    },
+    onError: error => {
+      setUpgradeError(error instanceof Error ? error.message : 'Failed to start upgrade')
+      setConfirmOpen(false)
+    },
+  })
+
+  const upgradeButtonLabel = useMemo(() => {
+    if (startUpgrade.isPending || isUpgradeRunning) return 'Upgrading...'
+    if (!latestVersion) return 'Upgrade unavailable'
+    return `Upgrade to ${latestVersion}`
+  }, [isUpgradeRunning, latestVersion, startUpgrade.isPending])
+
+  const canUpgrade = upgradeAvailable && !isUpgradeRunning && !startUpgrade.isPending
+
+  return (
+    <section className="space-y-6">
+      {isLoading && <p className="text-sm text-muted-foreground">Checking version information…</p>}
+
+      {isError && <p className="text-sm text-destructive">Unable to fetch version information right now.</p>}
+
+      {reconnectReady && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-emerald-300 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+          <p>Upgrade complete - click to reload.</p>
+          <Button type="button" size="sm" onClick={() => window.location.reload()}>
+            <RefreshCw className="h-4 w-4" />
+            Reload dashboard
+          </Button>
+        </div>
+      )}
+
+      {upgradeError && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-destructive">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p className="text-sm font-medium">Upgrade failed</p>
+          </div>
+          <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-xs">{upgradeError}</pre>
+        </div>
+      )}
+
+      <div className="rounded-lg border bg-card p-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h2 className="text-base font-semibold">Version</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Current release and upgrade availability.</p>
+          </div>
+          <Button type="button" disabled={!canUpgrade} onClick={() => setConfirmOpen(true)}>
+            {upgradeButtonLabel}
+          </Button>
+        </div>
+
+        <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-muted-foreground">Current version</dt>
+            <dd className="mt-1 font-mono text-foreground">{currentVersion}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Latest version</dt>
+            <dd className="mt-1 font-mono text-foreground">{latestVersion ?? 'Unavailable'}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Published</dt>
+            <dd className="mt-1 text-foreground">{formatDate(publishedAt)}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Cache refreshed</dt>
+            <dd className="mt-1 text-foreground">{formatDate(cachedAt)}</dd>
+          </div>
+        </dl>
+
+        <details className="mt-4 rounded-lg border bg-muted/20 p-3">
+          <summary className="cursor-pointer text-sm font-medium">Release notes</summary>
+          <pre className="mt-3 overflow-x-auto whitespace-pre-wrap font-mono text-xs text-muted-foreground">
+            {releaseNotes?.trim() || 'No release notes available.'}
+          </pre>
+        </details>
+      </div>
+
+      {(isUpgradeRunning || lines.length > 0) && (
+        <UpgradeLogPanel lines={lines} isRunning={isUpgradeRunning} streamClosed={streamClosed} />
+      )}
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm upgrade</DialogTitle>
+            <DialogDescription>
+              Dirigent services will briefly restart while the installer runs. Continue only if a short interruption is safe.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={() => startUpgrade.mutate()} disabled={startUpgrade.isPending}>
+              Start upgrade
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
+}

--- a/dashboard/src/router.tsx
+++ b/dashboard/src/router.tsx
@@ -7,7 +7,7 @@ import {
   redirect,
   useRouterState,
 } from '@tanstack/react-router'
-import { Boxes, Moon, Rocket, Server, Sun } from 'lucide-react'
+import { Boxes, Moon, Rocket, Server, Settings, Sun } from 'lucide-react'
 import { Button } from './components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './components/ui/card'
 import {
@@ -24,21 +24,33 @@ import {
 } from './components/ui/sidebar'
 import DeploymentList from './pages/DeploymentList'
 import { DeploymentDetailPage } from './pages/DeploymentDetailPage'
+import { SettingsPage } from './pages/SettingsPage'
 import { SystemStatusPage } from './pages/SystemStatusPage'
+import { useVersionCheck } from './settings/useVersionCheck'
 import { useTheme } from './theme'
 
 function DashboardLayout() {
   const pathname = useRouterState({ select: state => state.location.pathname })
   const { theme, toggleTheme } = useTheme()
+  const { upgradeAvailable } = useVersionCheck()
   const isSystemStatusPage = pathname === '/system-status'
+  const isSettingsPage = pathname === '/settings'
   const isDeploymentPage = pathname.startsWith('/deployments')
   const isDeploymentDetailPage = isDeploymentPage && pathname !== '/deployments'
-  const pageTitle = isSystemStatusPage ? 'System status' : isDeploymentDetailPage ? 'Deployment detail' : 'Deployments'
+  const pageTitle = isSystemStatusPage
+    ? 'System status'
+    : isSettingsPage
+      ? 'Settings'
+      : isDeploymentDetailPage
+        ? 'Deployment detail'
+        : 'Deployments'
   const pageDescription = isSystemStatusPage
     ? 'Observe API health and freshness.'
-    : isDeploymentDetailPage
-      ? 'Inspect deployment details and stream live logs.'
-      : 'Create, edit, and monitor your active deployments.'
+    : isSettingsPage
+      ? 'Manage product version and in-dashboard upgrades.'
+      : isDeploymentDetailPage
+        ? 'Inspect deployment details and stream live logs.'
+        : 'Create, edit, and monitor your active deployments.'
 
   return (
     <SidebarProvider>
@@ -79,6 +91,15 @@ function DashboardLayout() {
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton asChild isActive={pathname === '/settings'} size="lg" className="rounded-lg">
+                      <Link to="/settings">
+                        <Settings className="h-4 w-4 shrink-0" />
+                        <span>Settings</span>
+                        {upgradeAvailable && <span aria-label="Upgrade available" className="ml-auto h-2 w-2 rounded-full bg-orange-500" />}
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
                 </SidebarMenu>
               </SidebarGroupContent>
             </SidebarGroup>
@@ -87,7 +108,7 @@ function DashboardLayout() {
       </Sidebar>
 
       <SidebarInset>
-        <p className="mb-4 text-sm text-muted-foreground">{isSystemStatusPage ? 'Observability' : 'Deployments'}</p>
+        <p className="mb-4 text-sm text-muted-foreground">{isSystemStatusPage ? 'Observability' : isSettingsPage ? 'Configuration' : 'Deployments'}</p>
         {isDeploymentDetailPage ? (
           <div className="mx-auto w-full max-w-5xl space-y-4">
             <div>
@@ -142,7 +163,13 @@ const systemStatusRoute = createRoute({
   component: SystemStatusPage,
 })
 
-const routeTree = rootRoute.addChildren([indexRoute, deploymentsRoute, deploymentDetailRoute, systemStatusRoute])
+const settingsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/settings',
+  component: SettingsPage,
+})
+
+const routeTree = rootRoute.addChildren([indexRoute, deploymentsRoute, deploymentDetailRoute, systemStatusRoute, settingsRoute])
 
 export const router = createRouter({ routeTree })
 

--- a/dashboard/src/settings/UpgradeLogPanel.tsx
+++ b/dashboard/src/settings/UpgradeLogPanel.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+
+type Props = {
+  lines: string[]
+  isRunning: boolean
+  streamClosed: boolean
+}
+
+export function UpgradeLogPanel({ lines, isRunning, streamClosed }: Props) {
+  const logContainerRef = useRef<HTMLPreElement | null>(null)
+
+  useEffect(() => {
+    if (!logContainerRef.current) return
+    logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight
+  }, [lines])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Upgrade logs</CardTitle>
+        <CardDescription>
+          {isRunning
+            ? 'Live installer output while the upgrade runs.'
+            : streamClosed
+              ? 'Log stream closed.'
+              : 'Logs appear here after an upgrade starts.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <pre
+          ref={logContainerRef}
+          className="h-72 overflow-y-auto rounded-lg border bg-muted/30 p-4 font-mono text-xs leading-5 text-foreground whitespace-pre-wrap break-all"
+        >
+          {lines.length ? lines.join('\n') : 'Waiting for upgrade output...'}
+        </pre>
+      </CardContent>
+    </Card>
+  )
+}

--- a/dashboard/src/settings/useUpgradeLogsSSE.ts
+++ b/dashboard/src/settings/useUpgradeLogsSSE.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import type { UpgradeLogEvent } from '../lib/api'
+
+export function useUpgradeLogsSSE(enabled: boolean) {
+  const [lines, setLines] = useState<string[]>([])
+  const [streamClosed, setStreamClosed] = useState(false)
+
+  useEffect(() => {
+    if (!enabled) {
+      setLines([])
+      setStreamClosed(false)
+      return
+    }
+
+    setLines([])
+    setStreamClosed(false)
+    const es = new EventSource('/api/upgrade/logs')
+
+    es.onmessage = (event: MessageEvent) => {
+      try {
+        const { line }: UpgradeLogEvent = JSON.parse(event.data)
+        setLines(prev => [...prev, line])
+      } catch {
+        // ignore malformed events
+      }
+    }
+
+    es.onerror = () => {
+      setStreamClosed(true)
+      es.close()
+    }
+
+    return () => es.close()
+  }, [enabled])
+
+  return { lines, streamClosed }
+}

--- a/dashboard/src/settings/useVersionCheck.ts
+++ b/dashboard/src/settings/useVersionCheck.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+import { getVersionInfo, type VersionInfo } from '../lib/api'
+
+const VERSION_CHECK_INTERVAL_MS = 60 * 60 * 1000
+
+const FALLBACK_VERSION_INFO: VersionInfo = {
+  currentVersion: 'unknown',
+  upgradeAvailable: false,
+}
+
+export function useVersionCheck() {
+  const query = useQuery({
+    queryKey: ['version-check'],
+    queryFn: getVersionInfo,
+    staleTime: VERSION_CHECK_INTERVAL_MS,
+    refetchInterval: VERSION_CHECK_INTERVAL_MS,
+  })
+
+  return {
+    ...query,
+    currentVersion: query.data?.currentVersion ?? FALLBACK_VERSION_INFO.currentVersion,
+    latestVersion: query.data?.latestVersion,
+    publishedAt: query.data?.publishedAt,
+    releaseNotes: query.data?.releaseNotes,
+    upgradeAvailable: query.data?.upgradeAvailable ?? FALLBACK_VERSION_INFO.upgradeAvailable,
+    cachedAt: query.data?.cachedAt,
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `/settings` page with version details, release notes, upgrade confirmation, upgrade-state UX, and reconnect-to-reload handling
- add reusable settings hooks/components for low-frequency version checks and SSE-based upgrade log streaming, and wire upgrade API calls in the dashboard client
- add Settings navigation + upgrade-available sidebar dot badge, and update `GETTING_STARTED.md` to document in-dashboard upgrades

## Validation
- `bun run build` (dashboard)
- `bun test` currently fails due existing test-runtime incompatibilities in this repo (`vi.mocked`, `vi.stubGlobal`, `vi.unstubAllGlobals`) unrelated to this change

Closes #108