### PR TITLE
feat(dashboard): require deployment name confirmation before delete

### DIFF
--- a/dashboard/src/deployments/DeploymentRow.tsx
+++ b/dashboard/src/deployments/DeploymentRow.tsx
@@ -7,7 +7,7 @@ import { StatusBadge } from './StatusBadge'
 
 type Props = {
   deployment: Deployment
-  onDelete: (id: string) => void
+  onDelete: (deployment: Deployment) => void
   isDeleting: boolean
   onEdit: (deployment: Deployment) => void
 }
@@ -52,7 +52,7 @@ export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: P
             type="button"
             variant="ghost"
             size="icon"
-            onClick={() => onDelete(d.id)}
+            onClick={() => onDelete(d)}
             disabled={isDeleting}
             aria-label={`Delete ${d.name}`}
             className="h-7 w-7 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"

--- a/dashboard/src/deployments/DeploymentTable.tsx
+++ b/dashboard/src/deployments/DeploymentTable.tsx
@@ -1,5 +1,4 @@
 import { Box } from 'lucide-react'
-import type { UseMutationResult } from '@tanstack/react-query'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '../components/ui/table'
@@ -10,12 +9,13 @@ type Props = {
   deployments: Deployment[] | undefined
   isLoading: boolean
   isError: boolean
-  deleteMutation: UseMutationResult<void, Error, string>
+  isDeleting: boolean
+  onDelete: (deployment: Deployment) => void
   onEdit: (deployment: Deployment) => void
   onCreate: () => void
 }
 
-export function DeploymentTable({ deployments, isLoading, isError, deleteMutation, onEdit, onCreate }: Props) {
+export function DeploymentTable({ deployments, isLoading, isError, isDeleting, onDelete, onEdit, onCreate }: Props) {
   if (isLoading) return <p className="text-sm text-muted-foreground">Loading deployments…</p>
   if (isError) return <p className="text-sm text-destructive">Failed to load deployments.</p>
   if (!deployments?.length) {
@@ -54,8 +54,8 @@ export function DeploymentTable({ deployments, isLoading, isError, deleteMutatio
               <DeploymentRow
                 key={d.id}
                 deployment={d}
-                onDelete={id => deleteMutation.mutate(id)}
-                isDeleting={deleteMutation.isPending}
+                onDelete={onDelete}
+                isDeleting={isDeleting}
                 onEdit={onEdit}
               />
             ))}

--- a/dashboard/src/deployments/useDeleteDeploymentDialog.ts
+++ b/dashboard/src/deployments/useDeleteDeploymentDialog.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+import type { Deployment } from '../lib/api'
+
+export function useDeleteDeploymentDialog() {
+  const [deploymentToDelete, setDeploymentToDelete] = useState<Deployment | null>(null)
+  const [typedName, setTypedName] = useState('')
+
+  const openDeleteDialog = (deployment: Deployment) => {
+    setDeploymentToDelete(deployment)
+    setTypedName('')
+  }
+
+  const closeDeleteDialog = () => {
+    setDeploymentToDelete(null)
+    setTypedName('')
+  }
+
+  const nameMatches = deploymentToDelete !== null && typedName === deploymentToDelete.name
+
+  return {
+    deploymentToDelete,
+    typedName,
+    setTypedName,
+    nameMatches,
+    openDeleteDialog,
+    closeDeleteDialog,
+  }
+}

--- a/dashboard/src/pages/DeploymentList.tsx
+++ b/dashboard/src/pages/DeploymentList.tsx
@@ -1,16 +1,27 @@
 import { Plus } from 'lucide-react'
 import { Button } from '../components/ui/button'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
 import CreateDeploymentForm from '../deployments/CreateDeploymentForm'
 import EditDeploymentForm from '../deployments/EditDeploymentForm'
 import { DeploymentTable } from '../deployments/DeploymentTable'
+import { useDeleteDeploymentDialog } from '../deployments/useDeleteDeploymentDialog'
 import { useDeploymentDialogs } from '../deployments/useDeploymentDialogs'
 import { useDeploymentList } from '../deployments/useDeploymentList'
 import { useDeploymentSSE } from '../deployments/useDeploymentSSE'
 
 export default function DeploymentList() {
   useDeploymentSSE()
-  const listState = useDeploymentList()
+  const { deployments, isLoading, isError, deleteMutation } = useDeploymentList()
+  const {
+    deploymentToDelete,
+    typedName,
+    setTypedName,
+    nameMatches,
+    openDeleteDialog,
+    closeDeleteDialog,
+  } = useDeleteDeploymentDialog()
   const {
     createDialogOpen,
     openCreateDialog,
@@ -64,7 +75,52 @@ export default function DeploymentList() {
         </DialogContent>
       </Dialog>
 
-      <DeploymentTable {...listState} onEdit={openEditDialog} onCreate={openCreateDialog} />
+      <Dialog open={deploymentToDelete !== null} onOpenChange={open => !open && closeDeleteDialog()}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Delete deployment</DialogTitle>
+            <DialogDescription>
+              Type <span className="font-medium text-foreground">{deploymentToDelete?.name}</span> to confirm deletion.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="delete-deployment-name">Deployment name</Label>
+            <Input
+              id="delete-deployment-name"
+              value={typedName}
+              onChange={event => setTypedName(event.target.value)}
+              placeholder={deploymentToDelete?.name ?? ''}
+              autoComplete="off"
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={closeDeleteDialog} disabled={deleteMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={!nameMatches || deleteMutation.isPending}
+              onClick={() => {
+                if (!deploymentToDelete) return
+                deleteMutation.mutate(deploymentToDelete.id, { onSuccess: closeDeleteDialog })
+              }}
+            >
+              Delete deployment
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <DeploymentTable
+        deployments={deployments}
+        isLoading={isLoading}
+        isError={isError}
+        isDeleting={deleteMutation.isPending}
+        onDelete={openDeleteDialog}
+        onEdit={openEditDialog}
+        onCreate={openCreateDialog}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- add a delete confirmation dialog on the deployments list instead of deleting immediately from the row action
- require the user to type the exact deployment name before enabling the destructive action
- keep existing delete mutation behavior and close the dialog only after successful deletion

## Testing
- bunx vitest run
- bun run build