### PR TITLE
feat(api): serve dashboard from embedded assets in production

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,12 +182,6 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('dashboard/bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
 
-      - name: Build API binaries
-        working-directory: api
-        run: |
-          GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${{ github.ref_name }}" -o ../dirigent-linux-amd64 ./cmd/dirigent
-          GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=${{ github.ref_name }}" -o ../dirigent-linux-arm64 ./cmd/dirigent
-
       - name: Build CLI binaries
         working-directory: cli
         run: |
@@ -214,8 +208,16 @@ jobs:
         working-directory: dashboard
         run: bun run build
 
-      - name: Package dashboard
-        run: tar -czf dashboard.tar.gz -C dashboard dist server.ts package.json
+      - name: Sync dashboard bundle into API module
+        run: |
+          mkdir -p api/internal/dashboard/static
+          cp -R dashboard/dist/. api/internal/dashboard/static/
+
+      - name: Build API binaries
+        working-directory: api
+        run: |
+          GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${{ github.ref_name }}" -o ../dirigent-linux-amd64 ./cmd/dirigent
+          GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=${{ github.ref_name }}" -o ../dirigent-linux-arm64 ./cmd/dirigent
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -230,7 +232,6 @@ jobs:
             dirigent-orchestrator-linux-arm64
             dirigent-proxy-linux-amd64
             dirigent-proxy-linux-arm64
-            dashboard.tar.gz
             install.sh
             setup.sh
 
@@ -275,7 +276,6 @@ jobs:
             dirigent-orchestrator-linux-arm64 \
             dirigent-proxy-linux-amd64 \
             dirigent-proxy-linux-arm64 \
-            dashboard.tar.gz \
             install.sh \
             setup.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ control-plane/tmp/
 
 **/*/node_modules
 **/*/.vite
+
+api/internal/dashboard/static/*
+!api/internal/dashboard/static/zz-placeholder.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Docker orchestration for solo devs/VPS. Lightweight K8s alternative.
 ## Development Commands
 - **Full Stack:** `make dev` (API :8080, Dashboard :5173, Orchestrator).
 - **Setup:** `make setup` | **Build:** `make build` | **Test:** `make test`.
-- **Dashboard Prod:** `cd dashboard && bun run build && bun run start`.
+- **Dashboard Prod:** bundled into `dirigent-api` via embedded static assets.
 
 ## Guidelines
 ### Git & Commits

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -23,10 +23,9 @@ The bootstrap installer installs the `dirigent` CLI.
 
 Then `dirigent setup` will:
 1. Install Docker Engine if not already present
-2. Install Bun if not already present
-3. Download all Dirigent components for your architecture (`amd64` or `arm64`)
-4. Create and enable four systemd services
-5. Print a summary of running services and their ports
+2. Download all Dirigent components for your architecture (`amd64` or `arm64`)
+3. Create and enable three systemd services
+4. Print a summary of running services and their ports
 
 In interactive mode, setup recommends the `strict` security profile.
 
@@ -34,14 +33,13 @@ In interactive mode, setup recommends the `strict` security profile.
 
 | Service | Port | Description |
 |---|---|---|
-| `dirigent-api` | `:8080` | REST API |
+| `dirigent-api` | `:8080` | REST API + dashboard UI |
 | `dirigent-proxy` | `:80` | Reverse proxy for your deployments |
-| `dirigent-dashboard` | `:3000` | Web UI |
 | `dirigent-orchestrator` | — | Internal reconciler, no inbound port |
 
-Open the dashboard at `http://<your-vps-ip>:3000`.
+Open the dashboard at `http://<your-vps-ip>:8080`.
 
-> **Why port 3000?** The dashboard runs on its own port rather than through the Dirigent proxy. This gives you immediate access without any DNS setup. If you want HTTPS + Basic Auth on a dedicated domain through Dirigent's built-in proxy, run `sudo dirigent setup`.
+> **Why port 8080?** The API now serves the embedded dashboard bundle directly, so production no longer requires Bun or Node on the VPS. For HTTPS + Basic Auth on a dedicated domain, run `sudo dirigent setup` and set dashboard exposure.
 
 ### Configure dashboard access after install
 
@@ -82,7 +80,6 @@ For unattended runs (for example CI/automation), pass `--non-interactive --yes`.
 journalctl -u dirigent-api -f
 journalctl -u dirigent-orchestrator -f
 journalctl -u dirigent-proxy -f
-journalctl -u dirigent-dashboard -f
 
 # Restart a service
 sudo systemctl restart dirigent-api
@@ -145,7 +142,7 @@ All services share a single JSON file at `/tmp/dirigent.json` in dev mode. Delet
 
 ## Deploy your first container
 
-1. Open the dashboard (`http://localhost:5173` in dev, or `http://<vps-ip>:3000` in production)
+1. Open the dashboard (`http://localhost:5173` in dev, or `http://<vps-ip>:8080` in production)
 2. Click **New Deployment**
 3. Fill in a name, Docker image, and any ports or environment variables
 4. Click **Deploy**

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ dev:
 
 # Compile the Go binaries.
 build:
+	cd dashboard && bun run build
+	mkdir -p api/internal/dashboard/static
+	cp -R dashboard/dist/. api/internal/dashboard/static/
 	cd cli && go build -o ../dirigent-cli ./cmd/dirigent
 	cd api && go build -o ../dirigent ./cmd/dirigent
 	cd orchestrator && go build -o ../dirigent-orchestrator ./cmd/orchestrator

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ The bootstrap installer will:
 
 Then `dirigent setup` will:
 - Install Docker Engine if not already present
-- Install Bun if not already present
 - Download all Dirigent components for your architecture (`amd64` / `arm64`)
-- Register and start four systemd services that survive reboots
+- Register and start three systemd services that survive reboots
 - Create the `/var/lib/dirigent/` data directory and the `dirigent` Docker network
 - Offer security profiles in guided mode (`strict` is recommended)
 - Configure proxy hardening profiles (`standard` by default, `strict` recommended for internet-facing hosts)
@@ -56,13 +55,11 @@ sudo DIRIGENT_PROXY_HARDENING_PROFILE=strict dirigent setup
 
 | Service               | Port   | Description                                    |
 |-----------------------|--------|------------------------------------------------|
-| `dirigent-api`        | `:8080`| REST API — reads/writes deployment state       |
+| `dirigent-api`        | `:8080`| REST API + dashboard UI                        |
 | `dirigent-orchestrator` | —    | Reconciler — syncs state with Docker (no port) |
 | `dirigent-proxy`      | `:80`  | Reverse proxy — routes traffic to containers   |
-| `dirigent-dashboard`  | `:3000`| Web dashboard                                  |
 
-**Why is the dashboard on `:3000` and not behind the proxy at `:80`?**
-The reverse proxy only routes traffic to your deployed containers. The dashboard must remain reachable before any containers are configured, so it runs as its own service on a dedicated port.
+The dashboard is served by `dirigent-api` on `:8080` by default. If you set `DIRIGENT_DASHBOARD_DOMAIN` during setup, the proxy exposes it on `:80/:443` with optional Basic Auth.
 
 ## Features
 
@@ -84,7 +81,7 @@ The reverse proxy only routes traffic to your deployed containers. The dashboard
 | `api/`           | Go REST API — reads/writes the JSON store (`:8080`) |
 | `orchestrator/`  | Go reconciler — syncs store state with Docker      |
 | `store/`         | Shared Go module — deployment types + JSON store   |
-| `dashboard/`     | React + Vite web dashboard (`:3000`)               |
+| `dashboard/`     | React + Vite web dashboard (dev server `:5173`)    |
 
 The three Go services share a single `go.work` workspace at the repo root.
 

--- a/api/cmd/dirigent/main.go
+++ b/api/cmd/dirigent/main.go
@@ -8,6 +8,7 @@ import (
 	dockerclient "github.com/docker/docker/client"
 
 	"github.com/ercadev/dirigent/internal/api"
+	"github.com/ercadev/dirigent/internal/dashboard"
 	"github.com/ercadev/dirigent/internal/docker"
 	"github.com/ercadev/dirigent/internal/events"
 	"github.com/ercadev/dirigent/store"
@@ -44,9 +45,10 @@ func main() {
 
 	mux := http.NewServeMux()
 	api.NewWithVersion(s, broker, logStreamer, version).RegisterRoutes(mux)
+	handler := dashboard.New(mux)
 
 	log.Printf("dirigent API listening on %s", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	if err := http.ListenAndServe(addr, handler); err != nil {
 		log.Fatalf("dirigent: %v", err)
 	}
 }

--- a/api/internal/dashboard/handler.go
+++ b/api/internal/dashboard/handler.go
@@ -1,0 +1,82 @@
+package dashboard
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+)
+
+//go:embed all:static
+var staticAssets embed.FS
+
+func New(apiHandler http.Handler) http.Handler {
+	assets, err := fs.Sub(staticAssets, "static")
+	if err != nil {
+		panic(err)
+	}
+
+	index, err := fs.ReadFile(assets, "index.html")
+	if err != nil {
+		index, err = fs.ReadFile(assets, "zz-placeholder.html")
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	fileServer := http.FileServer(http.FS(assets))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isAPIPath(r.URL.Path) {
+			apiHandler.ServeHTTP(w, r)
+			return
+		}
+
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		assetPath := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
+		if assetPath == "." || assetPath == "" {
+			serveIndex(w, r, index)
+			return
+		}
+
+		if assetPath == "index.html" || fileExists(assets, assetPath) {
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+
+		serveIndex(w, r, index)
+	})
+}
+
+func isAPIPath(path string) bool {
+	return path == "/api" || strings.HasPrefix(path, "/api/")
+}
+
+func fileExists(fsys fs.FS, name string) bool {
+	f, err := fsys.Open(name)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+
+	return !info.IsDir()
+}
+
+func serveIndex(w http.ResponseWriter, r *http.Request, body []byte) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	_, _ = w.Write(body)
+}

--- a/api/internal/dashboard/handler_test.go
+++ b/api/internal/dashboard/handler_test.go
@@ -1,0 +1,114 @@
+package dashboard
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNew_RoutesAPIRequestsToAPIHandler(t *testing.T) {
+	apiMux := http.NewServeMux()
+	apiMux.HandleFunc("GET /api/ping", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("api"))
+	})
+
+	h := New(apiMux)
+	req := httptest.NewRequest(http.MethodGet, "/api/ping", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	if strings.TrimSpace(rr.Body.String()) != "api" {
+		t.Fatalf("want api response body, got %q", rr.Body.String())
+	}
+}
+
+func TestNew_ServesSPAIndexForRoot(t *testing.T) {
+	h := New(http.NewServeMux())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("want text/html content type, got %q", ct)
+	}
+	if rr.Body.Len() == 0 {
+		t.Fatal("want non-empty index body")
+	}
+}
+
+func TestNew_FallsBackToSPAIndexForUnknownPath(t *testing.T) {
+	h := New(http.NewServeMux())
+	req := httptest.NewRequest(http.MethodGet, "/deployments/123", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("want text/html content type, got %q", ct)
+	}
+}
+
+func TestNew_HeadReturnsHeadersWithoutBody(t *testing.T) {
+	h := New(http.NewServeMux())
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	res := rr.Result()
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if len(body) != 0 {
+		t.Fatalf("want empty body for HEAD, got %q", string(body))
+	}
+}
+
+func TestNew_NonGetAndNonHeadReturnsMethodNotAllowed(t *testing.T) {
+	h := New(http.NewServeMux())
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("want 405, got %d", rr.Code)
+	}
+}
+
+func TestIsAPIPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{path: "/api", want: true},
+		{path: "/api/", want: true},
+		{path: "/api/deployments", want: true},
+		{path: "/apix", want: false},
+		{path: "/", want: false},
+	}
+
+	for _, tc := range cases {
+		if got := isAPIPath(tc.path); got != tc.want {
+			t.Fatalf("path %q: want %v, got %v", tc.path, tc.want, got)
+		}
+	}
+}

--- a/api/internal/dashboard/static/zz-placeholder.html
+++ b/api/internal/dashboard/static/zz-placeholder.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dirigent</title>
+  </head>
+  <body>
+    <p>Dashboard assets are not bundled in this build.</p>
+  </body>
+</html>

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -65,8 +65,8 @@ func main() {
 	}
 	defer accessLogger.Close()
 	if dashboardAuth != nil {
-		table.SetStatic(dashboardAuth.Domain, "localhost:3000")
-		log.Printf("proxy: registered dashboard domain %s -> localhost:3000", dashboardAuth.Domain)
+		table.SetStatic(dashboardAuth.Domain, "localhost:8080")
+		log.Printf("proxy: registered dashboard domain %s -> localhost:8080", dashboardAuth.Domain)
 	}
 
 	log.Printf("proxy: hardening profile %s", hardeningProfile)

--- a/setup.sh
+++ b/setup.sh
@@ -331,52 +331,12 @@ else
     STEP_DOCKER="installed"
 fi
 
-# ─── Bun installation ─────────────────────────────────────────────────────────
-
-# install_bun downloads the Bun runtime binary directly from GitHub releases
-# and places it at /usr/local/bin/bun, making it available system-wide.
-install_bun() {
-    # Bun uses different arch names than Go.
-    local bun_arch
-    case "${ARCH}" in
-        amd64) bun_arch="x64" ;;
-        arm64) bun_arch="aarch64" ;;
-    esac
-
-    local bun_tmp
-    bun_tmp=$(mktemp -d)
-
-    step "Installing unzip (required to extract Bun)"
-    apt-get install -y -q unzip
-
-    step "Downloading Bun runtime (linux/${ARCH})"
-    curl -fsSL \
-        "https://github.com/oven-sh/bun/releases/latest/download/bun-linux-${bun_arch}.zip" \
-        -o "${bun_tmp}/bun.zip"
-
-    unzip -q "${bun_tmp}/bun.zip" -d "${bun_tmp}"
-    install -m 755 "${bun_tmp}/bun-linux-${bun_arch}/bun" /usr/local/bin/bun
-
-    rm -rf "${bun_tmp}"
-}
-
-step "Checking for existing Bun installation"
-
-if command -v bun > /dev/null 2>&1; then
-    step "Bun already installed ($(bun --version)); skipping"
-    STEP_BUN="already installed"
-else
-    install_bun
-    step "Bun installed ($(bun --version))"
-    STEP_BUN="installed"
-fi
-
 # ─── stop existing services (upgrade flow) ────────────────────────────────────
 
 # Stop all services before replacing any files so binaries are never swapped
 # out from under a running process. Also stop and disable the legacy monolithic
 # service from older installs so it does not hold port 8080.
-SERVICES="dirigent-api dirigent-orchestrator dirigent-proxy dirigent-dashboard"
+SERVICES="dirigent-api dirigent-orchestrator dirigent-proxy"
 
 step "Stopping any running Dirigent services"
 
@@ -385,6 +345,12 @@ if systemctl is-active --quiet dirigent 2>/dev/null; then
     systemctl stop dirigent
     systemctl disable dirigent 2>/dev/null || true
 fi
+
+if systemctl is-active --quiet dirigent-dashboard 2>/dev/null; then
+    step "Stopping legacy dirigent-dashboard"
+    systemctl stop dirigent-dashboard
+fi
+systemctl disable dirigent-dashboard 2>/dev/null || true
 
 for svc in ${SERVICES}; do
     if systemctl is-active --quiet "${svc}" 2>/dev/null; then
@@ -406,17 +372,6 @@ download_binary() {
 download_binary "dirigent-linux-${ARCH}"              /usr/local/bin/dirigent-api
 download_binary "dirigent-orchestrator-linux-${ARCH}" /usr/local/bin/dirigent-orchestrator
 download_binary "dirigent-proxy-linux-${ARCH}"        /usr/local/bin/dirigent-proxy
-
-# ─── download and install dashboard ──────────────────────────────────────────
-
-DASHBOARD_DIR="/opt/dirigent/dashboard"
-
-step "Installing dashboard to ${DASHBOARD_DIR}"
-mkdir -p "${DASHBOARD_DIR}"
-curl -fsSL "${RELEASE_BASE}/dashboard.tar.gz" | tar -xz -C "${DASHBOARD_DIR}"
-
-step "Installing dashboard production dependencies"
-(cd "${DASHBOARD_DIR}" && bun install --production)
 
 # ─── data directory ───────────────────────────────────────────────────────────
 
@@ -606,24 +561,6 @@ RestartSec=5
 WantedBy=multi-user.target
 EOF
 
-cat > /etc/systemd/system/dirigent-dashboard.service << EOF
-[Unit]
-Description=Dirigent dashboard
-Documentation=https://github.com/ercadev/dirigent
-After=network.target dirigent-api.service
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/bun ${DASHBOARD_DIR}/server.ts
-Environment=PORT=3000
-Environment=DIRIGENT_API_URL=http://localhost:8080
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
 # ─── enable and start services ────────────────────────────────────────────────
 
 step "Reloading systemd daemon"
@@ -661,13 +598,12 @@ echo "  Services:"
 printf "    %-30s %s\n" "dirigent-api          :8080"  "$(systemctl is-active dirigent-api)"
 printf "    %-30s %s\n" "dirigent-orchestrator  —"     "$(systemctl is-active dirigent-orchestrator)"
 printf "    %-30s %s\n" "dirigent-proxy        :80"    "$(systemctl is-active dirigent-proxy)"
-printf "    %-30s %s\n" "dirigent-dashboard    :3000"  "$(systemctl is-active dirigent-dashboard)"
 echo ""
 if [ -n "${DASHBOARD_DOMAIN}" ]; then
     echo "  Dashboard:  https://${DASHBOARD_DOMAIN}"
     echo "              (Basic Auth user: ${DASHBOARD_USER})"
 else
-    echo "  Dashboard:  http://${SERVER_IP}:3000"
+    echo "  Dashboard:  http://${SERVER_IP}:8080"
 fi
 echo "  API:        http://${SERVER_IP}:8080"
 echo "  Proxy:      http://${SERVER_IP}:80"
@@ -676,14 +612,13 @@ if [ -n "${DASHBOARD_DOMAIN}" ]; then
     echo "  Note: Ensure DNS A record for ${DASHBOARD_DOMAIN} points to this server"
     echo "  and port 80 is open so certificates can be issued."
 else
-    echo "  Note: The dashboard runs directly on :3000 rather than through the :80"
-    echo "  reverse proxy. This keeps it accessible even when no deployments are"
-    echo "  configured — the proxy only routes traffic to your deployed containers."
+    echo "  Note: The dashboard is served directly by dirigent-api on :8080."
+    echo "  Configure DIRIGENT_DASHBOARD_DOMAIN in setup to expose it through"
+    echo "  the :80/:443 reverse proxy with TLS and optional Basic Auth."
 fi
 echo ""
 echo "  Setup summary:"
 echo "    Docker        ${STEP_DOCKER}"
-echo "    Bun           ${STEP_BUN}"
 echo "    Network       ${STEP_NETWORK}"
 echo "    Data dir      ${DATA_DIR}"
 echo "    Version       ${DIRIGENT_VERSION}"

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -1,6 +1,6 @@
 ## Getting Started
 
-Dirigent installs as four systemd services on your VPS. This guide walks you from a fresh Ubuntu or Debian server to running your first container in under five minutes.
+Dirigent installs as three systemd services on your VPS. This guide walks you from a fresh Ubuntu or Debian server to running your first container in under five minutes.
 
 ## Prerequisites
 
@@ -21,23 +21,21 @@ Run the following command on your VPS:
 The installer will:
 
 - Install Docker if it is not already present.
-- Install Bun (required to run the dashboard server).
-- Download and install the four Dirigent binaries.
+- Download and install the three Dirigent binaries.
 - Create a Docker bridge network named `dirigent`.
-- Write and enable four systemd units: `dirigent-api`, `dirigent-orchestrator`, `dirigent-proxy`, and `dirigent-dashboard`.
+- Write and enable three systemd units: `dirigent-api`, `dirigent-orchestrator`, and `dirigent-proxy`.
 - Prompt for optional dashboard domain + Basic Auth setup (works in normal SSH sessions, including piped install commands).
 
 > **Tip:** To pin a specific version, prefix the command with `DIRIGENT_VERSION=v0.0.2` before the curl.
 
 ## Verify the installation
 
-Once the installer completes, confirm all four services are running:
+Once the installer completes, confirm all services are running:
 
 ```bash
 systemctl status dirigent-api
 systemctl status dirigent-orchestrator
 systemctl status dirigent-proxy
-systemctl status dirigent-dashboard
 ```
 
 Each service should report `active (running)`. If one has failed, inspect its logs:
@@ -48,13 +46,13 @@ journalctl -u dirigent-api -n 50
 
 ## Access the dashboard
 
-By default, the dashboard is available directly on port `3000`:
+By default, the dashboard is available on port `8080` (served by `dirigent-api`):
 
 ```text
-http://<your-vps-ip>:3000
+http://<your-vps-ip>:8080
 ```
 
-The dashboard connects to the local API on port 8080. The orchestrator has no public inbound port.
+The orchestrator has no public inbound port.
 
 ### Expose dashboard publicly (HTTPS + Basic Auth)
 


### PR DESCRIPTION
## Summary
- Add an embedded dashboard handler in the API so production serves SPA assets from the `dirigent-api` binary while preserving `/api/*` routing.
- Update build/release pipelines to build the dashboard bundle and sync `dashboard/dist` into `api/internal/dashboard/static` before API builds.
- Remove Bun/dashboard runtime requirements from VPS setup, switch proxy dashboard upstream to `localhost:8080`, and refresh docs for the new production flow.

## Testing
- go test ./... (api)
- go test ./... (proxy)
- make build

Closes #135