### PR TITLE
fix(installer): improve upgrade flow messaging and prompts

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -68,6 +68,13 @@ The dashboard streams installer logs in real time and prompts you to reload once
 If dashboard access is unavailable, you can still run the manual installer command. The installer stops all services,
 replaces the binaries, and restarts cleanly.
 
+```bash
+sudo dirigent upgrade
+```
+
+By default, `dirigent upgrade` now shows the current and target version, then asks for confirmation before continuing.
+For unattended runs (for example CI/automation), pass `--non-interactive --yes`.
+
 ### Manage services
 
 ```bash

--- a/cli/cmd/dirigent/main.go
+++ b/cli/cmd/dirigent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -17,6 +18,13 @@ const (
 	releaseBaseLatest = "https://github.com/ercadev/dirigent-releases/releases/latest/download"
 	releaseBaseTagFmt = "https://github.com/ercadev/dirigent-releases/releases/download/%s"
 )
+
+type versionSnapshot struct {
+	CurrentVersion string `json:"currentVersion"`
+	LatestVersion  string `json:"latestVersion"`
+}
+
+type versionLookup func() (versionSnapshot, error)
 
 func main() {
 	if len(os.Args) < 2 {
@@ -173,17 +181,32 @@ func runUpgrade(args []string) error {
 	fs.SetOutput(io.Discard)
 
 	target := fs.String("to", "latest", "Upgrade target version")
-	nonInteractive := fs.Bool("non-interactive", true, "Disable prompts")
-	yes := fs.Bool("yes", true, "Skip confirmation prompts")
+	nonInteractive := fs.Bool("non-interactive", false, "Disable prompts")
+	yes := fs.Bool("yes", false, "Skip confirmation prompts")
 
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("%w\n\nUsage: dirigent upgrade [--to latest|vX.Y.Z] [--non-interactive] [--yes]", err)
 	}
 
+	currentVersion, targetVersion := determineUpgradeVersions(*target, fetchLocalVersionSnapshot)
+	fmt.Printf("--> Upgrading Dirigent from %s to %s\n", currentVersion, targetVersion)
+
+	effectiveNonInteractive := *nonInteractive || !stdinIsTTY()
+	if !effectiveNonInteractive && !*yes {
+		confirmed, err := promptYesNo("Proceed with upgrade? [Y/n]: ", true)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return errors.New("upgrade cancelled")
+		}
+	}
+
 	env := append(os.Environ(),
 		"DIRIGENT_VERSION="+*target,
+		"DIRIGENT_UPGRADE=1",
 	)
-	if *nonInteractive {
+	if effectiveNonInteractive {
 		env = append(env, "DIRIGENT_NON_INTERACTIVE=1")
 	}
 	if *yes {
@@ -193,6 +216,57 @@ func runUpgrade(args []string) error {
 	url := releaseScriptURL(*target, "setup.sh")
 	fmt.Printf("--> Running upgrade from %s\n", url)
 	return runRemoteScript(url, env)
+}
+
+func determineUpgradeVersions(target string, lookup versionLookup) (string, string) {
+	from := "unknown"
+	to := strings.TrimSpace(target)
+	if to == "" {
+		to = "latest"
+	}
+
+	if lookup == nil {
+		return from, to
+	}
+
+	snapshot, err := lookup()
+	if err != nil {
+		return from, to
+	}
+
+	if strings.TrimSpace(snapshot.CurrentVersion) != "" {
+		from = strings.TrimSpace(snapshot.CurrentVersion)
+	}
+	if to == "latest" && strings.TrimSpace(snapshot.LatestVersion) != "" {
+		to = strings.TrimSpace(snapshot.LatestVersion)
+	}
+
+	return from, to
+}
+
+func fetchLocalVersionSnapshot() (versionSnapshot, error) {
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/version", nil)
+	if err != nil {
+		return versionSnapshot{}, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return versionSnapshot{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return versionSnapshot{}, fmt.Errorf("version endpoint status: %d", resp.StatusCode)
+	}
+
+	var snapshot versionSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snapshot); err != nil {
+		return versionSnapshot{}, err
+	}
+
+	return snapshot, nil
 }
 
 func runDoctor(args []string) error {

--- a/cli/cmd/dirigent/main_test.go
+++ b/cli/cmd/dirigent/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDetermineUpgradeVersions_WithLatestAndSnapshot(t *testing.T) {
+	lookup := func() (versionSnapshot, error) {
+		return versionSnapshot{CurrentVersion: "v0.1.0", LatestVersion: "v0.2.0"}, nil
+	}
+
+	from, to := determineUpgradeVersions("latest", lookup)
+	if from != "v0.1.0" {
+		t.Fatalf("from = %q, want %q", from, "v0.1.0")
+	}
+	if to != "v0.2.0" {
+		t.Fatalf("to = %q, want %q", to, "v0.2.0")
+	}
+}
+
+func TestDetermineUpgradeVersions_WithPinnedTarget(t *testing.T) {
+	lookup := func() (versionSnapshot, error) {
+		return versionSnapshot{CurrentVersion: "v0.1.0", LatestVersion: "v0.2.0"}, nil
+	}
+
+	from, to := determineUpgradeVersions("v0.1.5", lookup)
+	if from != "v0.1.0" {
+		t.Fatalf("from = %q, want %q", from, "v0.1.0")
+	}
+	if to != "v0.1.5" {
+		t.Fatalf("to = %q, want %q", to, "v0.1.5")
+	}
+}
+
+func TestDetermineUpgradeVersions_OnLookupFailure(t *testing.T) {
+	lookup := func() (versionSnapshot, error) {
+		return versionSnapshot{}, errors.New("boom")
+	}
+
+	from, to := determineUpgradeVersions("latest", lookup)
+	if from != "unknown" {
+		t.Fatalf("from = %q, want %q", from, "unknown")
+	}
+	if to != "latest" {
+		t.Fatalf("to = %q, want %q", to, "latest")
+	}
+}

--- a/setup.sh
+++ b/setup.sh
@@ -446,7 +446,7 @@ if [ -f "${ENV_FILE}" ]; then
     fi
 fi
 
-if [ -t 0 ]; then
+if [ -t 0 ] && [ "${DIRIGENT_NON_INTERACTIVE:-0}" != "1" ] && [ "${DIRIGENT_UPGRADE:-0}" != "1" ]; then
     echo ""
     echo "Dashboard public exposure setup"
     echo "  Configure HTTPS + Basic Auth on a dedicated domain (optional)."


### PR DESCRIPTION
## Summary
- make `dirigent upgrade` show an explicit from/to version before execution using a best-effort local version lookup
- require interactive confirmation by default for CLI upgrades while preserving unattended execution via `--non-interactive --yes`
- mark upgrade runs with `DIRIGENT_UPGRADE=1` and skip dashboard fresh-setup prompts in `setup.sh` during upgrades
- add CLI unit tests for version resolution behavior and document the updated manual upgrade flow in getting started docs

## Testing
- `go test ./...` (in `cli/`)