### PR TITLE
fix(version): show installed version separately from latest available

### DIFF
--- a/api/internal/version/service.go
+++ b/api/internal/version/service.go
@@ -120,7 +120,7 @@ func (s *Service) Snapshot(ctx context.Context) (Snapshot, error) {
 }
 
 func (s *Service) snapshotFromCache(cached cachedRelease) Snapshot {
-	currentVersion := displayCurrentVersion(s.currentVersion, cached.latestVersion)
+	currentVersion := s.currentVersion
 	upgradeAvailable := upgradeAvailable(currentVersion, cached.latestVersion)
 
 	return Snapshot{
@@ -131,23 +131,6 @@ func (s *Service) snapshotFromCache(cached cachedRelease) Snapshot {
 		UpgradeAvailable: upgradeAvailable,
 		CachedAt:         cached.cachedAt,
 	}
-}
-
-func displayCurrentVersion(currentVersion, latestVersion string) string {
-	if _, ok := parseSemver(currentVersion); ok {
-		return currentVersion
-	}
-
-	normalizedCurrent := strings.ToLower(strings.TrimSpace(currentVersion))
-	if normalizedCurrent != "main" && normalizedCurrent != "master" {
-		return currentVersion
-	}
-
-	if _, ok := parseSemver(latestVersion); !ok {
-		return currentVersion
-	}
-
-	return latestVersion
 }
 
 func (s *Service) fetchLatestRelease(ctx context.Context) (latestRelease, error) {

--- a/api/internal/version/service_test.go
+++ b/api/internal/version/service_test.go
@@ -112,7 +112,7 @@ func TestSnapshot_UsesCacheWithinTTL(t *testing.T) {
 	}
 }
 
-func TestSnapshot_DisplayCurrentVersionForBranchBuilds(t *testing.T) {
+func TestSnapshot_ReportsInstalledVersionForBranchBuilds(t *testing.T) {
 	tests := []struct {
 		name           string
 		currentVersion string
@@ -120,8 +120,8 @@ func TestSnapshot_DisplayCurrentVersionForBranchBuilds(t *testing.T) {
 		wantCurrent    string
 		wantUpgrade    bool
 	}{
-		{name: "main resolves to latest release", currentVersion: "main", latestVersion: "v1.2.3", wantCurrent: "v1.2.3", wantUpgrade: false},
-		{name: "master resolves to latest release", currentVersion: "master", latestVersion: "v1.2.3", wantCurrent: "v1.2.3", wantUpgrade: false},
+		{name: "main remains installed version", currentVersion: "main", latestVersion: "v1.2.3", wantCurrent: "main", wantUpgrade: false},
+		{name: "master remains installed version", currentVersion: "master", latestVersion: "v1.2.3", wantCurrent: "master", wantUpgrade: false},
 		{name: "main keeps branch name when latest is not semver", currentVersion: "main", latestVersion: "release-candidate", wantCurrent: "main", wantUpgrade: false},
 		{name: "dev keeps sentinel", currentVersion: "dev", latestVersion: "v1.2.3", wantCurrent: "dev", wantUpgrade: false},
 	}

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -39,7 +39,7 @@ export function SettingsPage() {
     refetchIntervalInBackground: true,
   })
 
-  const finishUpgradeRun = (reconnectedVersion?: string) => {
+  const finishUpgradeRun = (reconnectedCurrentVersion?: string, reconnectedLatestVersion?: string) => {
     setAwaitingReconnect(false)
     setIsUpgradeRunning(false)
     setReconnectReady(true)
@@ -48,7 +48,9 @@ export function SettingsPage() {
       queryClient.setQueryData(['version-check'], reconnectProbe.data)
     }
 
-    if (targetVersion && reconnectedVersion && reconnectedVersion !== targetVersion) {
+    const targetReached =
+      targetVersion && (reconnectedCurrentVersion === targetVersion || reconnectedLatestVersion === targetVersion)
+    if (targetVersion && !targetReached) {
       const lastLines = lines.slice(-8).join('\n')
       setUpgradeError(
         lastLines
@@ -70,7 +72,7 @@ export function SettingsPage() {
     }
 
     if (reconnectProbe.isSuccess && reconnectSawOffline) {
-      finishUpgradeRun(reconnectProbe.data.currentVersion)
+      finishUpgradeRun(reconnectProbe.data.currentVersion, reconnectProbe.data.latestVersion)
       return
     }
 
@@ -132,7 +134,7 @@ export function SettingsPage() {
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <h2 className="text-base font-semibold">Version</h2>
-            <p className="mt-1 text-sm text-muted-foreground">Current release and upgrade availability.</p>
+            <p className="mt-1 text-sm text-muted-foreground">Installed release and latest available version.</p>
           </div>
           <Button type="button" disabled={!canUpgrade} onClick={() => setConfirmOpen(true)}>
             {upgradeButtonLabel}
@@ -141,11 +143,11 @@ export function SettingsPage() {
 
         <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
           <div>
-            <dt className="text-muted-foreground">Current version</dt>
+            <dt className="text-muted-foreground">Installed version</dt>
             <dd className="mt-1 font-mono text-foreground">{currentVersion}</dd>
           </div>
           <div>
-            <dt className="text-muted-foreground">Latest version</dt>
+            <dt className="text-muted-foreground">Latest available</dt>
             <dd className="mt-1 font-mono text-foreground">{latestVersion ?? 'Unavailable'}</dd>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- keep `currentVersion` as the installed/runtime value instead of remapping `main`/`master` to the latest release tag
- update version service tests to assert branch builds report their installed identifier as current version
- clarify Settings labels to **Installed version** and **Latest available**, and prevent false upgrade-failed messages by accepting target match from reconnect latest version data

## Validation
- go test ./api/internal/version ./api/internal/api
- bun run build