### PR TITLE
feat(proxy): coordinate zero-downtime proxy swaps in redeploy

### DIFF
--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -1,13 +1,18 @@
 package docker
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net/http"
+	"os"
 	"sort"
 	"strings"
+	"time"
 
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -56,12 +61,18 @@ type Client interface {
 
 // Docker manages container lifecycle for Dirigent deployments.
 type Docker struct {
-	client Client
+	client      Client
+	proxyURL    string
+	proxyClient *http.Client
 }
 
 // New creates a Docker backed by the given client.
 func New(client Client) *Docker {
-	return &Docker{client: client}
+	return &Docker{
+		client:      client,
+		proxyURL:    proxyURLFromEnv(),
+		proxyClient: &http.Client{Timeout: 3 * time.Second},
+	}
 }
 
 // Ping reports whether the Docker daemon is reachable.
@@ -285,6 +296,12 @@ func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldC
 		return nil, fmt.Errorf("docker: resolve runtime ports for %s: %w", resp.ID, err)
 	}
 
+	if err := d.swapProxyRoute(ctx, dep.Domain, runtimePorts); err != nil {
+		_ = d.client.ContainerStop(ctx, resp.ID, container.StopOptions{})
+		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
+		return nil, fmt.Errorf("docker: swap proxy route for %q: %w", dep.Domain, err)
+	}
+
 	// New container is healthy; tear down the old one.
 	if err := d.StopAndRemove(ctx, oldContainerID); err != nil {
 		log.Printf("docker: remove old container %s: %v", oldContainerID, err)
@@ -432,4 +449,68 @@ func desiredExplicitHostPorts(ports []string) (map[string]string, error) {
 		result[p.Port()] = hostPort
 	}
 	return result, nil
+}
+
+type routeRequest struct {
+	Domain   string `json:"domain"`
+	Upstream string `json:"upstream"`
+}
+
+func (d *Docker) swapProxyRoute(ctx context.Context, domain string, runtimePorts []string) error {
+	domain = normalizeDomain(domain)
+	if domain == "" {
+		return nil
+	}
+
+	upstream := upstreamFromRuntimePorts(runtimePorts)
+	if upstream == "" {
+		return fmt.Errorf("runtime upstream not available")
+	}
+
+	body, err := json.Marshal(routeRequest{Domain: domain, Upstream: upstream})
+	if err != nil {
+		return fmt.Errorf("encode request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.proxyURL+"/internal/routes", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.proxyClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func upstreamFromRuntimePorts(runtimePorts []string) string {
+	for _, binding := range runtimePorts {
+		host, _, ok := strings.Cut(binding, ":")
+		if !ok || host == "" {
+			continue
+		}
+		return "localhost:" + host
+	}
+	return ""
+}
+
+func proxyURLFromEnv() string {
+	if baseURL := strings.TrimSpace(os.Getenv("DIRIGENT_PROXY_URL")); baseURL != "" {
+		return strings.TrimSuffix(baseURL, "/")
+	}
+	return "http://localhost:2019"
+}
+
+func normalizeDomain(domain string) string {
+	domain = strings.TrimSpace(domain)
+	domain = strings.TrimSuffix(domain, ".")
+	return strings.ToLower(domain)
 }

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	dockertypes "github.com/docker/docker/api/types"
@@ -36,6 +39,7 @@ type mockClient struct {
 	stopped          []string
 	removed          []string
 	renamed          []string
+	onStop           func(id string)
 }
 
 func (m *mockClient) Ping(_ context.Context) (dockertypes.Ping, error) {
@@ -64,6 +68,9 @@ func (m *mockClient) ContainerList(_ context.Context, _ container.ListOptions) (
 
 func (m *mockClient) ContainerStop(_ context.Context, id string, _ container.StopOptions) error {
 	m.stopped = append(m.stopped, id)
+	if m.onStop != nil {
+		m.onStop(id)
+	}
 	return m.stopErr
 }
 
@@ -345,6 +352,96 @@ func TestDocker_StartAndReplace_SameExplicitPorts_FallsBackToStopThenStart(t *te
 	}
 	if len(mock.removed) != 1 || mock.removed[0] != "old-c1" {
 		t.Fatalf("want old-c1 removed first, got %v", mock.removed)
+	}
+}
+
+func TestDocker_StartAndReplace_DomainConfigured_SwapsProxyBeforeStoppingOld(t *testing.T) {
+	var stopCalled atomic.Bool
+	var swapCalled atomic.Bool
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		swapCalled.Store(true)
+		if stopCalled.Load() {
+			t.Fatal("proxy swap happened after stopping old container")
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/internal/routes" {
+			t.Fatalf("want POST /internal/routes, got %s %s", r.Method, r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		r.Body.Close()
+		if string(body) != `{"domain":"example.com","upstream":"localhost:49123"}` {
+			t.Fatalf("unexpected body: %s", string(body))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer proxy.Close()
+
+	t.Setenv("DIRIGENT_PROXY_URL", proxy.URL)
+
+	mock := &mockClient{
+		containerCreate:  container.CreateResponse{ID: "new-c1"},
+		listContainers:   []dockertypes.Container{{ID: "new-c1", State: "running"}},
+		inspectContainer: inspectWithPort("3001/tcp", "49123"),
+		onStop: func(_ string) {
+			stopCalled.Store(true)
+		},
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.Ports = []string{"3001"}
+	dep.Domain = "Example.com."
+
+	if _, err := d.StartAndReplace(context.Background(), dep, "old-c1"); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+
+	if !swapCalled.Load() {
+		t.Fatal("want proxy route swap to be called")
+	}
+	if len(mock.stopped) != 1 || mock.stopped[0] != "old-c1" {
+		t.Fatalf("want old-c1 stopped, got %v", mock.stopped)
+	}
+}
+
+func TestDocker_StartAndReplace_ProxySwapFails_CleansUpNewAndKeepsOld(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer proxy.Close()
+
+	t.Setenv("DIRIGENT_PROXY_URL", proxy.URL)
+
+	mock := &mockClient{
+		containerCreate:  container.CreateResponse{ID: "new-c1"},
+		listContainers:   []dockertypes.Container{{ID: "new-c1", State: "running"}},
+		inspectContainer: inspectWithPort("3001/tcp", "49123"),
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.Ports = []string{"3001"}
+	dep.Domain = "example.com"
+
+	_, err := d.StartAndReplace(context.Background(), dep, "old-c1")
+	if err == nil {
+		t.Fatal("want error when proxy swap fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "swap proxy route") {
+		t.Fatalf("want proxy swap error, got %v", err)
+	}
+
+	if len(mock.stopped) != 1 || mock.stopped[0] != "new-c1" {
+		t.Fatalf("want only new-c1 stopped for cleanup, got %v", mock.stopped)
+	}
+	if len(mock.removed) != 1 || mock.removed[0] != "new-c1" {
+		t.Fatalf("want only new-c1 removed for cleanup, got %v", mock.removed)
+	}
+	if len(mock.renamed) != 0 {
+		t.Fatalf("want no rename on failure, got %v", mock.renamed)
 	}
 }
 

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -3,6 +3,8 @@ package handler_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -214,6 +216,102 @@ func TestSetRoute_InvalidBody(t *testing.T) {
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxy_AtomicSwap_KeepsInflightRequestsAndRoutesNewTraffic(t *testing.T) {
+	oldStarted := make(chan struct{}, 1)
+	oldRelease := make(chan struct{})
+
+	oldBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		oldStarted <- struct{}{}
+		<-oldRelease
+		_, _ = w.Write([]byte("old"))
+	}))
+	defer oldBackend.Close()
+
+	newBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("new"))
+	}))
+	defer newBackend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("example.com", oldBackend.Listener.Addr().String())
+
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	firstDone := make(chan string, 1)
+	firstErr := make(chan error, 1)
+	go func() {
+		req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+		req.Host = "example.com"
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			firstErr <- err
+			return
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			firstErr <- err
+			return
+		}
+		if resp.StatusCode != http.StatusOK {
+			firstErr <- errors.New("first request did not return 200")
+			return
+		}
+		firstDone <- string(body)
+	}()
+
+	select {
+	case <-oldStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first request to reach old backend")
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"domain":   "example.com",
+		"upstream": newBackend.Listener.Addr().String(),
+	})
+	resp, err := http.Post(proxy.URL+"/internal/routes", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /internal/routes: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("want 204 from swap, got %d", resp.StatusCode)
+	}
+
+	secondReq, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	secondReq.Host = "example.com"
+	secondResp, err := http.DefaultClient.Do(secondReq)
+	if err != nil {
+		t.Fatalf("second request through proxy: %v", err)
+	}
+	secondBody, err := io.ReadAll(secondResp.Body)
+	secondResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read second response: %v", err)
+	}
+	if secondResp.StatusCode != http.StatusOK {
+		t.Fatalf("want second request 200, got %d", secondResp.StatusCode)
+	}
+	if string(secondBody) != "new" {
+		t.Fatalf("want second request routed to new backend, got %q", string(secondBody))
+	}
+
+	close(oldRelease)
+
+	select {
+	case err := <-firstErr:
+		t.Fatalf("first request failed: %v", err)
+	case body := <-firstDone:
+		if body != "old" {
+			t.Fatalf("want inflight request to complete on old backend, got %q", body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first request completion")
 	}
 }
 


### PR DESCRIPTION
## Summary
- wire orchestrator `StartAndReplace` to call proxy `POST /internal/routes` after the new container is healthy and before the old container is stopped
- add configurable orchestrator proxy URL via `DIRIGENT_PROXY_URL` (default `http://localhost:2019`) and abort redeploy while preserving old container if route swap fails
- add tests covering swap ordering, failed swap rollback behavior, and proxy atomic swap behavior for in-flight vs new requests

## Testing
- go test ./... (orchestrator)
- go test ./... (proxy)

Closes #55