### PR TITLE
fix(some): split release workflow into auto-tag and tag-triggered release

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,69 @@
+name: Auto Tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  version:
+    name: Determine version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate next semver from conventional commits
+        run: |
+          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          [ -z "$LATEST" ] && LATEST="v0.0.0"
+
+          COMMITS=$(git log --pretty=format:"%s%n%b" "${LATEST}..HEAD")
+          if [ -z "$COMMITS" ]; then
+            echo "No commits since ${LATEST}, skipping tag"
+            exit 0
+          fi
+
+          BUMP="none"
+          while IFS= read -r line; do
+            # Footer token per conventional commits spec (must start the line).
+            # This avoids matching prose like "e.g. BREAKING CHANGE -> major".
+            if echo "$line" | grep -qE '^BREAKING[- ]CHANGE:'; then
+              BUMP="major"; break
+            fi
+            if echo "$line" | grep -qE '^[a-z]+(\([^)]+\))?!:'; then
+              BUMP="major"; break
+            fi
+            if echo "$line" | grep -qE '^feat(\([^)]+\))?:' && [ "$BUMP" != "major" ] && [ "$BUMP" != "minor" ]; then
+              BUMP="minor"
+            fi
+            if echo "$line" | grep -qE '^(fix|perf)(\([^)]+\))?:' && [ "$BUMP" = "none" ]; then
+              BUMP="patch"
+            fi
+          done <<< "$COMMITS"
+
+          if [ "$BUMP" = "none" ]; then
+            echo "No releasable commits since ${LATEST}, skipping tag"
+            exit 0
+          fi
+
+          VER=${LATEST#v}
+          MAJOR=$(echo "$VER" | cut -d. -f1)
+          MINOR=$(echo "$VER" | cut -d. -f2)
+          PATCH=$(echo "$VER" | cut -d. -f3)
+          case "$BUMP" in
+            major) MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR+1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH+1)) ;;
+          esac
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "Bumping ${LATEST} -> ${NEW_TAG} (${BUMP})"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,92 +2,12 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "v*"
 
 jobs:
-  # Runs only on push to main. Parses conventional commits since the last tag,
-  # determines the next vX.Y.Z, and pushes the tag. Downstream jobs key off the
-  # outputs so the rest of the pipeline is shared with manual tag pushes.
-  version:
-    name: Determine version
-    if: github.ref_type == 'branch'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      tag: ${{ steps.bump.outputs.tag }}
-      skip: ${{ steps.bump.outputs.skip }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Calculate next semver from conventional commits
-        id: bump
-        run: |
-          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          [ -z "$LATEST" ] && LATEST="v0.0.0"
-
-          COMMITS=$(git log --pretty=format:"%s%n%b" "${LATEST}..HEAD")
-          if [ -z "$COMMITS" ]; then
-            echo "No commits since ${LATEST}, skipping release"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          BUMP="none"
-          while IFS= read -r line; do
-            # Footer token per conventional commits spec (must start the line).
-            # This avoids matching prose like "e.g. BREAKING CHANGE → major".
-            if echo "$line" | grep -qE '^BREAKING[- ]CHANGE:'; then
-              BUMP="major"; break
-            fi
-            if echo "$line" | grep -qE '^[a-z]+(\([^)]+\))?!:'; then
-              BUMP="major"; break
-            fi
-            if echo "$line" | grep -qE '^feat(\([^)]+\))?:' && [ "$BUMP" != "major" ] && [ "$BUMP" != "minor" ]; then
-              BUMP="minor"
-            fi
-            if echo "$line" | grep -qE '^(fix|perf)(\([^)]+\))?:' && [ "$BUMP" = "none" ]; then
-              BUMP="patch"
-            fi
-          done <<< "$COMMITS"
-
-          if [ "$BUMP" = "none" ]; then
-            echo "No releasable commits since ${LATEST}, skipping release"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          VER=${LATEST#v}
-          MAJOR=$(echo "$VER" | cut -d. -f1)
-          MINOR=$(echo "$VER" | cut -d. -f2)
-          PATCH=$(echo "$VER" | cut -d. -f3)
-          case "$BUMP" in
-            major) MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0 ;;
-            minor) MINOR=$((MINOR+1)); PATCH=0 ;;
-            patch) PATCH=$((PATCH+1)) ;;
-          esac
-
-          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
-          echo "Bumping ${LATEST} → ${NEW_TAG} (${BUMP})"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$NEW_TAG"
-          git push origin "$NEW_TAG"
-
-          echo "tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
   ci-go:
     name: CI / Go
-    needs: [version]
-    # Run on tag pushes (version is skipped) or when version produced a new tag.
-    if: ${{ always() && (github.ref_type == 'tag' || needs.version.outputs.skip == 'false') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -130,8 +50,6 @@ jobs:
 
   ci-react:
     name: CI / React
-    needs: [version]
-    if: ${{ always() && (github.ref_type == 'tag' || needs.version.outputs.skip == 'false') }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -157,8 +75,7 @@ jobs:
 
   build:
     name: Build artifacts
-    needs: [ci-go, ci-react, version]
-    if: ${{ always() && needs.ci-go.result == 'success' && needs.ci-react.result == 'success' }}
+    needs: [ci-go, ci-react]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -236,13 +153,12 @@ jobs:
 
   release:
     name: GitHub Release
-    needs: [build, version]
-    if: ${{ always() && needs.build.result == 'success' }}
+    needs: [build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
-      RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || needs.version.outputs.tag }}
+      RELEASE_TAG: ${{ github.ref_name }}
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -281,11 +197,10 @@ jobs:
 
   docker-landing:
     name: Docker / Landing
-    needs: [build, version]
-    if: ${{ always() && needs.build.result == 'success' }}
+    needs: [build]
     runs-on: ubuntu-latest
     env:
-      RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || needs.version.outputs.tag }}
+      RELEASE_TAG: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- split release automation into two workflows: `auto-tag.yml` for `main` pushes and `release.yml` for `v*` tag pushes only
- remove branch/tag conditional plumbing from `release.yml` (`always()`, `ref_type`, and `needs.version.outputs` fallbacks)
- keep version injection tied to `github.ref_name` in tag context so API binaries report the actual semver release tag

Closes #137