### PR TITLE
feat(traffic): stream status and add paginated access logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ setup:
 # concurrently in a single terminal. Ctrl+C shuts down both processes cleanly.
 dev:
 	@trap 'kill 0' SIGINT; \
-	(cd api && DIRIGENT_DATA=/tmp/dirigent.json $(AIR)) & \
-	(cd orchestrator && DIRIGENT_DATA=/tmp/dirigent.json DIRIGENT_PROXY_HEALTH_URL=http://localhost:8090/internal/health $(AIR)) & \
-	(cd proxy && DIRIGENT_DATA=/tmp/dirigent.json DIRIGENT_PROXY_ADDR=:8090 $(AIR)) & \
+	(cd api && DIRIGENT_DATA=/tmp/dirigent.json DIRIGENT_PROXY_ACCESS_LOG_DIR=/tmp/dirigent-proxy-logs $(AIR)) & \
+	(cd orchestrator && DIRIGENT_DATA=/tmp/dirigent.json DIRIGENT_PROXY_HEALTH_URL=http://localhost:8090/internal/health DIRIGENT_PROXY_TRAFFIC_URL=http://localhost:8090/internal/traffic $(AIR)) & \
+	(cd proxy && DIRIGENT_DATA=/tmp/dirigent.json DIRIGENT_PROXY_ADDR=:8090 DIRIGENT_PROXY_ACCESS_LOG_DIR=/tmp/dirigent-proxy-logs $(AIR)) & \
 	(cd dashboard && bun run dev) & \
 	wait
 

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -76,6 +76,8 @@ type Handler struct {
 	store        Store
 	events       EventBus
 	dockerLogs   DockerLogs
+	statusEvents *systemStatusBroker
+	accessLogDir string
 	statusSource SystemStatusProvider
 	heartbeats   OrchestratorHeartbeatIngestor
 	docker       DockerConnectivityIngestor
@@ -131,7 +133,7 @@ func NewWithDependencies(s Store, eb EventBus, dl DockerLogs, statusSource Syste
 	cpuIngestor, _ := statusSource.(CPUUtilizationIngestor)
 	ramIngestor, _ := statusSource.(RAMUtilizationIngestor)
 
-	return &Handler{store: s, events: eb, dockerLogs: dl, statusSource: statusSource, heartbeats: heartbeatIngestor, docker: dockerIngestor, loadBalancer: loadBalancerIngestor, cpu: cpuIngestor, ram: ramIngestor, versions: versions, upgrade: upgrader}
+	return &Handler{store: s, events: eb, dockerLogs: dl, statusEvents: newSystemStatusBroker(), accessLogDir: proxyAccessLogDirFromEnv(), statusSource: statusSource, heartbeats: heartbeatIngestor, docker: dockerIngestor, loadBalancer: loadBalancerIngestor, cpu: cpuIngestor, ram: ramIngestor, versions: versions, upgrade: upgrader}
 }
 
 func buildAPIStoreChecker(s Store) func(context.Context) bool {
@@ -149,6 +151,8 @@ func buildAPIStoreChecker(s Store) func(context.Context) bool {
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/deployments", h.listDeployments)
 	mux.HandleFunc("GET /api/system-status", h.systemStatus)
+	mux.HandleFunc("GET /api/system-status/events", h.systemStatusEvents)
+	mux.HandleFunc("GET /api/load-balancer/access-logs", h.loadBalancerAccessLogs)
 	mux.HandleFunc("POST /api/system-status/orchestrator-heartbeat", h.recordOrchestratorHeartbeat)
 	mux.HandleFunc("GET /api/version", h.getVersion)
 	mux.HandleFunc("POST /api/upgrade", h.startUpgrade)
@@ -194,6 +198,13 @@ func orchestratorStaleAfterFromEnv() time.Duration {
 	}
 
 	return d
+}
+
+func proxyAccessLogDirFromEnv() string {
+	if dir := strings.TrimSpace(os.Getenv("DIRIGENT_PROXY_ACCESS_LOG_DIR")); dir != "" {
+		return dir
+	}
+	return "/var/lib/dirigent/logs/proxy"
 }
 
 const (

--- a/api/internal/api/handler_load_balancer_access_logs.go
+++ b/api/internal/api/handler_load_balancer_access_logs.go
@@ -1,0 +1,320 @@
+package api
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAccessLogsPageSize = 200
+	maxAccessLogsPageSize     = 500
+)
+
+type loadBalancerAccessLogEntry struct {
+	Timestamp    time.Time         `json:"timestamp"`
+	ClientIP     string            `json:"clientIp"`
+	Host         string            `json:"host"`
+	Method       string            `json:"method"`
+	Path         string            `json:"path"`
+	Query        string            `json:"query,omitempty"`
+	Status       int               `json:"status"`
+	DurationMs   int64             `json:"durationMs"`
+	BytesWritten int64             `json:"bytesWritten"`
+	Outcome      string            `json:"outcome"`
+	Headers      map[string]string `json:"headers,omitempty"`
+}
+
+type accessLogsCursor struct {
+	File          string `json:"file"`
+	OffsetFromEnd int    `json:"offsetFromEnd"`
+}
+
+type loadBalancerAccessLogsResponse struct {
+	Items      []loadBalancerAccessLogEntry `json:"items"`
+	HasMore    bool                         `json:"hasMore"`
+	NextCursor string                       `json:"nextCursor,omitempty"`
+}
+
+type accessLogsFilters struct {
+	Method string
+	Status int
+	Host   string
+	IP     string
+}
+
+func (h *Handler) loadBalancerAccessLogs(w http.ResponseWriter, r *http.Request) {
+	limit, err := parseAccessLogsLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	filters, err := parseAccessLogsFilters(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	cursor, err := decodeAccessLogsCursor(r.URL.Query().Get("cursor"))
+	if err != nil {
+		http.Error(w, "invalid cursor", http.StatusBadRequest)
+		return
+	}
+
+	items, next, hasMore, err := readAccessLogsPage(h.accessLogDir, cursor, filters, limit)
+	if err != nil {
+		http.Error(w, "failed to read access logs", http.StatusInternalServerError)
+		return
+	}
+
+	resp := loadBalancerAccessLogsResponse{Items: items, HasMore: hasMore}
+	if next != nil {
+		resp.NextCursor = encodeAccessLogsCursor(*next)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func parseAccessLogsFilters(r *http.Request) (accessLogsFilters, error) {
+	q := r.URL.Query()
+	filters := accessLogsFilters{
+		Method: strings.ToUpper(strings.TrimSpace(q.Get("method"))),
+		Host:   strings.ToLower(strings.TrimSpace(q.Get("host"))),
+		IP:     strings.TrimSpace(q.Get("ip")),
+	}
+
+	if rawStatus := strings.TrimSpace(q.Get("status")); rawStatus != "" {
+		status, err := strconv.Atoi(rawStatus)
+		if err != nil || status < 100 || status > 599 {
+			return accessLogsFilters{}, fmt.Errorf("status must be an HTTP status code")
+		}
+		filters.Status = status
+	}
+
+	if filters.Method != "" {
+		for _, ch := range filters.Method {
+			if ch < 'A' || ch > 'Z' {
+				return accessLogsFilters{}, fmt.Errorf("method must contain only letters")
+			}
+		}
+	}
+
+	return filters, nil
+}
+
+func parseAccessLogsLimit(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultAccessLogsPageSize, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("limit must be a positive integer")
+	}
+	if n > maxAccessLogsPageSize {
+		n = maxAccessLogsPageSize
+	}
+	return n, nil
+}
+
+func decodeAccessLogsCursor(raw string) (*accessLogsCursor, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	buf, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	var cursor accessLogsCursor
+	if err := json.Unmarshal(buf, &cursor); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(cursor.File) == "" || cursor.OffsetFromEnd < 0 {
+		return nil, errors.New("invalid cursor")
+	}
+	return &cursor, nil
+}
+
+func encodeAccessLogsCursor(cursor accessLogsCursor) string {
+	buf, _ := json.Marshal(cursor)
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+func readAccessLogsPage(dir string, cursor *accessLogsCursor, filters accessLogsFilters, limit int) ([]loadBalancerAccessLogEntry, *accessLogsCursor, bool, error) {
+	if limit <= 0 {
+		return []loadBalancerAccessLogEntry{}, nil, false, nil
+	}
+
+	files, err := listAccessLogFiles(dir)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if len(files) == 0 {
+		return []loadBalancerAccessLogEntry{}, nil, false, nil
+	}
+
+	fileIndex := 0
+	offset := 0
+	if cursor != nil {
+		idx := slices.Index(files, cursor.File)
+		if idx == -1 {
+			return []loadBalancerAccessLogEntry{}, nil, false, nil
+		}
+		fileIndex = idx
+		offset = cursor.OffsetFromEnd
+	}
+
+	items := make([]loadBalancerAccessLogEntry, 0, limit)
+	for i := fileIndex; i < len(files); i++ {
+		lines, err := readLogLines(filepath.Join(dir, files[i]))
+		if err != nil {
+			return nil, nil, false, err
+		}
+
+		startOffset := 0
+		if i == fileIndex {
+			startOffset = offset
+		}
+		for consumed := startOffset; consumed < len(lines); consumed++ {
+			idx := len(lines) - 1 - consumed
+			if idx < 0 {
+				break
+			}
+
+			line := strings.TrimSpace(lines[idx])
+			if line == "" {
+				continue
+			}
+			var entry loadBalancerAccessLogEntry
+			if err := json.Unmarshal([]byte(line), &entry); err != nil {
+				continue
+			}
+			if !entryMatchesAccessLogFilters(entry, filters) {
+				continue
+			}
+			items = append(items, entry)
+			if len(items) == limit {
+				next := accessLogsCursor{File: files[i], OffsetFromEnd: consumed + 1}
+				hasMore, hasMoreErr := hasMoreFilteredAccessLogs(dir, files, next, filters)
+				if hasMoreErr != nil {
+					return nil, nil, false, hasMoreErr
+				}
+				return items, &next, hasMore, nil
+			}
+		}
+	}
+
+	return items, nil, false, nil
+}
+
+func entryMatchesAccessLogFilters(entry loadBalancerAccessLogEntry, filters accessLogsFilters) bool {
+	if filters.Method != "" && strings.ToUpper(strings.TrimSpace(entry.Method)) != filters.Method {
+		return false
+	}
+	if filters.Status != 0 && entry.Status != filters.Status {
+		return false
+	}
+	if filters.Host != "" && !strings.Contains(strings.ToLower(strings.TrimSpace(entry.Host)), filters.Host) {
+		return false
+	}
+	if filters.IP != "" && !strings.Contains(strings.TrimSpace(entry.ClientIP), filters.IP) {
+		return false
+	}
+	return true
+}
+
+func hasMoreFilteredAccessLogs(dir string, files []string, cursor accessLogsCursor, filters accessLogsFilters) (bool, error) {
+	startFile := slices.Index(files, cursor.File)
+	if startFile == -1 {
+		return false, nil
+	}
+
+	for i := startFile; i < len(files); i++ {
+		lines, err := readLogLines(filepath.Join(dir, files[i]))
+		if err != nil {
+			return false, err
+		}
+
+		offset := 0
+		if i == startFile {
+			offset = cursor.OffsetFromEnd
+		}
+
+		for consumed := offset; consumed < len(lines); consumed++ {
+			idx := len(lines) - 1 - consumed
+			if idx < 0 {
+				break
+			}
+			line := strings.TrimSpace(lines[idx])
+			if line == "" {
+				continue
+			}
+			var entry loadBalancerAccessLogEntry
+			if err := json.Unmarshal([]byte(line), &entry); err != nil {
+				continue
+			}
+			if entryMatchesAccessLogFilters(entry, filters) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func listAccessLogFiles(logDir string) ([]string, error) {
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, "access-") && strings.HasSuffix(name, ".log") {
+			files = append(files, name)
+		}
+	}
+
+	slices.Sort(files)
+	slices.Reverse(files)
+	return files, nil
+}
+
+func readLogLines(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lines := make([]string, 0, 256)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
+}

--- a/api/internal/api/handler_record_orchestrator_heartbeat.go
+++ b/api/internal/api/handler_record_orchestrator_heartbeat.go
@@ -28,6 +28,16 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 		LoadBalancer *struct {
 			Responding *bool      `json:"responding"`
 			CheckedAt  *time.Time `json:"checkedAt"`
+			Traffic    *struct {
+				TotalRequests      *int64 `json:"totalRequests"`
+				SuspiciousRequests *int64 `json:"suspiciousRequests"`
+				BlockedRequests    *int64 `json:"blockedRequests"`
+				ActiveBlockedIPs   *int   `json:"activeBlockedIps"`
+				BlockedIPs         []struct {
+					IP           string     `json:"ip"`
+					BlockedUntil *time.Time `json:"blockedUntil"`
+				} `json:"blockedIps"`
+			} `json:"traffic"`
 		} `json:"loadBalancer"`
 		Host *struct {
 			CPU *struct {
@@ -89,7 +99,9 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 			checkedAt = body.LoadBalancer.CheckedAt.UTC()
 		}
 
-		if err := h.loadBalancer.RecordLoadBalancerHealth(r.Context(), *body.LoadBalancer.Responding, checkedAt); err != nil {
+		traffic := buildLoadBalancerTraffic(body.LoadBalancer.Traffic)
+
+		if err := h.loadBalancer.RecordLoadBalancerHealth(r.Context(), *body.LoadBalancer.Responding, checkedAt, traffic); err != nil {
 			http.Error(w, "failed to record load balancer health", http.StatusInternalServerError)
 			return
 		}
@@ -141,9 +153,55 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 		}
 	}
 
+	if h.statusEvents != nil {
+		h.statusEvents.Publish(h.currentSystemStatusSnapshot(r))
+	}
+
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func isValidUsagePercent(v float64) bool {
 	return v >= 0 && v <= 100
+}
+
+func buildLoadBalancerTraffic(in *struct {
+	TotalRequests      *int64 `json:"totalRequests"`
+	SuspiciousRequests *int64 `json:"suspiciousRequests"`
+	BlockedRequests    *int64 `json:"blockedRequests"`
+	ActiveBlockedIPs   *int   `json:"activeBlockedIps"`
+	BlockedIPs         []struct {
+		IP           string     `json:"ip"`
+		BlockedUntil *time.Time `json:"blockedUntil"`
+	} `json:"blockedIps"`
+}) *LoadBalancerTrafficSystemStatus {
+	if in == nil {
+		return nil
+	}
+
+	traffic := &LoadBalancerTrafficSystemStatus{}
+	if in.TotalRequests != nil {
+		traffic.TotalRequests = *in.TotalRequests
+	}
+	if in.SuspiciousRequests != nil {
+		traffic.SuspiciousRequests = *in.SuspiciousRequests
+	}
+	if in.BlockedRequests != nil {
+		traffic.BlockedRequests = *in.BlockedRequests
+	}
+	if in.ActiveBlockedIPs != nil {
+		traffic.ActiveBlockedIPs = *in.ActiveBlockedIPs
+	}
+
+	if len(in.BlockedIPs) > 0 {
+		traffic.BlockedIPs = make([]LoadBalancerBlockedIPStatus, 0, len(in.BlockedIPs))
+		for _, blocked := range in.BlockedIPs {
+			ip := blocked.IP
+			if ip == "" {
+				continue
+			}
+			traffic.BlockedIPs = append(traffic.BlockedIPs, LoadBalancerBlockedIPStatus{IP: ip, BlockedUntil: blocked.BlockedUntil})
+		}
+	}
+
+	return traffic
 }

--- a/api/internal/api/handler_system_status_events.go
+++ b/api/internal/api/handler_system_status_events.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type systemStatusBroker struct {
+	mu   sync.Mutex
+	subs map[chan SystemStatusSnapshot]struct{}
+}
+
+func newSystemStatusBroker() *systemStatusBroker {
+	return &systemStatusBroker{subs: make(map[chan SystemStatusSnapshot]struct{})}
+}
+
+func (b *systemStatusBroker) Subscribe() (<-chan SystemStatusSnapshot, func()) {
+	ch := make(chan SystemStatusSnapshot, 16)
+	b.mu.Lock()
+	b.subs[ch] = struct{}{}
+	b.mu.Unlock()
+
+	cancel := func() {
+		b.mu.Lock()
+		delete(b.subs, ch)
+		b.mu.Unlock()
+	}
+
+	return ch, cancel
+}
+
+func (b *systemStatusBroker) Publish(snapshot SystemStatusSnapshot) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for ch := range b.subs {
+		select {
+		case ch <- snapshot:
+		default:
+		}
+	}
+}
+
+func (h *Handler) systemStatusEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	ch, cancel := h.statusEvents.Subscribe()
+	defer cancel()
+
+	write := func(snapshot SystemStatusSnapshot) error {
+		data, err := json.Marshal(snapshot)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+			return err
+		}
+		flusher.Flush()
+		return nil
+	}
+
+	if err := write(h.currentSystemStatusSnapshot(r)); err != nil {
+		log.Printf("systemStatusEvents: write initial snapshot: %v", err)
+		return
+	}
+
+	keepAlive := time.NewTicker(20 * time.Second)
+	defer keepAlive.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-keepAlive.C:
+			if _, err := w.Write([]byte(": keepalive\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		case snapshot := <-ch:
+			if err := write(snapshot); err != nil {
+				log.Printf("systemStatusEvents: write snapshot: %v", err)
+				return
+			}
+		}
+	}
+}

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -478,6 +480,122 @@ func TestRecordOrchestratorHeartbeat_UpdatesLoadBalancerHealth(t *testing.T) {
 	}
 }
 
+func TestRecordOrchestratorHeartbeat_UpdatesLoadBalancerTrafficTelemetry(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	reqBody := `{"loadBalancer":{"responding":true,"traffic":{"totalRequests":201,"suspiciousRequests":19,"blockedRequests":4,"activeBlockedIps":2,"blockedIps":[{"ip":"203.0.113.7"},{"ip":"198.51.100.11"}]}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString(reqBody))
+	if err != nil {
+		t.Fatalf("POST heartbeat request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/system-status/orchestrator-heartbeat: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", resp.StatusCode)
+	}
+
+	statusResp, err := http.Get(srv.URL + "/api/system-status")
+	if err != nil {
+		t.Fatalf("GET /api/system-status: %v", err)
+	}
+	defer statusResp.Body.Close()
+
+	var body api.SystemStatusSnapshot
+	if err := json.NewDecoder(statusResp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.LoadBalancer.Traffic == nil {
+		t.Fatal("want load balancer traffic telemetry")
+	}
+	if body.LoadBalancer.Traffic.TotalRequests != 201 {
+		t.Fatalf("want total requests 201, got %d", body.LoadBalancer.Traffic.TotalRequests)
+	}
+	if body.LoadBalancer.Traffic.ActiveBlockedIPs != 2 {
+		t.Fatalf("want active blocked ips 2, got %d", body.LoadBalancer.Traffic.ActiveBlockedIPs)
+	}
+	if len(body.LoadBalancer.Traffic.BlockedIPs) != 2 {
+		t.Fatalf("want 2 blocked ips, got %d", len(body.LoadBalancer.Traffic.BlockedIPs))
+	}
+}
+
+func TestSystemStatusEvents_StreamSendsHeartbeatUpdates(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/system-status/events", nil)
+	if err != nil {
+		t.Fatalf("build events request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/system-status/events: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	readEvent := func(r *bufio.Reader) api.SystemStatusSnapshot {
+		t.Helper()
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			line, readErr := r.ReadString('\n')
+			if readErr != nil {
+				t.Fatalf("read stream line: %v", readErr)
+			}
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+			var snapshot api.SystemStatusSnapshot
+			if err := json.Unmarshal([]byte(payload), &snapshot); err != nil {
+				t.Fatalf("unmarshal stream payload: %v", err)
+			}
+			return snapshot
+		}
+		t.Fatal("timed out waiting for system-status event")
+		return api.SystemStatusSnapshot{}
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	_ = readEvent(reader) // initial snapshot
+
+	heartbeatReqBody := `{"loadBalancer":{"responding":false,"traffic":{"totalRequests":88,"blockedRequests":3,"activeBlockedIps":1,"blockedIps":[{"ip":"203.0.113.7"}]}}}`
+	heartbeatReq, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString(heartbeatReqBody))
+	if err != nil {
+		t.Fatalf("build heartbeat request: %v", err)
+	}
+	heartbeatReq.Header.Set("Content-Type", "application/json")
+
+	heartbeatResp, err := http.DefaultClient.Do(heartbeatReq)
+	if err != nil {
+		t.Fatalf("POST /api/system-status/orchestrator-heartbeat: %v", err)
+	}
+	heartbeatResp.Body.Close()
+
+	if heartbeatResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", heartbeatResp.StatusCode)
+	}
+
+	updated := readEvent(reader)
+	if updated.LoadBalancer.State != api.SystemStatusStateDegraded {
+		t.Fatalf("want degraded load balancer state, got %s", updated.LoadBalancer.State)
+	}
+	if updated.LoadBalancer.Traffic == nil || updated.LoadBalancer.Traffic.BlockedRequests != 3 {
+		t.Fatalf("want blocked request count 3, got %+v", updated.LoadBalancer.Traffic)
+	}
+}
+
 func TestRecordOrchestratorHeartbeat_RejectsInvalidHostMetricPercent(t *testing.T) {
 	srv := newTestServer(newMemStore())
 	defer srv.Close()
@@ -492,6 +610,170 @@ func TestRecordOrchestratorHeartbeat_RejectsInvalidHostMetricPercent(t *testing.
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("POST /api/system-status/orchestrator-heartbeat: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoadBalancerAccessLogs_PaginatesNewestFirst(t *testing.T) {
+	logDir := t.TempDir()
+	t.Setenv("DIRIGENT_PROXY_ACCESS_LOG_DIR", logDir)
+
+	writeAccessLogFile := func(name string, lines []string) {
+		t.Helper()
+		path := filepath.Join(logDir, name)
+		if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatalf("write access log file %s: %v", name, err)
+		}
+	}
+
+	writeAccessLogFile("access-2026-02-24-20.log", []string{
+		`{"timestamp":"2026-02-24T20:30:00Z","clientIp":"203.0.113.5","host":"api.example.com","method":"GET","path":"/health","status":200,"durationMs":4,"bytesWritten":12,"outcome":"proxied","headers":{"user-agent":"ua-3"}}`,
+		`{"timestamp":"2026-02-24T20:31:00Z","clientIp":"203.0.113.6","host":"api.example.com","method":"GET","path":"/ready","status":200,"durationMs":5,"bytesWritten":15,"outcome":"proxied","headers":{"user-agent":"ua-4"}}`,
+	})
+	writeAccessLogFile("access-2026-02-24-19.log", []string{
+		`{"timestamp":"2026-02-24T19:10:00Z","clientIp":"198.51.100.7","host":"api.example.com","method":"POST","path":"/deploy","status":201,"durationMs":12,"bytesWritten":80,"outcome":"proxied","headers":{"user-agent":"ua-2"}}`,
+		`{"timestamp":"2026-02-24T19:09:00Z","clientIp":"198.51.100.8","host":"api.example.com","method":"GET","path":"/metrics","status":200,"durationMs":6,"bytesWritten":22,"outcome":"proxied","headers":{"user-agent":"ua-1"}}`,
+	})
+
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/load-balancer/access-logs?limit=2")
+	if err != nil {
+		t.Fatalf("GET access logs page1: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var page1 struct {
+		Items []struct {
+			Path string `json:"path"`
+		} `json:"items"`
+		HasMore    bool   `json:"hasMore"`
+		NextCursor string `json:"nextCursor"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&page1); err != nil {
+		t.Fatalf("decode page1: %v", err)
+	}
+
+	if len(page1.Items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(page1.Items))
+	}
+	if page1.Items[0].Path != "/ready" || page1.Items[1].Path != "/health" {
+		t.Fatalf("unexpected page1 order: %+v", page1.Items)
+	}
+	if !page1.HasMore || page1.NextCursor == "" {
+		t.Fatalf("want next cursor and more=true, got hasMore=%v cursor=%q", page1.HasMore, page1.NextCursor)
+	}
+
+	resp2, err := http.Get(srv.URL + "/api/load-balancer/access-logs?limit=2&cursor=" + page1.NextCursor)
+	if err != nil {
+		t.Fatalf("GET access logs page2: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	var page2 struct {
+		Items []struct {
+			Path string `json:"path"`
+		} `json:"items"`
+		HasMore bool `json:"hasMore"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&page2); err != nil {
+		t.Fatalf("decode page2: %v", err)
+	}
+
+	if len(page2.Items) != 2 {
+		t.Fatalf("want 2 items in page2, got %d", len(page2.Items))
+	}
+	if page2.Items[0].Path != "/metrics" || page2.Items[1].Path != "/deploy" {
+		t.Fatalf("unexpected page2 order: %+v", page2.Items)
+	}
+	if page2.HasMore {
+		t.Fatal("want hasMore=false at end")
+	}
+}
+
+func TestLoadBalancerAccessLogs_InvalidCursorReturns400(t *testing.T) {
+	t.Setenv("DIRIGENT_PROXY_ACCESS_LOG_DIR", t.TempDir())
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/load-balancer/access-logs?cursor=!!!!")
+	if err != nil {
+		t.Fatalf("GET access logs: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoadBalancerAccessLogs_FiltersByMethodStatusHostAndIP(t *testing.T) {
+	logDir := t.TempDir()
+	t.Setenv("DIRIGENT_PROXY_ACCESS_LOG_DIR", logDir)
+
+	path := filepath.Join(logDir, "access-2026-02-24-20.log")
+	content := strings.Join([]string{
+		`{"timestamp":"2026-02-24T20:31:00Z","clientIp":"203.0.113.10","host":"api.example.com","method":"GET","path":"/health","status":200,"durationMs":2,"bytesWritten":10,"outcome":"proxied"}`,
+		`{"timestamp":"2026-02-24T20:32:00Z","clientIp":"198.51.100.8","host":"admin.example.com","method":"POST","path":"/login","status":401,"durationMs":5,"bytesWritten":15,"outcome":"unauthorized"}`,
+		`{"timestamp":"2026-02-24T20:33:00Z","clientIp":"203.0.113.7","host":"api.example.com","method":"POST","path":"/deploy","status":201,"durationMs":8,"bytesWritten":25,"outcome":"proxied"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write access log file: %v", err)
+	}
+
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	url := srv.URL + "/api/load-balancer/access-logs?method=POST&status=201&host=api.example&ip=203.0.113.7"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET filtered access logs: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Items []struct {
+			Path   string `json:"path"`
+			Method string `json:"method"`
+			Status int    `json:"status"`
+			Host   string `json:"host"`
+			IP     string `json:"clientIp"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(body.Items) != 1 {
+		t.Fatalf("want 1 filtered item, got %d", len(body.Items))
+	}
+	entry := body.Items[0]
+	if entry.Path != "/deploy" || entry.Method != "POST" || entry.Status != 201 || entry.Host != "api.example.com" || entry.IP != "203.0.113.7" {
+		t.Fatalf("unexpected filtered entry: %+v", entry)
+	}
+}
+
+func TestLoadBalancerAccessLogs_InvalidStatusFilterReturns400(t *testing.T) {
+	t.Setenv("DIRIGENT_PROXY_ACCESS_LOG_DIR", t.TempDir())
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/load-balancer/access-logs?status=abc")
+	if err != nil {
+		t.Fatalf("GET access logs: %v", err)
 	}
 	defer resp.Body.Close()
 

--- a/api/internal/api/system_status.go
+++ b/api/internal/api/system_status.go
@@ -47,10 +47,24 @@ type LoadBalancerSystemStatusChecks struct {
 	HealthcheckResponding bool `json:"healthcheckResponding"`
 }
 
+type LoadBalancerBlockedIPStatus struct {
+	IP           string     `json:"ip"`
+	BlockedUntil *time.Time `json:"blockedUntil,omitempty"`
+}
+
+type LoadBalancerTrafficSystemStatus struct {
+	TotalRequests      int64                         `json:"totalRequests"`
+	SuspiciousRequests int64                         `json:"suspiciousRequests"`
+	BlockedRequests    int64                         `json:"blockedRequests"`
+	ActiveBlockedIPs   int                           `json:"activeBlockedIps"`
+	BlockedIPs         []LoadBalancerBlockedIPStatus `json:"blockedIps,omitempty"`
+}
+
 type LoadBalancerSystemStatus struct {
-	State       SystemStatusState              `json:"state"`
-	LastUpdated *time.Time                     `json:"lastUpdated,omitempty"`
-	Checks      LoadBalancerSystemStatusChecks `json:"checks"`
+	State       SystemStatusState                `json:"state"`
+	LastUpdated *time.Time                       `json:"lastUpdated,omitempty"`
+	Checks      LoadBalancerSystemStatusChecks   `json:"checks"`
+	Traffic     *LoadBalancerTrafficSystemStatus `json:"traffic,omitempty"`
 }
 
 type DockerSystemStatusChecks struct {
@@ -103,7 +117,7 @@ type DockerConnectivityIngestor interface {
 }
 
 type LoadBalancerHealthIngestor interface {
-	RecordLoadBalancerHealth(ctx context.Context, responding bool, at time.Time) error
+	RecordLoadBalancerHealth(ctx context.Context, responding bool, at time.Time, traffic *LoadBalancerTrafficSystemStatus) error
 }
 
 // CPUUtilizationIngestor accepts host CPU utilization observations.
@@ -146,6 +160,7 @@ type dockerConnectivitySignal struct {
 type loadBalancerHealthSignal struct {
 	lastCheckedUTC time.Time
 	responding     bool
+	traffic        *LoadBalancerTrafficSystemStatus
 	hasSignal      bool
 }
 
@@ -291,15 +306,18 @@ func (p *defaultSystemStatusProvider) dockerStatus() DockerSystemStatus {
 	}
 }
 
-func (p *defaultSystemStatusProvider) RecordLoadBalancerHealth(_ context.Context, responding bool, at time.Time) error {
+func (p *defaultSystemStatusProvider) RecordLoadBalancerHealth(_ context.Context, responding bool, at time.Time, traffic *LoadBalancerTrafficSystemStatus) error {
 	if at.IsZero() {
 		at = p.now()
 	}
+
+	trafficCopy := cloneLoadBalancerTraffic(traffic)
 
 	p.loadBalancerMu.Lock()
 	p.loadBalancerSignal = loadBalancerHealthSignal{
 		lastCheckedUTC: at.UTC(),
 		responding:     responding,
+		traffic:        trafficCopy,
 		hasSignal:      true,
 	}
 	p.loadBalancerMu.Unlock()
@@ -334,7 +352,22 @@ func (p *defaultSystemStatusProvider) loadBalancerStatus() LoadBalancerSystemSta
 			ProcessRunning:        true,
 			HealthcheckResponding: signal.responding,
 		},
+		Traffic: cloneLoadBalancerTraffic(signal.traffic),
 	}
+}
+
+func cloneLoadBalancerTraffic(in *LoadBalancerTrafficSystemStatus) *LoadBalancerTrafficSystemStatus {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+	if len(in.BlockedIPs) > 0 {
+		out.BlockedIPs = make([]LoadBalancerBlockedIPStatus, len(in.BlockedIPs))
+		copy(out.BlockedIPs, in.BlockedIPs)
+	}
+
+	return &out
 }
 
 func (p *defaultSystemStatusProvider) RecordCPUUtilization(_ context.Context, usagePercent float64, at time.Time) error {
@@ -414,22 +447,35 @@ func (p *defaultSystemStatusProvider) ramStatus() HostMetricSystemStatus {
 func (h *Handler) systemStatus(w http.ResponseWriter, r *http.Request) {
 	snapshot, err := h.statusSource.Snapshot(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusServiceUnavailable, SystemStatusSnapshot{
-			API: APISystemStatus{
-				State:       SystemStatusStateUnavailable,
-				LastUpdated: time.Now().UTC(),
-			},
-			Orchestrator: OrchestratorSystemStatus{State: SystemStatusStateUnavailable},
-			LoadBalancer: LoadBalancerSystemStatus{State: SystemStatusStateUnavailable},
-			Docker:       DockerSystemStatus{State: SystemStatusStateUnavailable},
-			Host: HostSystemStatus{
-				CPU: HostMetricSystemStatus{State: SystemStatusStateUnavailable},
-				RAM: HostMetricSystemStatus{State: SystemStatusStateUnavailable},
-			},
-			Error: "system status unavailable",
-		})
+		writeJSON(w, http.StatusServiceUnavailable, unavailableSystemStatusSnapshot(time.Now().UTC()))
 		return
 	}
 
 	writeJSON(w, http.StatusOK, snapshot)
+}
+
+func (h *Handler) currentSystemStatusSnapshot(r *http.Request) SystemStatusSnapshot {
+	snapshot, err := h.statusSource.Snapshot(r.Context())
+	if err != nil {
+		return unavailableSystemStatusSnapshot(time.Now().UTC())
+	}
+
+	return snapshot
+}
+
+func unavailableSystemStatusSnapshot(now time.Time) SystemStatusSnapshot {
+	return SystemStatusSnapshot{
+		API: APISystemStatus{
+			State:       SystemStatusStateUnavailable,
+			LastUpdated: now,
+		},
+		Orchestrator: OrchestratorSystemStatus{State: SystemStatusStateUnavailable},
+		LoadBalancer: LoadBalancerSystemStatus{State: SystemStatusStateUnavailable},
+		Docker:       DockerSystemStatus{State: SystemStatusStateUnavailable},
+		Host: HostSystemStatus{
+			CPU: HostMetricSystemStatus{State: SystemStatusStateUnavailable},
+			RAM: HostMetricSystemStatus{State: SystemStatusStateUnavailable},
+		},
+		Error: "system status unavailable",
+	}
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -64,6 +64,16 @@ export type LoadBalancerSystemStatus = {
     processRunning: boolean
     healthcheckResponding: boolean
   }
+  traffic?: {
+    totalRequests: number
+    suspiciousRequests: number
+    blockedRequests: number
+    activeBlockedIps: number
+    blockedIps?: Array<{
+      ip: string
+      blockedUntil?: string
+    }>
+  }
 }
 
 export type DockerSystemStatus = {
@@ -92,6 +102,33 @@ export type SystemStatusSnapshot = {
   docker: DockerSystemStatus
   host: HostSystemStatus
   error?: string
+}
+
+export type LoadBalancerAccessLogEntry = {
+  timestamp: string
+  clientIp: string
+  host: string
+  method: string
+  path: string
+  query?: string
+  status: number
+  durationMs: number
+  bytesWritten: number
+  outcome: string
+  headers?: Record<string, string>
+}
+
+export type LoadBalancerAccessLogsPage = {
+  items: LoadBalancerAccessLogEntry[]
+  hasMore: boolean
+  nextCursor?: string
+}
+
+export type LoadBalancerAccessLogFilters = {
+  method?: string
+  status?: number
+  host?: string
+  ip?: string
 }
 
 export async function getDeployments(): Promise<Deployment[]> {
@@ -146,6 +183,33 @@ export async function deleteDeployment(id: string): Promise<void> {
 export async function getSystemStatus(): Promise<SystemStatusSnapshot> {
   const res = await fetch('/api/system-status')
   if (!res.ok) throw new Error('Failed to fetch system status')
+  return res.json()
+}
+
+export async function getLoadBalancerAccessLogs(
+  cursor?: string,
+  limit = 100,
+  filters?: LoadBalancerAccessLogFilters
+): Promise<LoadBalancerAccessLogsPage> {
+  const params = new URLSearchParams({ limit: String(limit) })
+  if (cursor) {
+    params.set('cursor', cursor)
+  }
+  if (filters?.method) {
+    params.set('method', filters.method)
+  }
+  if (typeof filters?.status === 'number') {
+    params.set('status', String(filters.status))
+  }
+  if (filters?.host) {
+    params.set('host', filters.host)
+  }
+  if (filters?.ip) {
+    params.set('ip', filters.ip)
+  }
+
+  const res = await fetch(`/api/load-balancer/access-logs?${params.toString()}`)
+  if (!res.ok) throw new Error('Failed to fetch load balancer access logs')
   return res.json()
 }
 

--- a/dashboard/src/system-status/SystemStatusPanel.test.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.test.tsx
@@ -6,6 +6,7 @@ import * as api from '../lib/api'
 
 vi.mock('../lib/api', () => ({
   getSystemStatus: vi.fn(),
+  getLoadBalancerAccessLogs: vi.fn(),
 }))
 
 function renderWithQuery(ui: React.ReactElement) {
@@ -19,6 +20,10 @@ function renderWithQuery(ui: React.ReactElement) {
 describe('SystemStatusPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(api.getLoadBalancerAccessLogs).mockResolvedValue({
+      items: [],
+      hasMore: false,
+    })
   })
 
   it('renders loading state while request is pending', () => {
@@ -245,6 +250,62 @@ describe('SystemStatusPanel', () => {
     expect(screen.getAllByText(/Reading: Unavailable/)).toHaveLength(2)
     expect(screen.getAllByText('unavailable telemetry')).toHaveLength(2)
     expect(screen.getAllByText(/No signal yet/, { selector: 'p' })).toHaveLength(3)
+  })
+
+  it('renders load balancer blocked IP telemetry', async () => {
+    const apiUpdated = '2026-02-22T12:00:00.000Z'
+    const blockedUntil = '2026-02-22T12:15:00.000Z'
+    vi.mocked(api.getSystemStatus).mockResolvedValue({
+      api: {
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+      },
+      orchestrator: {
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+      },
+      loadBalancer: {
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+        checks: {
+          processRunning: true,
+          healthcheckResponding: true,
+        },
+        traffic: {
+          totalRequests: 1200,
+          suspiciousRequests: 34,
+          blockedRequests: 7,
+          activeBlockedIps: 2,
+          blockedIps: [
+            { ip: '203.0.113.7', blockedUntil },
+            { ip: '198.51.100.11', blockedUntil },
+          ],
+        },
+      },
+      docker: {
+        state: 'healthy',
+        lastUpdated: apiUpdated,
+      },
+      host: {
+        cpu: {
+          state: 'healthy',
+          usagePercent: 20,
+          lastUpdated: apiUpdated,
+        },
+        ram: {
+          state: 'healthy',
+          usagePercent: 30,
+          lastUpdated: apiUpdated,
+        },
+      },
+    })
+
+    renderWithQuery(<SystemStatusPanel />)
+
+    await waitFor(() => expect(screen.getByText('Traffic and security')).toBeInTheDocument())
+    expect(screen.getByText('Total requests: 1,200')).toBeInTheDocument()
+    expect(screen.getByText('Active blocked IPs: 2')).toBeInTheDocument()
+    expect(screen.getByText('203.0.113.7')).toBeInTheDocument()
   })
 
   it('renders fetch failure UI when endpoint errors', async () => {

--- a/dashboard/src/system-status/SystemStatusPanel.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.tsx
@@ -1,7 +1,9 @@
 import { useSystemStatus } from './useSystemStatus'
+import { useLoadBalancerAccessLogs } from './useLoadBalancerAccessLogs'
 import { Badge } from '../components/ui/badge'
 import { AlertTriangle, Check, CheckCircle2, CircleHelp, CircleSlash2, X } from 'lucide-react'
 import type { HostMetricSystemStatus, SystemStatusState } from '../lib/api'
+import { useState } from 'react'
 
 type BadgeVariant = 'secondary' | 'info' | 'success' | 'destructive' | 'warning'
 type CheckValue = boolean | undefined
@@ -90,6 +92,30 @@ function formatUsageValue(metric: HostMetricSystemStatus) {
   return `${Math.round(metric.usagePercent)}%`
 }
 
+function formatCount(value?: number) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '--'
+  }
+  return value.toLocaleString()
+}
+
+function formatBlockedUntil(timestamp?: string) {
+  if (!timestamp) {
+    return 'Unknown unblock time'
+  }
+
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown unblock time'
+  }
+
+  if (date.getTime() <= Date.now()) {
+    return 'Unblock due now'
+  }
+
+  return `Blocked until ${date.toLocaleTimeString()}`
+}
+
 function statusIcon(state: SystemStatusState) {
   if (state === 'healthy') return CheckCircle2
   if (state === 'degraded') return AlertTriangle
@@ -155,6 +181,43 @@ function ServiceChecks({
 
 export function SystemStatusPanel() {
   const { status, isLoading, isError } = useSystemStatus()
+  const [methodFilter, setMethodFilter] = useState('')
+  const [statusFilter, setStatusFilter] = useState('')
+  const [hostFilter, setHostFilter] = useState('')
+  const [ipFilter, setIPFilter] = useState('')
+  const [appliedFilters, setAppliedFilters] = useState<{ method?: string; status?: number; host?: string; ip?: string }>({})
+  const accessLogs = useLoadBalancerAccessLogs(appliedFilters)
+
+  const applyAccessLogFilters = () => {
+    const next: { method?: string; status?: number; host?: string; ip?: string } = {}
+    const method = methodFilter.trim().toUpperCase()
+    const status = Number(statusFilter)
+    const host = hostFilter.trim()
+    const ip = ipFilter.trim()
+
+    if (method) {
+      next.method = method
+    }
+    if (statusFilter.trim() && Number.isFinite(status) && status > 0) {
+      next.status = status
+    }
+    if (host) {
+      next.host = host
+    }
+    if (ip) {
+      next.ip = ip
+    }
+
+    setAppliedFilters(next)
+  }
+
+  const clearAccessLogFilters = () => {
+    setMethodFilter('')
+    setStatusFilter('')
+    setHostFilter('')
+    setIPFilter('')
+    setAppliedFilters({})
+  }
 
   return (
     <section className="space-y-6">
@@ -303,6 +366,152 @@ export function SystemStatusPanel() {
                   {status.loadBalancer.state === 'degraded' && 'Load balancer healthcheck failed at last probe'}
                   {status.loadBalancer.state === 'unavailable' && 'No load balancer telemetry yet'}
                 </p>
+                {status.loadBalancer.traffic && (
+                  <div className="mt-3 border-t border-border/50 pt-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Traffic and security</p>
+                    <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
+                      <p>Total requests: {formatCount(status.loadBalancer.traffic.totalRequests)}</p>
+                      <p>Suspicious: {formatCount(status.loadBalancer.traffic.suspiciousRequests)}</p>
+                      <p>Blocked requests: {formatCount(status.loadBalancer.traffic.blockedRequests)}</p>
+                      <p>Active blocked IPs: {formatCount(status.loadBalancer.traffic.activeBlockedIps)}</p>
+                    </div>
+                    {status.loadBalancer.traffic.blockedIps && status.loadBalancer.traffic.blockedIps.length > 0 ? (
+                      <ul className="mt-2 max-h-28 space-y-1 overflow-auto text-xs">
+                        {status.loadBalancer.traffic.blockedIps.map(ip => (
+                          <li key={ip.ip} className="flex items-center justify-between gap-2 rounded border border-border/50 px-2 py-1">
+                            <span className="font-mono text-[11px] text-foreground">{ip.ip}</span>
+                            <span className="text-muted-foreground">{formatBlockedUntil(ip.blockedUntil)}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="mt-2 text-xs text-muted-foreground">No blocked IPs currently.</p>
+                    )}
+                  </div>
+                )}
+                <div className="mt-3 border-t border-border/50 pt-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Access logs</p>
+                  <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                    <label className="text-[11px] text-muted-foreground">
+                      Method
+                      <select
+                        value={methodFilter}
+                        onChange={event => setMethodFilter(event.target.value)}
+                        className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
+                      >
+                        <option value="">Any</option>
+                        {['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].map(method => (
+                          <option key={method} value={method}>
+                            {method}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label className="text-[11px] text-muted-foreground">
+                      Status
+                      <input
+                        type="number"
+                        min={100}
+                        max={599}
+                        value={statusFilter}
+                        onChange={event => setStatusFilter(event.target.value)}
+                        className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
+                        placeholder="Any"
+                      />
+                    </label>
+                    <label className="text-[11px] text-muted-foreground">
+                      Host contains
+                      <input
+                        type="text"
+                        value={hostFilter}
+                        onChange={event => setHostFilter(event.target.value)}
+                        className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
+                        placeholder="api.example.com"
+                      />
+                    </label>
+                    <label className="text-[11px] text-muted-foreground">
+                      IP contains
+                      <input
+                        type="text"
+                        value={ipFilter}
+                        onChange={event => setIPFilter(event.target.value)}
+                        className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
+                        placeholder="203.0.113"
+                      />
+                    </label>
+                  </div>
+                  <div className="mt-2 flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={applyAccessLogFilters}
+                      className="rounded border border-border px-2 py-1 text-xs text-foreground"
+                    >
+                      Apply filters
+                    </button>
+                    <button
+                      type="button"
+                      onClick={clearAccessLogFilters}
+                      className="rounded border border-border px-2 py-1 text-xs text-muted-foreground"
+                    >
+                      Clear
+                    </button>
+                  </div>
+                  {accessLogs.isError && (
+                    <p className="mt-2 text-xs text-destructive">Unable to load access logs right now.</p>
+                  )}
+                  {!accessLogs.isError && accessLogs.items.length === 0 && !accessLogs.isLoading && (
+                    <p className="mt-2 text-xs text-muted-foreground">No access logs available yet.</p>
+                  )}
+                  {accessLogs.items.length > 0 && (
+                    <div className="mt-2 overflow-x-auto">
+                      <table className="w-full min-w-[560px] text-left text-xs">
+                        <thead>
+                          <tr className="text-muted-foreground">
+                            <th className="py-1 pr-2 font-medium">Time</th>
+                            <th className="py-1 pr-2 font-medium">IP</th>
+                            <th className="py-1 pr-2 font-medium">Request</th>
+                            <th className="py-1 pr-2 font-medium">Status</th>
+                            <th className="py-1 pr-2 font-medium">Outcome</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {accessLogs.items.map((entry, idx) => (
+                            <tr key={`${entry.timestamp}-${entry.clientIp}-${entry.path}-${idx}`} className="border-t border-border/30 align-top">
+                              <td className="py-1 pr-2 whitespace-nowrap">{formatTimestamp(entry.timestamp)}</td>
+                              <td className="py-1 pr-2 font-mono text-[11px]">{entry.clientIp || '-'}</td>
+                              <td className="py-1 pr-2">
+                                <div className="text-foreground">
+                                  {entry.method} {entry.path}
+                                  {entry.query ? `?${entry.query}` : ''}
+                                </div>
+                                {entry.headers && Object.keys(entry.headers).length > 0 && (
+                                  <details className="mt-1 text-[11px] text-muted-foreground">
+                                    <summary className="cursor-pointer select-none">Headers</summary>
+                                    <pre className="mt-1 whitespace-pre-wrap rounded border border-border/40 bg-background/70 p-2 text-[10px] text-foreground">
+                                      {JSON.stringify(entry.headers, null, 2)}
+                                    </pre>
+                                  </details>
+                                )}
+                              </td>
+                              <td className="py-1 pr-2">{entry.status}</td>
+                              <td className="py-1 pr-2">{entry.outcome}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                  <div className="mt-2 flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={accessLogs.loadOlder}
+                      disabled={!accessLogs.hasMore || accessLogs.isLoading}
+                      className="rounded border border-border px-2 py-1 text-xs text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {accessLogs.isLoading ? 'Loading…' : accessLogs.hasMore ? 'Load older logs' : 'No older logs'}
+                    </button>
+                  </div>
+                </div>
               </article>
             </div>
           </section>

--- a/dashboard/src/system-status/useLoadBalancerAccessLogs.ts
+++ b/dashboard/src/system-status/useLoadBalancerAccessLogs.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  getLoadBalancerAccessLogs,
+  type LoadBalancerAccessLogEntry,
+  type LoadBalancerAccessLogFilters,
+} from '../lib/api'
+
+const PAGE_SIZE = 50
+
+export function useLoadBalancerAccessLogs(filters: LoadBalancerAccessLogFilters) {
+  const [items, setItems] = useState<LoadBalancerAccessLogEntry[]>([])
+  const [nextCursor, setNextCursor] = useState<string | undefined>(undefined)
+  const [hasMore, setHasMore] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isError, setIsError] = useState(false)
+
+  const loadPage = useCallback(async (cursor?: string, append = false) => {
+    setIsLoading(true)
+    setIsError(false)
+    try {
+      const page = await getLoadBalancerAccessLogs(cursor, PAGE_SIZE, filters)
+      setItems(prev => (append ? [...prev, ...page.items] : page.items))
+      setNextCursor(page.nextCursor)
+      setHasMore(page.hasMore)
+    } catch {
+      setIsError(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [filters])
+
+  useEffect(() => {
+    loadPage(undefined, false)
+  }, [loadPage])
+
+  const loadOlder = useCallback(() => {
+    if (isLoading || !nextCursor) {
+      return
+    }
+    void loadPage(nextCursor, true)
+  }, [isLoading, nextCursor, loadPage])
+
+  return { items, hasMore, isLoading, isError, loadOlder }
+}

--- a/dashboard/src/system-status/useSystemStatus.ts
+++ b/dashboard/src/system-status/useSystemStatus.ts
@@ -1,15 +1,37 @@
-import { useQuery } from '@tanstack/react-query'
-import { getSystemStatus } from '../lib/api'
+import { useEffect } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { getSystemStatus, type SystemStatusSnapshot } from '../lib/api'
 
 export function useSystemStatus() {
+  const queryClient = useQueryClient()
   const query = useQuery({
     queryKey: ['system-status'],
     queryFn: getSystemStatus,
+    retry: false,
   })
+
+  useEffect(() => {
+    if (typeof EventSource === 'undefined') {
+      return
+    }
+
+    const es = new EventSource('/api/system-status/events')
+
+    es.onmessage = (event: MessageEvent) => {
+      try {
+        const snapshot: SystemStatusSnapshot = JSON.parse(event.data)
+        queryClient.setQueryData(['system-status'], snapshot)
+      } catch {
+        // ignore malformed events
+      }
+    }
+
+    return () => es.close()
+  }, [queryClient])
 
   return {
     status: query.data,
-    isLoading: query.isLoading,
-    isError: query.isError,
+    isLoading: query.isLoading && !query.data,
+    isError: query.isError && !query.data,
   }
 }

--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -64,6 +65,10 @@ func main() {
 	if v := os.Getenv("DIRIGENT_PROXY_HEALTH_URL"); v != "" {
 		proxyHealthURL = v
 	}
+	proxyTrafficURL := "http://localhost/internal/traffic"
+	if v := os.Getenv("DIRIGENT_PROXY_TRAFFIC_URL"); v != "" {
+		proxyTrafficURL = v
+	}
 	notifier := apiclient.New(apiURL)
 	metrics := hostmetrics.NewCollector()
 
@@ -83,6 +88,7 @@ func main() {
 			now := time.Now().UTC()
 			dockerReachable := true
 			loadBalancerResponding := false
+			var loadBalancerTraffic *apiclient.HeartbeatLoadBalancerTraffic
 			storeAccessible := true
 			var cpuUsagePercent *float64
 			var ramUsagePercent *float64
@@ -106,6 +112,12 @@ func main() {
 				loadBalancerResponding = true
 			}
 
+			if traffic, err := probeProxyTraffic(ctx, proxyTrafficURL); err != nil {
+				log.Printf("orchestrator: load balancer traffic telemetry failed: %v", err)
+			} else {
+				loadBalancerTraffic = traffic
+			}
+
 			if usage, ok, err := metrics.CPUUsagePercent(); err != nil {
 				log.Printf("orchestrator: collect cpu telemetry: %v", err)
 			} else if ok {
@@ -119,7 +131,7 @@ func main() {
 			}
 
 			// Heartbeat is always sent, regardless of Docker state.
-			if err := notifier.NotifyHeartbeat(dockerReachable, loadBalancerResponding, storeAccessible, now, cpuUsagePercent, ramUsagePercent); err != nil {
+			if err := notifier.NotifyHeartbeat(dockerReachable, loadBalancerResponding, loadBalancerTraffic, storeAccessible, now, cpuUsagePercent, ramUsagePercent); err != nil {
 				log.Printf("orchestrator: notify heartbeat: %v", err)
 			}
 
@@ -134,6 +146,60 @@ func main() {
 			return
 		}
 	}
+}
+
+func probeProxyTraffic(ctx context.Context, trafficURL string) (*apiclient.HeartbeatLoadBalancerTraffic, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, trafficURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var body struct {
+		TotalRequests      int64 `json:"totalRequests"`
+		SuspiciousRequests int64 `json:"suspiciousRequests"`
+		BlockedRequests    int64 `json:"blockedRequests"`
+		ActiveBlockedIPs   int   `json:"activeBlockedIps"`
+		BlockedIPs         []struct {
+			IP           string     `json:"ip"`
+			BlockedUntil *time.Time `json:"blockedUntil"`
+		} `json:"blockedIps"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	traffic := &apiclient.HeartbeatLoadBalancerTraffic{
+		TotalRequests:      body.TotalRequests,
+		SuspiciousRequests: body.SuspiciousRequests,
+		BlockedRequests:    body.BlockedRequests,
+		ActiveBlockedIPs:   body.ActiveBlockedIPs,
+	}
+
+	if len(body.BlockedIPs) > 0 {
+		traffic.BlockedIPs = make([]apiclient.HeartbeatLoadBalancerBlockedIPState, 0, len(body.BlockedIPs))
+		for _, blocked := range body.BlockedIPs {
+			if blocked.IP == "" {
+				continue
+			}
+			traffic.BlockedIPs = append(traffic.BlockedIPs, apiclient.HeartbeatLoadBalancerBlockedIPState{IP: blocked.IP, BlockedUntil: blocked.BlockedUntil})
+		}
+	}
+
+	return traffic, nil
 }
 
 func probeProxyHealth(ctx context.Context, healthURL string) error {

--- a/orchestrator/internal/apiclient/client.go
+++ b/orchestrator/internal/apiclient/client.go
@@ -34,8 +34,22 @@ type heartbeatDockerState struct {
 }
 
 type heartbeatLoadBalancerState struct {
-	Responding bool      `json:"responding"`
-	CheckedAt  time.Time `json:"checkedAt"`
+	Responding bool                          `json:"responding"`
+	CheckedAt  time.Time                     `json:"checkedAt"`
+	Traffic    *HeartbeatLoadBalancerTraffic `json:"traffic,omitempty"`
+}
+
+type HeartbeatLoadBalancerTraffic struct {
+	TotalRequests      int64                                 `json:"totalRequests"`
+	SuspiciousRequests int64                                 `json:"suspiciousRequests"`
+	BlockedRequests    int64                                 `json:"blockedRequests"`
+	ActiveBlockedIPs   int                                   `json:"activeBlockedIps"`
+	BlockedIPs         []HeartbeatLoadBalancerBlockedIPState `json:"blockedIps,omitempty"`
+}
+
+type HeartbeatLoadBalancerBlockedIPState struct {
+	IP           string     `json:"ip"`
+	BlockedUntil *time.Time `json:"blockedUntil,omitempty"`
 }
 
 type heartbeatHostState struct {
@@ -89,7 +103,7 @@ func (c *Client) NotifyStatus(id string, status store.Status, errorMessage strin
 
 // NotifyHeartbeat calls POST /api/system-status/orchestrator-heartbeat so the
 // API can update orchestrator liveness, Docker connectivity, and host metrics.
-func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bool, storeAccessible bool, checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64) error {
+func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bool, loadBalancerTraffic *HeartbeatLoadBalancerTraffic, storeAccessible bool, checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64) error {
 	if checkedAt.IsZero() {
 		checkedAt = time.Now().UTC()
 	} else {
@@ -110,6 +124,7 @@ func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bo
 		LoadBalancer: heartbeatLoadBalancerState{
 			Responding: loadBalancerResponding,
 			CheckedAt:  checkedAt,
+			Traffic:    cloneHeartbeatLoadBalancerTraffic(loadBalancerTraffic),
 		},
 		Host: host,
 	})
@@ -134,6 +149,20 @@ func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bo
 	}
 
 	return nil
+}
+
+func cloneHeartbeatLoadBalancerTraffic(in *HeartbeatLoadBalancerTraffic) *HeartbeatLoadBalancerTraffic {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+	if len(in.BlockedIPs) > 0 {
+		out.BlockedIPs = make([]HeartbeatLoadBalancerBlockedIPState, len(in.BlockedIPs))
+		copy(out.BlockedIPs, in.BlockedIPs)
+	}
+
+	return &out
 }
 
 func buildHeartbeatHostState(checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64) *heartbeatHostState {

--- a/orchestrator/internal/apiclient/client_test.go
+++ b/orchestrator/internal/apiclient/client_test.go
@@ -14,6 +14,13 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 	checkedAt := time.Date(2026, time.February, 22, 14, 0, 0, 0, time.UTC)
 	cpu := 41.7
 	ram := 68.9
+	traffic := &HeartbeatLoadBalancerTraffic{
+		TotalRequests:      99,
+		SuspiciousRequests: 12,
+		BlockedRequests:    5,
+		ActiveBlockedIPs:   1,
+		BlockedIPs:         []HeartbeatLoadBalancerBlockedIPState{{IP: "203.0.113.7", BlockedUntil: &checkedAt}},
+	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -35,6 +42,16 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 			LoadBalancer struct {
 				Responding bool      `json:"responding"`
 				CheckedAt  time.Time `json:"checkedAt"`
+				Traffic    *struct {
+					TotalRequests      int64 `json:"totalRequests"`
+					SuspiciousRequests int64 `json:"suspiciousRequests"`
+					BlockedRequests    int64 `json:"blockedRequests"`
+					ActiveBlockedIPs   int   `json:"activeBlockedIps"`
+					BlockedIPs         []struct {
+						IP           string     `json:"ip"`
+						BlockedUntil *time.Time `json:"blockedUntil"`
+					} `json:"blockedIps"`
+				} `json:"traffic"`
 			} `json:"loadBalancer"`
 			Host *struct {
 				CPU *struct {
@@ -69,6 +86,15 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 		if !body.LoadBalancer.CheckedAt.Equal(checkedAt) {
 			t.Fatalf("want load balancer checkedAt %s, got %s", checkedAt, body.LoadBalancer.CheckedAt)
 		}
+		if body.LoadBalancer.Traffic == nil {
+			t.Fatal("want load balancer traffic included")
+		}
+		if body.LoadBalancer.Traffic.TotalRequests != traffic.TotalRequests {
+			t.Fatalf("want total requests %d, got %d", traffic.TotalRequests, body.LoadBalancer.Traffic.TotalRequests)
+		}
+		if len(body.LoadBalancer.Traffic.BlockedIPs) != 1 || body.LoadBalancer.Traffic.BlockedIPs[0].IP != "203.0.113.7" {
+			t.Fatal("want blocked ip payload")
+		}
 		if body.Host == nil || body.Host.CPU == nil || body.Host.RAM == nil {
 			t.Fatal("want host cpu and ram metrics in heartbeat")
 		}
@@ -90,7 +116,7 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(false, false, false, checkedAt, &cpu, &ram); err != nil {
+	if err := client.NotifyHeartbeat(false, false, traffic, false, checkedAt, &cpu, &ram); err != nil {
 		t.Fatalf("NotifyHeartbeat: %v", err)
 	}
 }
@@ -118,7 +144,7 @@ func TestClient_NotifyHeartbeat_WithoutHostMetrics(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(false, true, true, checkedAt, nil, nil); err != nil {
+	if err := client.NotifyHeartbeat(false, true, nil, true, checkedAt, nil, nil); err != nil {
 		t.Fatalf("NotifyHeartbeat: %v", err)
 	}
 }
@@ -130,7 +156,7 @@ func TestClient_NotifyHeartbeat_UnexpectedResponse(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(true, true, true, time.Time{}, nil, nil); err == nil {
+	if err := client.NotifyHeartbeat(true, true, nil, true, time.Time{}, nil, nil); err == nil {
 		t.Fatal("want error for non-204 heartbeat response")
 	}
 }

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -27,6 +27,7 @@ const (
 	defaultHTTPAddr                = ":80"
 	defaultHTTPSAddr               = ":443"
 	defaultCertCacheDir            = "/var/lib/dirigent/certs"
+	defaultAccessLogDir            = "/var/lib/dirigent/logs/proxy"
 	letsencryptProdDirectoryURL    = "https://acme-v02.api.letsencrypt.org/directory"
 	letsencryptStagingDirectoryURL = "https://acme-staging-v02.api.letsencrypt.org/directory"
 )
@@ -54,6 +55,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("proxy: %v", err)
 	}
+	accessLogConfig, err := accessLogConfigFromEnv()
+	if err != nil {
+		log.Fatalf("proxy: %v", err)
+	}
+	accessLogger, err := handler.NewFileAccessLogger(accessLogConfig)
+	if err != nil {
+		log.Fatalf("proxy: initialize access logger: %v", err)
+	}
+	defer accessLogger.Close()
 	if dashboardAuth != nil {
 		table.SetStatic(dashboardAuth.Domain, "localhost:3000")
 		log.Printf("proxy: registered dashboard domain %s -> localhost:3000", dashboardAuth.Domain)
@@ -69,7 +79,7 @@ func main() {
 	}
 
 	p := poller.New(s, table, interval)
-	h := handler.New(table, dashboardAuth, handler.WithHardeningProfile(hardeningProfile))
+	h := handler.New(table, dashboardAuth, handler.WithHardeningProfile(hardeningProfile), handler.WithAccessLogger(accessLogger))
 
 	hostPolicy := hostPolicyFromTable(table)
 	cacheDir := envOrDefault("DIRIGENT_CERT_CACHE_DIR", defaultCertCacheDir)
@@ -254,4 +264,32 @@ func hardeningProfileFromEnv() (handler.HardeningProfile, error) {
 	default:
 		return "", fmt.Errorf("DIRIGENT_PROXY_HARDENING_PROFILE must be one of: off, standard, strict")
 	}
+}
+
+func accessLogConfigFromEnv() (handler.AccessLogConfig, error) {
+	retentionRaw := strings.TrimSpace(envOrDefault("DIRIGENT_PROXY_ACCESS_LOG_RETENTION", "168h"))
+	retention, err := time.ParseDuration(retentionRaw)
+	if err != nil || retention <= 0 {
+		return handler.AccessLogConfig{}, fmt.Errorf("DIRIGENT_PROXY_ACCESS_LOG_RETENTION must be a positive duration")
+	}
+
+	headers := []string{"host", "user-agent", "accept", "accept-encoding", "accept-language", "referer", "x-forwarded-for", "x-real-ip"}
+	if raw := strings.TrimSpace(os.Getenv("DIRIGENT_PROXY_ACCESS_LOG_HEADERS")); raw != "" {
+		headers = headers[:0]
+		for _, part := range strings.Split(raw, ",") {
+			header := strings.ToLower(strings.TrimSpace(part))
+			if header != "" {
+				headers = append(headers, header)
+			}
+		}
+		if len(headers) == 0 {
+			return handler.AccessLogConfig{}, fmt.Errorf("DIRIGENT_PROXY_ACCESS_LOG_HEADERS must contain at least one header")
+		}
+	}
+
+	return handler.AccessLogConfig{
+		Dir:             strings.TrimSpace(envOrDefault("DIRIGENT_PROXY_ACCESS_LOG_DIR", defaultAccessLogDir)),
+		Retention:       retention,
+		WhitelistedKeys: headers,
+	}, nil
 }

--- a/proxy/internal/handler/access_log.go
+++ b/proxy/internal/handler/access_log.go
@@ -1,0 +1,271 @@
+package handler
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+const accessLogFilenamePrefix = "access-"
+
+type AccessLogConfig struct {
+	Dir             string
+	Retention       time.Duration
+	WhitelistedKeys []string
+	Now             func() time.Time
+}
+
+type AccessLogEvent struct {
+	Timestamp    time.Time
+	ClientIP     string
+	Host         string
+	Method       string
+	Path         string
+	Query        string
+	Status       int
+	DurationMs   int64
+	BytesWritten int64
+	Outcome      string
+	Headers      http.Header
+}
+
+type accessLogRecord struct {
+	Timestamp    time.Time         `json:"timestamp"`
+	ClientIP     string            `json:"clientIp"`
+	Host         string            `json:"host"`
+	Method       string            `json:"method"`
+	Path         string            `json:"path"`
+	Query        string            `json:"query,omitempty"`
+	Status       int               `json:"status"`
+	DurationMs   int64             `json:"durationMs"`
+	BytesWritten int64             `json:"bytesWritten"`
+	Outcome      string            `json:"outcome"`
+	Headers      map[string]string `json:"headers,omitempty"`
+}
+
+type AccessLogger interface {
+	Log(AccessLogEvent)
+	Close() error
+}
+
+type fileAccessLogger struct {
+	mu         sync.Mutex
+	dir        string
+	retention  time.Duration
+	now        func() time.Time
+	allowed    map[string]struct{}
+	currentKey string
+	current    *os.File
+	writer     *bufio.Writer
+}
+
+func NewFileAccessLogger(cfg AccessLogConfig) (AccessLogger, error) {
+	if strings.TrimSpace(cfg.Dir) == "" {
+		return nil, fmt.Errorf("access log dir is required")
+	}
+	if cfg.Retention <= 0 {
+		cfg.Retention = 7 * 24 * time.Hour
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	allowed := make(map[string]struct{})
+	for _, key := range cfg.WhitelistedKeys {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "" {
+			continue
+		}
+		allowed[normalized] = struct{}{}
+	}
+
+	if err := os.MkdirAll(cfg.Dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create access log dir: %w", err)
+	}
+
+	logger := &fileAccessLogger{dir: cfg.Dir, retention: cfg.Retention, now: cfg.Now, allowed: allowed}
+	if err := logger.rotateIfNeeded(cfg.Now().UTC()); err != nil {
+		return nil, err
+	}
+	return logger, nil
+}
+
+func (l *fileAccessLogger) Log(event AccessLogEvent) {
+	now := l.now().UTC()
+	if event.Timestamp.IsZero() {
+		event.Timestamp = now
+	} else {
+		event.Timestamp = event.Timestamp.UTC()
+	}
+
+	record := accessLogRecord{
+		Timestamp:    event.Timestamp,
+		ClientIP:     event.ClientIP,
+		Host:         event.Host,
+		Method:       event.Method,
+		Path:         event.Path,
+		Query:        event.Query,
+		Status:       event.Status,
+		DurationMs:   event.DurationMs,
+		BytesWritten: event.BytesWritten,
+		Outcome:      event.Outcome,
+		Headers:      l.pickHeaders(event.Headers, event.Host),
+	}
+
+	line, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if err := l.rotateIfNeeded(now); err != nil {
+		return
+	}
+
+	if _, err := l.writer.Write(line); err != nil {
+		return
+	}
+	if err := l.writer.WriteByte('\n'); err != nil {
+		return
+	}
+	_ = l.writer.Flush()
+}
+
+func (l *fileAccessLogger) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.writer != nil {
+		if err := l.writer.Flush(); err != nil {
+			return err
+		}
+	}
+	if l.current != nil {
+		if err := l.current.Close(); err != nil {
+			return err
+		}
+	}
+
+	l.writer = nil
+	l.current = nil
+	return nil
+}
+
+func (l *fileAccessLogger) pickHeaders(headers http.Header, host string) map[string]string {
+	if len(l.allowed) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	for rawKey, values := range headers {
+		key := strings.ToLower(strings.TrimSpace(rawKey))
+		if _, ok := l.allowed[key]; !ok {
+			continue
+		}
+		if len(values) == 0 {
+			continue
+		}
+		out[key] = strings.Join(values, ",")
+	}
+	if len(out) == 0 {
+		if _, ok := l.allowed["host"]; ok && host != "" {
+			return map[string]string{"host": host}
+		}
+		return nil
+	}
+	if _, ok := l.allowed["host"]; ok && host != "" {
+		if _, exists := out["host"]; !exists {
+			out["host"] = host
+		}
+	}
+	return out
+}
+
+func (l *fileAccessLogger) rotateIfNeeded(now time.Time) error {
+	key := now.Format("2006-01-02-15")
+	if l.current != nil && l.currentKey == key {
+		return nil
+	}
+
+	if l.writer != nil {
+		if err := l.writer.Flush(); err != nil {
+			return err
+		}
+	}
+	if l.current != nil {
+		if err := l.current.Close(); err != nil {
+			return err
+		}
+	}
+
+	path := filepath.Join(l.dir, fmt.Sprintf("%s%s.log", accessLogFilenamePrefix, key))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open access log file: %w", err)
+	}
+
+	l.currentKey = key
+	l.current = f
+	l.writer = bufio.NewWriterSize(f, 64*1024)
+	l.cleanupExpired(now)
+	return nil
+}
+
+func (l *fileAccessLogger) cleanupExpired(now time.Time) {
+	entries, err := os.ReadDir(l.dir)
+	if err != nil {
+		return
+	}
+	cutoff := now.Add(-l.retention)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, accessLogFilenamePrefix) || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		if l.current != nil && filepath.Base(l.current.Name()) == name {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			_ = os.Remove(filepath.Join(l.dir, name))
+		}
+	}
+}
+
+func listAccessLogFiles(logDir string) ([]string, error) {
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, accessLogFilenamePrefix) && strings.HasSuffix(name, ".log") {
+			files = append(files, name)
+		}
+	}
+
+	slices.Sort(files)
+	slices.Reverse(files)
+	return files, nil
+}

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -1,12 +1,15 @@
 package handler
 
 import (
+	"bufio"
 	"encoding/json"
+	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -29,6 +32,7 @@ type Handler struct {
 	dashboardAuth *DashboardAuth
 	hardening     HardeningProfile
 	scanner       *scannerLimiter
+	accessLogs    AccessLogger
 }
 
 // HardeningProfile controls request filtering and anti-scan behavior.
@@ -70,6 +74,13 @@ func WithHardeningProfile(profile HardeningProfile) Option {
 	}
 }
 
+// WithAccessLogger enables per-request access log writing.
+func WithAccessLogger(logger AccessLogger) Option {
+	return func(h *Handler) {
+		h.accessLogs = logger
+	}
+}
+
 // RegisterRoutes wires the proxy catch-all and the internal control API into mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	h.RegisterInternalRoutes(mux)
@@ -79,6 +90,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 // RegisterInternalRoutes wires the internal health/control API into mux.
 func (h *Handler) RegisterInternalRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /internal/health", h.health)
+	mux.HandleFunc("GET /internal/traffic", h.traffic)
 	mux.HandleFunc("POST /internal/routes", h.setRoute)
 }
 
@@ -91,21 +103,74 @@ func (h *Handler) health(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+type blockedIPTrafficStatus struct {
+	IP           string     `json:"ip"`
+	BlockedUntil *time.Time `json:"blockedUntil,omitempty"`
+}
+
+type trafficStatus struct {
+	TotalRequests      int64                    `json:"totalRequests"`
+	SuspiciousRequests int64                    `json:"suspiciousRequests"`
+	BlockedRequests    int64                    `json:"blockedRequests"`
+	ActiveBlockedIPs   int                      `json:"activeBlockedIps"`
+	BlockedIPs         []blockedIPTrafficStatus `json:"blockedIps,omitempty"`
+}
+
+func (h *Handler) traffic(w http.ResponseWriter, _ *http.Request) {
+	status := trafficStatus{}
+	if h.scanner != nil {
+		status = h.scanner.Snapshot(time.Now())
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		log.Printf("traffic: encode: %v", err)
+	}
+}
+
 // proxy routes inbound requests to the upstream registered for the Host header.
 // Returns 404 for unknown domains and 502 when the upstream is unreachable.
 func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 	now := time.Now()
+	start := now
 	client := clientIP(r)
+	outcome := "proxied"
+	rw := &accessLogResponseWriter{ResponseWriter: w}
+	defer func() {
+		if h.accessLogs == nil {
+			return
+		}
+		h.accessLogs.Log(AccessLogEvent{
+			Timestamp:    start.UTC(),
+			ClientIP:     client,
+			Host:         normalizeDomain(r.Host),
+			Method:       r.Method,
+			Path:         r.URL.Path,
+			Query:        r.URL.RawQuery,
+			Status:       rw.Status(),
+			DurationMs:   time.Since(start).Milliseconds(),
+			BytesWritten: rw.BytesWritten(),
+			Outcome:      outcome,
+			Headers:      r.Header,
+		})
+	}()
+
+	if h.scanner != nil {
+		h.scanner.RecordRequest()
+	}
 	if h.scanner != nil && client != "" && h.scanner.IsBlocked(client, now) {
-		http.Error(w, "too many requests", http.StatusTooManyRequests)
+		h.scanner.RecordBlockedRequest()
+		outcome = "rate_limited"
+		http.Error(rw, "too many requests", http.StatusTooManyRequests)
 		return
 	}
 
 	if shouldBlockPath(r.URL.Path, h.hardening) {
-		if h.scanner != nil && client != "" {
+		if h.scanner != nil {
 			h.scanner.RecordSuspicious(client, now)
 		}
-		http.NotFound(w, r)
+		outcome = "blocked_path"
+		http.NotFound(rw, r)
 		return
 	}
 
@@ -118,14 +183,16 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 
 	if h.dashboardAuth != nil && host == h.dashboardAuth.Domain {
 		if !middleware.ValidBasicAuth(r, h.dashboardAuth.Username, h.dashboardAuth.Password) {
-			middleware.WriteBasicAuthChallenge(w, "Dirigent")
+			outcome = "unauthorized"
+			middleware.WriteBasicAuthChallenge(rw, "Dirigent")
 			return
 		}
 	}
 
 	upstream, ok := h.table.Get(host)
 	if !ok {
-		http.Error(w, "unknown domain", http.StatusNotFound)
+		outcome = "unknown_domain"
+		http.Error(rw, "unknown domain", http.StatusNotFound)
 		return
 	}
 
@@ -141,12 +208,84 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 			req.Header.Set("X-Forwarded-Host", req.Host)
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			outcome = "upstream_error"
 			log.Printf("proxy: upstream %s: %v", upstream, err)
 			http.Error(w, "upstream unavailable", http.StatusBadGateway)
 		},
 	}
 
-	rp.ServeHTTP(w, r)
+	rp.ServeHTTP(rw, r)
+}
+
+type accessLogResponseWriter struct {
+	http.ResponseWriter
+	status       int
+	bytesWritten int64
+}
+
+func (w *accessLogResponseWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *accessLogResponseWriter) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(b)
+	w.bytesWritten += int64(n)
+	return n, err
+}
+
+func (w *accessLogResponseWriter) Status() int {
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
+}
+
+func (w *accessLogResponseWriter) BytesWritten() int64 {
+	return w.bytesWritten
+}
+
+func (w *accessLogResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *accessLogResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, http.ErrNotSupported
+	}
+	return h.Hijack()
+}
+
+func (w *accessLogResponseWriter) ReadFrom(r io.Reader) (int64, error) {
+	rf, ok := w.ResponseWriter.(io.ReaderFrom)
+	if !ok {
+		n, err := io.Copy(w.ResponseWriter, r)
+		w.bytesWritten += n
+		if w.status == 0 {
+			w.status = http.StatusOK
+		}
+		return n, err
+	}
+	n, err := rf.ReadFrom(r)
+	w.bytesWritten += n
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return n, err
+}
+
+func (w *accessLogResponseWriter) Push(target string, opts *http.PushOptions) error {
+	p, ok := w.ResponseWriter.(http.Pusher)
+	if !ok {
+		return http.ErrNotSupported
+	}
+	return p.Push(target, opts)
 }
 
 type routeRequest struct {
@@ -253,11 +392,14 @@ func hasPathPrefix(path, prefix string) bool {
 }
 
 type scannerLimiter struct {
-	mu        sync.Mutex
-	entries   map[string]scannerEntry
-	window    time.Duration
-	threshold int
-	blockFor  time.Duration
+	mu                 sync.Mutex
+	entries            map[string]scannerEntry
+	window             time.Duration
+	threshold          int
+	blockFor           time.Duration
+	totalRequests      int64
+	suspiciousRequests int64
+	blockedRequests    int64
 }
 
 type scannerEntry struct {
@@ -300,6 +442,11 @@ func (l *scannerLimiter) IsBlocked(ip string, now time.Time) bool {
 func (l *scannerLimiter) RecordSuspicious(ip string, now time.Time) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	l.suspiciousRequests++
+
+	if ip == "" {
+		return
+	}
 
 	e := l.entries[ip]
 	if e.windowStart.IsZero() || now.Sub(e.windowStart) > l.window {
@@ -313,6 +460,52 @@ func (l *scannerLimiter) RecordSuspicious(ip string, now time.Time) {
 		e.count = 0
 	}
 	l.entries[ip] = e
+}
+
+func (l *scannerLimiter) RecordRequest() {
+	l.mu.Lock()
+	l.totalRequests++
+	l.mu.Unlock()
+}
+
+func (l *scannerLimiter) RecordBlockedRequest() {
+	l.mu.Lock()
+	l.blockedRequests++
+	l.mu.Unlock()
+}
+
+func (l *scannerLimiter) Snapshot(now time.Time) trafficStatus {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	blocked := make([]blockedIPTrafficStatus, 0, len(l.entries))
+	for ip, entry := range l.entries {
+		if now.Before(entry.blockedUntil) {
+			blockedUntil := entry.blockedUntil
+			blocked = append(blocked, blockedIPTrafficStatus{IP: ip, BlockedUntil: &blockedUntil})
+		}
+	}
+
+	slices.SortFunc(blocked, func(a, b blockedIPTrafficStatus) int {
+		if a.BlockedUntil == nil || b.BlockedUntil == nil {
+			return strings.Compare(a.IP, b.IP)
+		}
+		if a.BlockedUntil.Equal(*b.BlockedUntil) {
+			return strings.Compare(a.IP, b.IP)
+		}
+		if a.BlockedUntil.Before(*b.BlockedUntil) {
+			return 1
+		}
+		return -1
+	})
+
+	return trafficStatus{
+		TotalRequests:      l.totalRequests,
+		SuspiciousRequests: l.suspiciousRequests,
+		BlockedRequests:    l.blockedRequests,
+		ActiveBlockedIPs:   len(blocked),
+		BlockedIPs:         blocked,
+	}
 }
 
 func clientIP(r *http.Request) string {

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -5,8 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ercadev/dirigent/proxy/internal/handler"
 )
@@ -487,5 +491,174 @@ func TestProxy_StandardHardeningRateLimitsRepeatedScans(t *testing.T) {
 
 	if resp.StatusCode != http.StatusTooManyRequests {
 		t.Fatalf("want 429, got %d", resp.StatusCode)
+	}
+}
+
+func TestInternalTraffic_ReportsBlockedIPsAndCounters(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", backend.Listener.Addr().String())
+
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	for i := 0; i < 12; i++ {
+		req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/.env", nil)
+		req.Host = "example.com"
+		req.Header.Set("X-Forwarded-For", "203.0.113.7")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("scan request %d: %v", i, err)
+		}
+		resp.Body.Close()
+	}
+
+	blocked, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	blocked.Host = "example.com"
+	blocked.Header.Set("X-Forwarded-For", "203.0.113.7")
+	blockedResp, err := http.DefaultClient.Do(blocked)
+	if err != nil {
+		t.Fatalf("GET / blocked request: %v", err)
+	}
+	blockedResp.Body.Close()
+
+	trafficResp, err := http.Get(proxy.URL + "/internal/traffic")
+	if err != nil {
+		t.Fatalf("GET /internal/traffic: %v", err)
+	}
+	defer trafficResp.Body.Close()
+
+	if trafficResp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", trafficResp.StatusCode)
+	}
+
+	var body struct {
+		TotalRequests      int64 `json:"totalRequests"`
+		SuspiciousRequests int64 `json:"suspiciousRequests"`
+		BlockedRequests    int64 `json:"blockedRequests"`
+		ActiveBlockedIPs   int   `json:"activeBlockedIps"`
+		BlockedIPs         []struct {
+			IP           string     `json:"ip"`
+			BlockedUntil *time.Time `json:"blockedUntil"`
+		} `json:"blockedIps"`
+	}
+
+	if err := json.NewDecoder(trafficResp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode traffic response: %v", err)
+	}
+
+	if body.TotalRequests != 13 {
+		t.Fatalf("want total requests 13, got %d", body.TotalRequests)
+	}
+	if body.SuspiciousRequests != 12 {
+		t.Fatalf("want suspicious requests 12, got %d", body.SuspiciousRequests)
+	}
+	if body.BlockedRequests != 1 {
+		t.Fatalf("want blocked requests 1, got %d", body.BlockedRequests)
+	}
+	if body.ActiveBlockedIPs != 1 {
+		t.Fatalf("want active blocked ips 1, got %d", body.ActiveBlockedIPs)
+	}
+	if len(body.BlockedIPs) != 1 || body.BlockedIPs[0].IP != "203.0.113.7" {
+		t.Fatalf("want blocked ip 203.0.113.7, got %+v", body.BlockedIPs)
+	}
+	if body.BlockedIPs[0].BlockedUntil == nil || body.BlockedIPs[0].BlockedUntil.IsZero() {
+		t.Fatal("want blockedUntil for blocked ip")
+	}
+}
+
+func TestProxy_WritesAccessLogWithWhitelistedHeaders(t *testing.T) {
+	dir := t.TempDir()
+	logger, err := handler.NewFileAccessLogger(handler.AccessLogConfig{
+		Dir:             dir,
+		Retention:       24 * time.Hour,
+		WhitelistedKeys: []string{"host", "user-agent", "x-forwarded-for"},
+	})
+	if err != nil {
+		t.Fatalf("NewFileAccessLogger: %v", err)
+	}
+	defer logger.Close()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", backend.Listener.Addr().String())
+
+	proxy := newProxyServerWithOptions(tbl, handler.WithAccessLogger(logger))
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/v1/health?deep=1", nil)
+	req.Host = "example.com"
+	req.Header.Set("User-Agent", "dirigent-test")
+	req.Header.Set("Authorization", "secret-token")
+	req.Header.Set("X-Forwarded-For", "203.0.113.7")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	resp.Body.Close()
+
+	files, err := filepath.Glob(filepath.Join(dir, "access-*.log"))
+	if err != nil {
+		t.Fatalf("glob access logs: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("want 1 access log file, got %d", len(files))
+	}
+
+	raw, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatalf("read access log file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("want exactly one log line, got %d", len(lines))
+	}
+
+	var entry struct {
+		Host    string            `json:"host"`
+		Method  string            `json:"method"`
+		Path    string            `json:"path"`
+		Query   string            `json:"query"`
+		Status  int               `json:"status"`
+		Outcome string            `json:"outcome"`
+		Headers map[string]string `json:"headers"`
+	}
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("unmarshal access log line: %v", err)
+	}
+
+	if entry.Host != "example.com" {
+		t.Fatalf("want host example.com, got %q", entry.Host)
+	}
+	if entry.Method != http.MethodGet {
+		t.Fatalf("want method GET, got %q", entry.Method)
+	}
+	if entry.Path != "/v1/health" {
+		t.Fatalf("want path /v1/health, got %q", entry.Path)
+	}
+	if entry.Query != "deep=1" {
+		t.Fatalf("want query deep=1, got %q", entry.Query)
+	}
+	if entry.Status != http.StatusCreated {
+		t.Fatalf("want status 201, got %d", entry.Status)
+	}
+	if entry.Outcome != "proxied" {
+		t.Fatalf("want outcome proxied, got %q", entry.Outcome)
+	}
+	if _, ok := entry.Headers["authorization"]; ok {
+		t.Fatal("authorization header must not be logged")
+	}
+	if entry.Headers["user-agent"] != "dirigent-test" {
+		t.Fatalf("want user-agent header, got %q", entry.Headers["user-agent"])
 	}
 }


### PR DESCRIPTION
## Summary
- replace system-status polling in the dashboard with SSE updates and enrich load balancer telemetry with blocked-IP and traffic counters
- add proxy access logging to hourly rotating JSONL files with safe request-header whitelisting and retention controls
- expose paginated load balancer access logs from the API (cursor + method/status/host/ip filters) and wire a dashboard log viewer with filter controls

## Verification
- `go test ./api/internal/api ./proxy/internal/handler ./proxy/cmd/proxy ./orchestrator/internal/apiclient ./orchestrator/cmd/orchestrator`
- `bunx vitest run \"src/system-status/SystemStatusPanel.test.tsx\"`
- `bunx tsc --noEmit`