### PR TITLE
Fix current version display when running branch builds

### DIFF
--- a/api/internal/version/service.go
+++ b/api/internal/version/service.go
@@ -120,14 +120,34 @@ func (s *Service) Snapshot(ctx context.Context) (Snapshot, error) {
 }
 
 func (s *Service) snapshotFromCache(cached cachedRelease) Snapshot {
+	currentVersion := displayCurrentVersion(s.currentVersion, cached.latestVersion)
+	upgradeAvailable := upgradeAvailable(currentVersion, cached.latestVersion)
+
 	return Snapshot{
-		CurrentVersion:   s.currentVersion,
+		CurrentVersion:   currentVersion,
 		LatestVersion:    cached.latestVersion,
 		ReleaseNotes:     cached.releaseNotes,
 		PublishedAt:      cached.publishedAt,
-		UpgradeAvailable: upgradeAvailable(s.currentVersion, cached.latestVersion),
+		UpgradeAvailable: upgradeAvailable,
 		CachedAt:         cached.cachedAt,
 	}
+}
+
+func displayCurrentVersion(currentVersion, latestVersion string) string {
+	if _, ok := parseSemver(currentVersion); ok {
+		return currentVersion
+	}
+
+	normalizedCurrent := strings.ToLower(strings.TrimSpace(currentVersion))
+	if normalizedCurrent != "main" && normalizedCurrent != "master" {
+		return currentVersion
+	}
+
+	if _, ok := parseSemver(latestVersion); !ok {
+		return currentVersion
+	}
+
+	return latestVersion
 }
 
 func (s *Service) fetchLatestRelease(ctx context.Context) (latestRelease, error) {

--- a/api/internal/version/service_test.go
+++ b/api/internal/version/service_test.go
@@ -111,3 +111,46 @@ func TestSnapshot_UsesCacheWithinTTL(t *testing.T) {
 		t.Fatalf("GitHub API calls = %d, want 1", got)
 	}
 }
+
+func TestSnapshot_DisplayCurrentVersionForBranchBuilds(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		latestVersion  string
+		wantCurrent    string
+		wantUpgrade    bool
+	}{
+		{name: "main resolves to latest release", currentVersion: "main", latestVersion: "v1.2.3", wantCurrent: "v1.2.3", wantUpgrade: false},
+		{name: "master resolves to latest release", currentVersion: "master", latestVersion: "v1.2.3", wantCurrent: "v1.2.3", wantUpgrade: false},
+		{name: "main keeps branch name when latest is not semver", currentVersion: "main", latestVersion: "release-candidate", wantCurrent: "main", wantUpgrade: false},
+		{name: "dev keeps sentinel", currentVersion: "dev", latestVersion: "v1.2.3", wantCurrent: "dev", wantUpgrade: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, time.February, 24, 10, 0, 0, 0, time.UTC)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprintf(w, `{"tag_name":"%s","body":"notes","published_at":"2026-02-24T09:00:00Z"}`+"\n", tt.latestVersion)
+			}))
+			defer server.Close()
+
+			oldURL := latestReleaseURL
+			latestReleaseURL = server.URL
+			defer func() { latestReleaseURL = oldURL }()
+
+			svc := NewWithOptions(tt.currentVersion, server.Client(), func() time.Time { return now }, time.Hour)
+
+			snapshot, err := svc.Snapshot(context.Background())
+			if err != nil {
+				t.Fatalf("Snapshot() error = %v", err)
+			}
+
+			if snapshot.CurrentVersion != tt.wantCurrent {
+				t.Fatalf("CurrentVersion = %q, want %q", snapshot.CurrentVersion, tt.wantCurrent)
+			}
+			if snapshot.UpgradeAvailable != tt.wantUpgrade {
+				t.Fatalf("UpgradeAvailable = %v, want %v", snapshot.UpgradeAvailable, tt.wantUpgrade)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- The dashboard showed branch names like `main` as the "Current version" even when a released semver tag (e.g. `v0.12.0`) was available, which is confusing for users and prevents correct upgrade display.
- Upgrade availability must be determined from the displayed release version rather than the raw build identifier so the UI and upgrade flow behave correctly.

### Description
- Introduced `displayCurrentVersion` which returns the original `currentVersion` unless it is a branch identifier (`main`/`master`) and `latestVersion` is a valid semver, in which case it returns the `latestVersion` for display. (`api/internal/version/service.go`)
- Updated `snapshotFromCache` to use `displayCurrentVersion` for `CurrentVersion` and to compute `UpgradeAvailable` from that display-safe version. (`api/internal/version/service.go`)
- Added unit tests `TestSnapshot_DisplayCurrentVersionForBranchBuilds` to cover `main`, `master`, non-semver latest tags, and the `dev` sentinel behavior. (`api/internal/version/service_test.go`)

### Testing
- Ran the package tests with `go test ./api/internal/version` and they passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df23c2a448333903791509cfb52db)