### PR TITLE
feat(proxy): add configurable hardening profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,29 @@ Then `dirigent setup` will:
 - Register and start four systemd services that survive reboots
 - Create the `/var/lib/dirigent/` data directory and the `dirigent` Docker network
 - Offer security profiles in guided mode (`strict` is recommended)
+- Configure proxy hardening profiles (`standard` by default, `strict` recommended for internet-facing hosts)
 
 Re-running the installer performs an in-place upgrade.
+
+### Proxy hardening profiles
+
+Dirigent proxy supports three hardening levels:
+
+- `standard` (default): blocks sensitive file and dot-path probes like `/.env`, `/.git`, and `/.vscode`
+- `strict`: includes `standard` plus broader scanner-target blocks (`/swagger*`, `/actuator`, `/wp-*`, etc.) and tighter anti-scan throttling
+- `off`: disables proxy hardening checks
+
+Configure during setup:
+
+```bash
+sudo dirigent setup --proxy-hardening-profile strict
+```
+
+Or via environment variable:
+
+```bash
+sudo DIRIGENT_PROXY_HARDENING_PROFILE=strict dirigent setup
+```
 
 ### Ports
 

--- a/cli/cmd/dirigent/main.go
+++ b/cli/cmd/dirigent/main.go
@@ -64,6 +64,7 @@ func runSetup(args []string) error {
 	nonInteractive := fs.Bool("non-interactive", false, "Disable prompts")
 	yes := fs.Bool("yes", false, "Skip confirmation prompts")
 	profile := fs.String("profile", "", "Security profile: strict, standard, off")
+	proxyHardeningProfile := fs.String("proxy-hardening-profile", "", "Proxy hardening profile: strict, standard, off")
 	version := fs.String("version", "latest", "Dirigent version to install")
 	dashboardExpose := fs.Bool("dashboard-expose", false, "Expose dashboard via proxy")
 	dashboardDomain := fs.String("dashboard-domain", "", "Dashboard domain")
@@ -96,6 +97,20 @@ func runSetup(args []string) error {
 	case "strict", "standard", "off":
 	default:
 		return fmt.Errorf("invalid --profile %q (expected strict, standard, or off)", selectedProfile)
+	}
+
+	selectedProxyHardeningProfile := strings.TrimSpace(*proxyHardeningProfile)
+	if selectedProxyHardeningProfile == "" {
+		selectedProxyHardeningProfile = strings.TrimSpace(os.Getenv("DIRIGENT_PROXY_HARDENING_PROFILE"))
+	}
+	if selectedProxyHardeningProfile == "" {
+		selectedProxyHardeningProfile = selectedProfile
+	}
+
+	switch selectedProxyHardeningProfile {
+	case "strict", "standard", "off":
+	default:
+		return fmt.Errorf("invalid --proxy-hardening-profile %q (expected strict, standard, or off)", selectedProxyHardeningProfile)
 	}
 
 	dashboardPassword := ""
@@ -132,6 +147,7 @@ func runSetup(args []string) error {
 	env := append(os.Environ(),
 		"DIRIGENT_VERSION="+*version,
 		"DIRIGENT_SECURITY_PROFILE="+selectedProfile,
+		"DIRIGENT_PROXY_HARDENING_PROFILE="+selectedProxyHardeningProfile,
 	)
 	if *nonInteractive {
 		env = append(env, "DIRIGENT_NON_INTERACTIVE=1")
@@ -160,6 +176,7 @@ func setupUsage(parseErr error) error {
 	fmt.Fprintln(b, "  --non-interactive         Disable prompts")
 	fmt.Fprintln(b, "  --yes                     Skip confirmation prompts")
 	fmt.Fprintln(b, "  --profile <name>          Security profile: strict, standard, off")
+	fmt.Fprintln(b, "  --proxy-hardening-profile <name> Proxy hardening profile: strict, standard, off")
 	fmt.Fprintln(b, "  --version <value>         Version to install (default: latest)")
 	fmt.Fprintln(b, "  --dashboard-expose        Configure dashboard domain and basic auth")
 	fmt.Fprintln(b, "  --dashboard-domain <fqdn> Dashboard domain")

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -50,10 +50,16 @@ func main() {
 	if err != nil {
 		log.Fatalf("proxy: %v", err)
 	}
+	hardeningProfile, err := hardeningProfileFromEnv()
+	if err != nil {
+		log.Fatalf("proxy: %v", err)
+	}
 	if dashboardAuth != nil {
 		table.SetStatic(dashboardAuth.Domain, "localhost:3000")
 		log.Printf("proxy: registered dashboard domain %s -> localhost:3000", dashboardAuth.Domain)
 	}
+
+	log.Printf("proxy: hardening profile %s", hardeningProfile)
 
 	interval := 5 * time.Second
 	if v := os.Getenv("DIRIGENT_POLL_INTERVAL"); v != "" {
@@ -63,7 +69,7 @@ func main() {
 	}
 
 	p := poller.New(s, table, interval)
-	h := handler.New(table, dashboardAuth)
+	h := handler.New(table, dashboardAuth, handler.WithHardeningProfile(hardeningProfile))
 
 	hostPolicy := hostPolicyFromTable(table)
 	cacheDir := envOrDefault("DIRIGENT_CERT_CACHE_DIR", defaultCertCacheDir)
@@ -238,4 +244,14 @@ func dashboardAuthFromEnv() (*handler.DashboardAuth, error) {
 		Username: user,
 		Password: password,
 	}, nil
+}
+
+func hardeningProfileFromEnv() (handler.HardeningProfile, error) {
+	profile := handler.HardeningProfile(strings.ToLower(strings.TrimSpace(envOrDefault("DIRIGENT_PROXY_HARDENING_PROFILE", string(handler.HardeningStandard)))))
+	switch profile {
+	case handler.HardeningOff, handler.HardeningStandard, handler.HardeningStrict:
+		return profile, nil
+	default:
+		return "", fmt.Errorf("DIRIGENT_PROXY_HARDENING_PROFILE must be one of: off, standard, strict")
+	}
 }

--- a/proxy/cmd/proxy/main_test.go
+++ b/proxy/cmd/proxy/main_test.go
@@ -175,3 +175,35 @@ func TestDashboardAuthFromEnv_IgnoresCredentialsWithoutDomain(t *testing.T) {
 		t.Fatal("want nil config when dashboard domain is unset")
 	}
 }
+
+func TestHardeningProfileFromEnv_DefaultsToStandard(t *testing.T) {
+	t.Setenv("DIRIGENT_PROXY_HARDENING_PROFILE", "")
+
+	profile, err := hardeningProfileFromEnv()
+	if err != nil {
+		t.Fatalf("hardeningProfileFromEnv: %v", err)
+	}
+	if profile != handler.HardeningStandard {
+		t.Fatalf("want profile %s, got %s", handler.HardeningStandard, profile)
+	}
+}
+
+func TestHardeningProfileFromEnv_AcceptsStrict(t *testing.T) {
+	t.Setenv("DIRIGENT_PROXY_HARDENING_PROFILE", " STRICT ")
+
+	profile, err := hardeningProfileFromEnv()
+	if err != nil {
+		t.Fatalf("hardeningProfileFromEnv: %v", err)
+	}
+	if profile != handler.HardeningStrict {
+		t.Fatalf("want profile %s, got %s", handler.HardeningStrict, profile)
+	}
+}
+
+func TestHardeningProfileFromEnv_RejectsInvalidValue(t *testing.T) {
+	t.Setenv("DIRIGENT_PROXY_HARDENING_PROFILE", "aggressive")
+
+	if _, err := hardeningProfileFromEnv(); err == nil {
+		t.Fatal("want validation error for invalid profile")
+	}
+}

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/ercadev/dirigent/proxy/internal/middleware"
 )
@@ -25,7 +27,21 @@ type RoutingTable interface {
 type Handler struct {
 	table         RoutingTable
 	dashboardAuth *DashboardAuth
+	hardening     HardeningProfile
+	scanner       *scannerLimiter
 }
+
+// HardeningProfile controls request filtering and anti-scan behavior.
+type HardeningProfile string
+
+const (
+	HardeningOff      HardeningProfile = "off"
+	HardeningStandard HardeningProfile = "standard"
+	HardeningStrict   HardeningProfile = "strict"
+)
+
+// Option customizes handler behavior.
+type Option func(*Handler)
 
 // DashboardAuth configures host-scoped authentication for the dashboard domain.
 type DashboardAuth struct {
@@ -35,8 +51,23 @@ type DashboardAuth struct {
 }
 
 // New creates a Handler backed by the given routing table.
-func New(table RoutingTable, dashboardAuth *DashboardAuth) *Handler {
-	return &Handler{table: table, dashboardAuth: dashboardAuth}
+func New(table RoutingTable, dashboardAuth *DashboardAuth, options ...Option) *Handler {
+	h := &Handler{table: table, dashboardAuth: dashboardAuth, hardening: HardeningStandard}
+	for _, apply := range options {
+		if apply != nil {
+			apply(h)
+		}
+	}
+	h.hardening = normalizeHardeningProfile(h.hardening)
+	h.scanner = newScannerLimiter(h.hardening)
+	return h
+}
+
+// WithHardeningProfile applies proxy hardening rules.
+func WithHardeningProfile(profile HardeningProfile) Option {
+	return func(h *Handler) {
+		h.hardening = profile
+	}
 }
 
 // RegisterRoutes wires the proxy catch-all and the internal control API into mux.
@@ -63,6 +94,21 @@ func (h *Handler) health(w http.ResponseWriter, _ *http.Request) {
 // proxy routes inbound requests to the upstream registered for the Host header.
 // Returns 404 for unknown domains and 502 when the upstream is unreachable.
 func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
+	now := time.Now()
+	client := clientIP(r)
+	if h.scanner != nil && client != "" && h.scanner.IsBlocked(client, now) {
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	if shouldBlockPath(r.URL.Path, h.hardening) {
+		if h.scanner != nil && client != "" {
+			h.scanner.RecordSuspicious(client, now)
+		}
+		http.NotFound(w, r)
+		return
+	}
+
 	host := r.Host
 	// Strip port if present (e.g. "example.com:80" → "example.com").
 	if bare, _, err := net.SplitHostPort(host); err == nil {
@@ -133,4 +179,160 @@ func normalizeDomain(domain string) string {
 	domain = strings.TrimSpace(domain)
 	domain = strings.TrimSuffix(domain, ".")
 	return strings.ToLower(domain)
+}
+
+func normalizeHardeningProfile(profile HardeningProfile) HardeningProfile {
+	switch HardeningProfile(strings.ToLower(strings.TrimSpace(string(profile)))) {
+	case HardeningOff:
+		return HardeningOff
+	case HardeningStrict:
+		return HardeningStrict
+	default:
+		return HardeningStandard
+	}
+}
+
+func shouldBlockPath(path string, profile HardeningProfile) bool {
+	if normalizeHardeningProfile(profile) == HardeningOff {
+		return false
+	}
+
+	p := strings.ToLower(strings.TrimSpace(path))
+	if p == "" {
+		p = "/"
+	}
+
+	for _, prefix := range []string{"/.git", "/.env", "/.vscode", "/.idea", "/.aws", "/.ssh", "/.svn", "/.hg"} {
+		if hasPathPrefix(p, prefix) {
+			return true
+		}
+	}
+
+	for _, exact := range []string{"/.ds_store", "/docker-compose.yml", "/docker-compose.yaml"} {
+		if p == exact {
+			return true
+		}
+	}
+
+	if normalizeHardeningProfile(profile) != HardeningStrict {
+		return false
+	}
+
+	for _, prefix := range []string{"/wp-admin", "/wp-includes", "/actuator", "/swagger", "/api-docs", "/debug", "/telescope", "/server-status", "/phpmyadmin"} {
+		if hasPathPrefix(p, prefix) {
+			return true
+		}
+	}
+
+	for _, exact := range []string{"/wp-login.php", "/xmlrpc.php", "/info.php", "/phpinfo.php", "/v2/_catalog"} {
+		if p == exact {
+			return true
+		}
+	}
+
+	for _, prefix := range []string{"/swagger-", "/v2/api-docs", "/v3/api-docs"} {
+		if strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasPathPrefix(path, prefix string) bool {
+	if path == prefix {
+		return true
+	}
+	if strings.HasPrefix(path, prefix+"/") {
+		return true
+	}
+	if prefix == "/.env" && strings.HasPrefix(path, "/.env.") {
+		return true
+	}
+	return false
+}
+
+type scannerLimiter struct {
+	mu        sync.Mutex
+	entries   map[string]scannerEntry
+	window    time.Duration
+	threshold int
+	blockFor  time.Duration
+}
+
+type scannerEntry struct {
+	windowStart  time.Time
+	count        int
+	blockedUntil time.Time
+}
+
+func newScannerLimiter(profile HardeningProfile) *scannerLimiter {
+	switch normalizeHardeningProfile(profile) {
+	case HardeningOff:
+		return nil
+	case HardeningStrict:
+		return &scannerLimiter{entries: make(map[string]scannerEntry), window: time.Minute, threshold: 6, blockFor: 15 * time.Minute}
+	default:
+		return &scannerLimiter{entries: make(map[string]scannerEntry), window: time.Minute, threshold: 12, blockFor: 10 * time.Minute}
+	}
+}
+
+func (l *scannerLimiter) IsBlocked(ip string, now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	e, ok := l.entries[ip]
+	if !ok {
+		return false
+	}
+	if now.Before(e.blockedUntil) {
+		return true
+	}
+	if !e.blockedUntil.IsZero() {
+		e.blockedUntil = time.Time{}
+		e.windowStart = now
+		e.count = 0
+		l.entries[ip] = e
+	}
+	return false
+}
+
+func (l *scannerLimiter) RecordSuspicious(ip string, now time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	e := l.entries[ip]
+	if e.windowStart.IsZero() || now.Sub(e.windowStart) > l.window {
+		e.windowStart = now
+		e.count = 0
+	}
+	e.count++
+	if e.count >= l.threshold {
+		e.blockedUntil = now.Add(l.blockFor)
+		e.windowStart = now
+		e.count = 0
+	}
+	l.entries[ip] = e
+}
+
+func clientIP(r *http.Request) string {
+	forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
+	if forwarded != "" {
+		parts := strings.Split(forwarded, ",")
+		if len(parts) > 0 {
+			ip := strings.TrimSpace(parts[0])
+			if net.ParseIP(ip) != nil {
+				return ip
+			}
+		}
+	}
+
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err == nil && net.ParseIP(host) != nil {
+		return host
+	}
+	if net.ParseIP(strings.TrimSpace(r.RemoteAddr)) != nil {
+		return strings.TrimSpace(r.RemoteAddr)
+	}
+	return ""
 }

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -40,6 +40,12 @@ func newProxyServer(tbl *testTable) *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
+func newProxyServerWithOptions(tbl *testTable, options ...handler.Option) *httptest.Server {
+	mux := http.NewServeMux()
+	handler.New(tbl, nil, options...).RegisterRoutes(mux)
+	return httptest.NewServer(mux)
+}
+
 func newProxyServerWithDashboardAuth(tbl *testTable, auth *handler.DashboardAuth) *httptest.Server {
 	mux := http.NewServeMux()
 	handler.New(tbl, auth).RegisterRoutes(mux)
@@ -363,5 +369,123 @@ func TestProxy_NonDashboardDomainDoesNotRequireBasicAuth(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxy_StandardHardeningBlocksSensitivePaths(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", backend.Listener.Addr().String())
+
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/.env", nil)
+	req.Host = "example.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /.env: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxy_OffHardeningAllowsSensitivePaths(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.env" {
+			t.Fatalf("want path /.env, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", backend.Listener.Addr().String())
+
+	proxy := newProxyServerWithOptions(tbl, handler.WithHardeningProfile(handler.HardeningOff))
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/.env", nil)
+	req.Host = "example.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /.env: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxy_StrictHardeningBlocksScannerPaths(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", backend.Listener.Addr().String())
+
+	proxy := newProxyServerWithOptions(tbl, handler.WithHardeningProfile(handler.HardeningStrict))
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/swagger-ui.html", nil)
+	req.Host = "example.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /swagger-ui.html: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxy_StandardHardeningRateLimitsRepeatedScans(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", backend.Listener.Addr().String())
+
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	for i := 0; i < 12; i++ {
+		req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/.env", nil)
+		req.Host = "example.com"
+		req.Header.Set("X-Forwarded-For", "203.0.113.7")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("scan request %d: %v", i, err)
+		}
+		resp.Body.Close()
+	}
+
+	blocked, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	blocked.Host = "example.com"
+	blocked.Header.Set("X-Forwarded-For", "203.0.113.7")
+	resp, err := http.DefaultClient.Do(blocked)
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("want 429, got %d", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
## Summary
- add proxy hardening profiles (`standard`, `strict`, `off`) with `standard` as default and env-based configuration via `DIRIGENT_PROXY_HARDENING_PROFILE`
- block common sensitive/scanner paths before upstream proxying and add lightweight per-IP suspicious-scan throttling that returns `429`
- expose hardening selection in `dirigent setup` (`--proxy-hardening-profile`) and document recommended production usage in `README.md`

## Testing
- go test ./cli/... ./proxy/...