### PR TITLE
feat(auth): add per-deployment HTTP Basic Auth (API + proxy + dashboard)

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,6 +2,9 @@ module github.com/ercadev/dirigent
 
 go 1.24.0
 
-require github.com/ercadev/dirigent/store v0.0.0
+require (
+	github.com/ercadev/dirigent/store v0.0.0
+	golang.org/x/crypto v0.48.0
+)
 
 replace github.com/ercadev/dirigent/store => ../store

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/ercadev/dirigent/internal/events"
 	"github.com/ercadev/dirigent/internal/upgrade"
 	"github.com/ercadev/dirigent/internal/version"
@@ -54,21 +56,32 @@ type UpgradeRunner interface {
 	IsRunning() bool
 }
 
+type basicAuthUserRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type basicAuthRequest struct {
+	Users []basicAuthUserRequest `json:"users"`
+}
+
 type deploymentRequest struct {
-	Name    string            `json:"name"`
-	Image   string            `json:"image"`
-	Envs    map[string]string `json:"envs"`
-	Ports   []string          `json:"ports"`
-	Volumes []string          `json:"volumes"`
-	Domain  string            `json:"domain"`
+	Name      string            `json:"name"`
+	Image     string            `json:"image"`
+	Envs      map[string]string `json:"envs"`
+	Ports     []string          `json:"ports"`
+	Volumes   []string          `json:"volumes"`
+	Domain    string            `json:"domain"`
+	BasicAuth *basicAuthRequest `json:"basic_auth"`
 }
 
 type patchDeploymentRequest struct {
-	Image   string            `json:"image"`
-	Envs    map[string]string `json:"envs"`
-	Ports   []string          `json:"ports"`
-	Volumes []string          `json:"volumes"`
-	Domain  string            `json:"domain"`
+	Image     string            `json:"image"`
+	Envs      map[string]string `json:"envs"`
+	Ports     []string          `json:"ports"`
+	Volumes   []string          `json:"volumes"`
+	Domain    string            `json:"domain"`
+	BasicAuth *basicAuthRequest `json:"basic_auth"`
 }
 
 // Handler holds the dependencies for the API layer.
@@ -369,7 +382,8 @@ func updateRequiresRedeploy(existing store.Deployment, body deploymentRequest) b
 	return existing.Image != body.Image ||
 		!equalStringMap(existing.Envs, body.Envs) ||
 		!slices.Equal(existing.Ports, body.Ports) ||
-		!slices.Equal(existing.Volumes, body.Volumes)
+		!slices.Equal(existing.Volumes, body.Volumes) ||
+		!equalBasicAuthConfig(existing.BasicAuth, body.BasicAuth)
 }
 
 func patchRequiresRedeploy(existing store.Deployment, body patchDeploymentRequest) bool {
@@ -385,7 +399,42 @@ func patchRequiresRedeploy(existing store.Deployment, body patchDeploymentReques
 	if body.Volumes != nil && !slices.Equal(existing.Volumes, body.Volumes) {
 		return true
 	}
+	if body.BasicAuth != nil && !equalBasicAuthConfig(existing.BasicAuth, body.BasicAuth) {
+		return true
+	}
 	return false
+}
+
+func sanitizeAndHashBasicAuth(input *basicAuthRequest) (*store.BasicAuthConfig, error) {
+	if input == nil {
+		return nil, nil
+	}
+	if len(input.Users) == 0 {
+		return nil, nil
+	}
+	users := make([]store.BasicAuthUser, 0, len(input.Users))
+	for _, user := range input.Users {
+		username := strings.TrimSpace(user.Username)
+		if username == "" {
+			return nil, fmt.Errorf("basic auth username is required")
+		}
+		password := strings.TrimSpace(user.Password)
+		if password == "" {
+			return nil, fmt.Errorf("basic auth password is required")
+		}
+
+		if _, err := bcrypt.Cost([]byte(password)); err != nil {
+			hashed, hashErr := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+			if hashErr != nil {
+				return nil, fmt.Errorf("hash basic auth password: %w", hashErr)
+			}
+			password = string(hashed)
+		}
+
+		users = append(users, store.BasicAuthUser{Username: username, Password: password})
+	}
+
+	return &store.BasicAuthConfig{Users: users}, nil
 }
 
 func dashboardDomainFromEnv() string {
@@ -412,6 +461,27 @@ func equalStringMap(a, b map[string]string) bool {
 	}
 	for k, av := range a {
 		if bv, ok := b[k]; !ok || bv != av {
+			return false
+		}
+	}
+	return true
+}
+
+func equalBasicAuthConfig(existing *store.BasicAuthConfig, request *basicAuthRequest) bool {
+	if request == nil {
+		return existing == nil
+	}
+	if existing == nil {
+		return false
+	}
+	if len(existing.Users) != len(request.Users) {
+		return false
+	}
+	for i, user := range request.Users {
+		if existing.Users[i].Username != strings.TrimSpace(user.Username) {
+			return false
+		}
+		if existing.Users[i].Password != strings.TrimSpace(user.Password) {
 			return false
 		}
 	}

--- a/api/internal/api/handler_create_deployment.go
+++ b/api/internal/api/handler_create_deployment.go
@@ -27,6 +27,12 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	basicAuth, err := sanitizeAndHashBasicAuth(body.BasicAuth)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	id, err := newID()
 	if err != nil {
 		http.Error(w, "failed to generate id", http.StatusInternalServerError)
@@ -53,14 +59,15 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	d := store.Deployment{
-		ID:      id,
-		Name:    body.Name,
-		Image:   body.Image,
-		Envs:    body.Envs,
-		Ports:   assignedPorts,
-		Volumes: body.Volumes,
-		Domain:  body.Domain,
-		Status:  store.StatusDeploying,
+		ID:        id,
+		Name:      body.Name,
+		Image:     body.Image,
+		Envs:      body.Envs,
+		Ports:     assignedPorts,
+		Volumes:   body.Volumes,
+		Domain:    body.Domain,
+		BasicAuth: basicAuth,
+		Status:    store.StatusDeploying,
 	}
 
 	created, err := h.store.Create(d)

--- a/api/internal/api/handler_patch_deployment.go
+++ b/api/internal/api/handler_patch_deployment.go
@@ -23,6 +23,12 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	basicAuth, err := sanitizeAndHashBasicAuth(body.BasicAuth)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	existing, err := h.store.Get(id)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
@@ -48,11 +54,12 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	patch := store.Deployment{
-		Image:   body.Image,
-		Envs:    body.Envs,
-		Ports:   body.Ports,
-		Volumes: body.Volumes,
-		Domain:  body.Domain,
+		Image:     body.Image,
+		Envs:      body.Envs,
+		Ports:     body.Ports,
+		Volumes:   body.Volumes,
+		Domain:    body.Domain,
+		BasicAuth: basicAuth,
 	}
 	if patchRequiresRedeploy(existing, body) {
 		patch.Status = store.StatusDeploying

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -2364,3 +2364,50 @@ func TestSecurityConfig_ProxiesProxySettings(t *testing.T) {
 		t.Fatalf("want profile standard, got %s", cfg.Profile)
 	}
 }
+
+func TestCreateDeployment_HashesBasicAuthPasswords(t *testing.T) {
+	s := newMemStore()
+	srv := newTestServer(s)
+	defer srv.Close()
+
+	body := []byte(`{"name":"web","image":"nginx:latest","envs":{},"ports":["80"],"volumes":[],"domain":"app.example.com","basic_auth":{"users":[{"username":"admin","password":"secret"}]}}`)
+	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/deployments: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("want 201, got %d", resp.StatusCode)
+	}
+
+	var created store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if created.BasicAuth == nil || len(created.BasicAuth.Users) != 1 {
+		t.Fatalf("want 1 basic auth user, got %#v", created.BasicAuth)
+	}
+	if created.BasicAuth.Users[0].Password == "secret" {
+		t.Fatal("want password hash, got plaintext")
+	}
+	if !strings.HasPrefix(created.BasicAuth.Users[0].Password, "$2") {
+		t.Fatalf("want bcrypt hash prefix, got %q", created.BasicAuth.Users[0].Password)
+	}
+}
+
+func TestCreateDeployment_RejectsEmptyBasicAuthUsername(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	body := []byte(`{"name":"web","image":"nginx:latest","envs":{},"ports":["80"],"volumes":[],"domain":"app.example.com","basic_auth":{"users":[{"username":"","password":"secret"}]}}`)
+	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/deployments: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}

--- a/api/internal/api/handler_update_deployment.go
+++ b/api/internal/api/handler_update_deployment.go
@@ -28,6 +28,12 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	basicAuth, err := sanitizeAndHashBasicAuth(body.BasicAuth)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	if body.Envs == nil {
 		body.Envs = map[string]string{}
 	}
@@ -64,14 +70,15 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	d := store.Deployment{
-		ID:      id,
-		Name:    body.Name,
-		Image:   body.Image,
-		Envs:    body.Envs,
-		Ports:   body.Ports,
-		Volumes: body.Volumes,
-		Domain:  body.Domain,
-		Status:  nextStatus,
+		ID:        id,
+		Name:      body.Name,
+		Image:     body.Image,
+		Envs:      body.Envs,
+		Ports:     body.Ports,
+		Volumes:   body.Volumes,
+		Domain:    body.Domain,
+		BasicAuth: basicAuth,
+		Status:    nextStatus,
 	}
 
 	updated, err := h.store.Update(d)

--- a/dashboard/src/deployments/CreateDeploymentForm.tsx
+++ b/dashboard/src/deployments/CreateDeploymentForm.tsx
@@ -1,4 +1,4 @@
-import { useCreateDeploymentForm, type EnvRow, type PairRow, type PortRow } from './useCreateDeploymentForm'
+import { useCreateDeploymentForm, type BasicAuthUserRow, type EnvRow, type PairRow, type PortRow } from './useCreateDeploymentForm'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 import { DynamicSection } from './DynamicSection'
@@ -17,7 +17,7 @@ type Props = {
 export default function CreateDeploymentForm({ onSuccess, className, hideHeader = false }: Props) {
   const {
     name, setName, image, setImage, domain, setDomain,
-    envRows, portRows, volumeRows,
+    envRows, portRows, volumeRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
     errors, handleSubmit, isPending,
   } = useCreateDeploymentForm({ onSuccess })
 
@@ -99,6 +99,37 @@ export default function CreateDeploymentForm({ onSuccess, className, hideHeader 
               className="font-mono" />
           </>)}
         />
+
+
+        <div className="space-y-3 rounded-md border p-4">
+          <div className="flex items-center gap-2">
+            <input id="basic-auth-enabled" type="checkbox" checked={basicAuthEnabled}
+              onChange={e => setBasicAuthEnabled(e.target.checked)} />
+            <Label htmlFor="basic-auth-enabled">Enable basic auth</Label>
+          </div>
+
+          {basicAuthEnabled && (
+            <DynamicSection<BasicAuthUserRow>
+              title="Basic auth users"
+              addLabel="Add user"
+              removeLabel="Remove user"
+              rows={basicAuthRows.rows}
+              onAdd={basicAuthRows.add}
+              onRemove={basicAuthRows.remove}
+              errorFor={row => errors.basicAuth[row.id]}
+              renderRow={row => (<>
+                <Input type="text" placeholder="Username" value={row.username}
+                  onChange={e => basicAuthRows.update(row.id, { username: e.target.value })}
+                  aria-invalid={Boolean(errors.basicAuth[row.id])}
+                />
+                <Input type="password" placeholder="Password" value={row.password}
+                  onChange={e => basicAuthRows.update(row.id, { password: e.target.value })}
+                  aria-invalid={Boolean(errors.basicAuth[row.id])}
+                />
+              </>)}
+            />
+          )}
+        </div>
 
         {errors.form && <p className={fieldErrorCls}>{errors.form}</p>}
         <Button type="submit" disabled={isPending}>

--- a/dashboard/src/deployments/EditDeploymentForm.tsx
+++ b/dashboard/src/deployments/EditDeploymentForm.tsx
@@ -6,7 +6,7 @@ import { DynamicSection } from './DynamicSection'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import { cn } from '../lib/utils'
-import type { EnvRow, PairRow, PortRow } from './useCreateDeploymentForm'
+import type { BasicAuthUserRow, EnvRow, PairRow, PortRow } from './useCreateDeploymentForm'
 
 const fieldErrorCls = 'text-xs text-destructive'
 
@@ -20,7 +20,7 @@ type Props = {
 export default function EditDeploymentForm({ deployment, onClose, className, hideHeader = false }: Props) {
   const {
     name, setName, image, setImage, domain, setDomain,
-    envRows, portRows, volumeRows,
+    envRows, portRows, volumeRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
     errors, handleSubmit, isPending,
   } = useEditDeploymentForm(deployment, onClose)
 
@@ -102,6 +102,37 @@ export default function EditDeploymentForm({ deployment, onClose, className, hid
               className="font-mono" />
           </>)}
         />
+
+
+        <div className="space-y-3 rounded-md border p-4">
+          <div className="flex items-center gap-2">
+            <input id="basic-auth-enabled" type="checkbox" checked={basicAuthEnabled}
+              onChange={e => setBasicAuthEnabled(e.target.checked)} />
+            <Label htmlFor="basic-auth-enabled">Enable basic auth</Label>
+          </div>
+
+          {basicAuthEnabled && (
+            <DynamicSection<BasicAuthUserRow>
+              title="Basic auth users"
+              addLabel="Add user"
+              removeLabel="Remove user"
+              rows={basicAuthRows.rows}
+              onAdd={basicAuthRows.add}
+              onRemove={basicAuthRows.remove}
+              errorFor={row => errors.basicAuth[row.id]}
+              renderRow={row => (<>
+                <Input type="text" placeholder="Username" value={row.username}
+                  onChange={e => basicAuthRows.update(row.id, { username: e.target.value })}
+                  aria-invalid={Boolean(errors.basicAuth[row.id])}
+                />
+                <Input type="password" placeholder="Password" value={row.password}
+                  onChange={e => basicAuthRows.update(row.id, { password: e.target.value })}
+                  aria-invalid={Boolean(errors.basicAuth[row.id])}
+                />
+              </>)}
+            />
+          )}
+        </div>
 
         {errors.form && <p className={fieldErrorCls}>{errors.form}</p>}
         <div className="flex items-center gap-3">

--- a/dashboard/src/deployments/useCreateDeploymentForm.ts
+++ b/dashboard/src/deployments/useCreateDeploymentForm.ts
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createDeployment } from '../lib/api'
+import { hashPasswordIfNeeded } from '../lib/password'
 import { useDynamicRows } from './useDynamicRows'
 
 export type EnvRow = { id: number; key: string; value: string }
 export type PairRow = { id: number; left: string; right: string }
 export type PortRow = { id: number; port: string }
+export type BasicAuthUserRow = { id: number; username: string; password: string }
 
 export type FormErrors = {
   name?: string
@@ -13,10 +15,11 @@ export type FormErrors = {
   envs: Record<number, string>
   ports: Record<number, string>
   volumes: Record<number, string>
+  basicAuth: Record<number, string>
   form?: string
 }
 
-const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {} }
+const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {}, basicAuth: {} }
 
 type UseCreateDeploymentFormOptions = {
   onSuccess?: () => void
@@ -28,11 +31,13 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
   const [name, setName] = useState('')
   const [image, setImage] = useState('')
   const [domain, setDomain] = useState('')
+  const [basicAuthEnabled, setBasicAuthEnabled] = useState(false)
   const [errors, setErrors] = useState<FormErrors>(EMPTY_ERRORS)
 
   const envRows = useDynamicRows<EnvRow>(id => ({ id, key: '', value: '' }))
   const portRows = useDynamicRows<PortRow>(id => ({ id, port: '' }))
   const volumeRows = useDynamicRows<PairRow>(id => ({ id, left: '', right: '' }))
+  const basicAuthRows = useDynamicRows<BasicAuthUserRow>(id => ({ id, username: '', password: '' }))
 
   const mutation = useMutation({
     mutationFn: createDeployment,
@@ -41,9 +46,11 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
       setName('')
       setImage('')
       setDomain('')
+      setBasicAuthEnabled(false)
       envRows.reset()
       portRows.reset()
       volumeRows.reset()
+      basicAuthRows.reset()
       setErrors(EMPTY_ERRORS)
       options.onSuccess?.()
     },
@@ -51,19 +58,23 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
   })
 
   function validate(): boolean {
-    const errs: FormErrors = { envs: {}, ports: {}, volumes: {} }
+    const errs: FormErrors = { envs: {}, ports: {}, volumes: {}, basicAuth: {} }
     if (!name.trim()) errs.name = 'Name is required'
     if (!image.trim()) errs.image = 'Image is required'
     for (const row of envRows.rows) {
       if (!row.key.trim()) errs.envs[row.id] = 'Key is required'
     }
     for (const row of portRows.rows) {
-      if (!row.port.trim())
-        errs.ports[row.id] = 'Container port is required'
+      if (!row.port.trim()) errs.ports[row.id] = 'Container port is required'
     }
     for (const row of volumeRows.rows) {
-      if (!row.left.trim() || !row.right.trim())
-        errs.volumes[row.id] = 'Both host and container paths are required'
+      if (!row.left.trim() || !row.right.trim()) errs.volumes[row.id] = 'Both host and container paths are required'
+    }
+    if (basicAuthEnabled) {
+      if (basicAuthRows.rows.length === 0) errs.form = 'Add at least one basic auth user'
+      for (const row of basicAuthRows.rows) {
+        if (!row.username.trim() || !row.password.trim()) errs.basicAuth[row.id] = 'Username and password are required'
+      }
     }
     setErrors(errs)
     return (
@@ -71,15 +82,29 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
       !errs.image &&
       Object.keys(errs.envs).length === 0 &&
       Object.keys(errs.ports).length === 0 &&
-      Object.keys(errs.volumes).length === 0
+      Object.keys(errs.volumes).length === 0 &&
+      Object.keys(errs.basicAuth).length === 0 &&
+      !errs.form
     )
   }
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!validate()) return
     const envs: Record<string, string> = {}
     for (const row of envRows.rows) envs[row.key.trim()] = row.value
+
+    const basicAuth = basicAuthEnabled
+      ? {
+          users: await Promise.all(
+            basicAuthRows.rows.map(async row => ({
+              username: row.username.trim(),
+              password: await hashPasswordIfNeeded(row.password.trim()),
+            }))
+          ),
+        }
+      : undefined
+
     mutation.mutate({
       name: name.trim(),
       image: image.trim(),
@@ -87,6 +112,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
       ports: portRows.rows.map(r => r.port.trim()),
       volumes: volumeRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
       domain: domain.trim(),
+      basic_auth: basicAuth,
     })
   }
 
@@ -94,9 +120,11 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
     name, setName,
     image, setImage,
     domain, setDomain,
+    basicAuthEnabled, setBasicAuthEnabled,
     envRows,
     portRows,
     volumeRows,
+    basicAuthRows,
     errors,
     handleSubmit,
     isPending: mutation.isPending,

--- a/dashboard/src/deployments/useEditDeploymentForm.ts
+++ b/dashboard/src/deployments/useEditDeploymentForm.ts
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { updateDeployment, type Deployment } from '../lib/api'
+import { hashPasswordIfNeeded } from '../lib/password'
 import { useDynamicRows } from './useDynamicRows'
-import type { EnvRow, FormErrors, PairRow, PortRow } from './useCreateDeploymentForm'
+import type { BasicAuthUserRow, EnvRow, FormErrors, PairRow, PortRow } from './useCreateDeploymentForm'
 
-const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {} }
+const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {}, basicAuth: {} }
 
 function toEnvRows(envs: Record<string, string>): EnvRow[] {
   return Object.entries(envs).map(([key, value], i) => ({ id: i, key, value }))
@@ -17,13 +18,15 @@ function toPairRows(items: string[]): PairRow[] {
   })
 }
 
-// Ports are stored as "hostPort:containerPort" after reconciliation.
-// The user only controls the container port; extract it for the edit form.
 function toPortRows(items: string[]): PortRow[] {
   return items.map((item, i) => {
     const sep = item.indexOf(':')
     return { id: i, port: sep >= 0 ? item.slice(sep + 1) : item }
   })
+}
+
+function toBasicAuthRows(deployment: Deployment): BasicAuthUserRow[] {
+  return (deployment.basic_auth?.users ?? []).map((user, i) => ({ id: i, username: user.username, password: user.password }))
 }
 
 export function useEditDeploymentForm(deployment: Deployment, onClose: () => void) {
@@ -32,11 +35,13 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
   const [name, setName] = useState(deployment.name)
   const [image, setImage] = useState(deployment.image)
   const [domain, setDomain] = useState(deployment.domain)
+  const [basicAuthEnabled, setBasicAuthEnabled] = useState(Boolean(deployment.basic_auth && deployment.basic_auth.users.length > 0))
   const [errors, setErrors] = useState<FormErrors>(EMPTY_ERRORS)
 
   const envRows = useDynamicRows<EnvRow>(id => ({ id, key: '', value: '' }), toEnvRows(deployment.envs))
   const portRows = useDynamicRows<PortRow>(id => ({ id, port: '' }), toPortRows(deployment.ports))
   const volumeRows = useDynamicRows<PairRow>(id => ({ id, left: '', right: '' }), toPairRows(deployment.volumes))
+  const basicAuthRows = useDynamicRows<BasicAuthUserRow>(id => ({ id, username: '', password: '' }), toBasicAuthRows(deployment))
 
   const mutation = useMutation({
     mutationFn: (data: Parameters<typeof updateDeployment>[1]) => updateDeployment(deployment.id, data),
@@ -50,19 +55,23 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
   })
 
   function validate(): boolean {
-    const errs: FormErrors = { envs: {}, ports: {}, volumes: {} }
+    const errs: FormErrors = { envs: {}, ports: {}, volumes: {}, basicAuth: {} }
     if (!name.trim()) errs.name = 'Name is required'
     if (!image.trim()) errs.image = 'Image is required'
     for (const row of envRows.rows) {
       if (!row.key.trim()) errs.envs[row.id] = 'Key is required'
     }
     for (const row of portRows.rows) {
-      if (!row.port.trim())
-        errs.ports[row.id] = 'Container port is required'
+      if (!row.port.trim()) errs.ports[row.id] = 'Container port is required'
     }
     for (const row of volumeRows.rows) {
-      if (!row.left.trim() || !row.right.trim())
-        errs.volumes[row.id] = 'Both host and container paths are required'
+      if (!row.left.trim() || !row.right.trim()) errs.volumes[row.id] = 'Both host and container paths are required'
+    }
+    if (basicAuthEnabled) {
+      if (basicAuthRows.rows.length === 0) errs.form = 'Add at least one basic auth user'
+      for (const row of basicAuthRows.rows) {
+        if (!row.username.trim() || !row.password.trim()) errs.basicAuth[row.id] = 'Username and password are required'
+      }
     }
     setErrors(errs)
     return (
@@ -70,15 +79,29 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
       !errs.image &&
       Object.keys(errs.envs).length === 0 &&
       Object.keys(errs.ports).length === 0 &&
-      Object.keys(errs.volumes).length === 0
+      Object.keys(errs.volumes).length === 0 &&
+      Object.keys(errs.basicAuth).length === 0 &&
+      !errs.form
     )
   }
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!validate()) return
     const envs: Record<string, string> = {}
     for (const row of envRows.rows) envs[row.key.trim()] = row.value
+
+    const basicAuth = basicAuthEnabled
+      ? {
+          users: await Promise.all(
+            basicAuthRows.rows.map(async row => ({
+              username: row.username.trim(),
+              password: await hashPasswordIfNeeded(row.password.trim()),
+            }))
+          ),
+        }
+      : undefined
+
     mutation.mutate({
       name: name.trim(),
       image: image.trim(),
@@ -86,6 +109,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
       ports: portRows.rows.map(r => r.port.trim()),
       volumes: volumeRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
       domain: domain.trim(),
+      basic_auth: basicAuth,
     })
   }
 
@@ -93,9 +117,11 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
     name, setName,
     image, setImage,
     domain, setDomain,
+    basicAuthEnabled, setBasicAuthEnabled,
     envRows,
     portRows,
     volumeRows,
+    basicAuthRows,
     errors,
     handleSubmit,
     isPending: mutation.isPending,

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,5 +1,14 @@
 export type DeploymentStatus = 'idle' | 'deploying' | 'healthy' | 'failed'
 
+export type BasicAuthUser = {
+  username: string
+  password: string
+}
+
+export type BasicAuthConfig = {
+  users: BasicAuthUser[]
+}
+
 export type Deployment = {
   id: string
   name: string
@@ -8,6 +17,7 @@ export type Deployment = {
   ports: string[]
   volumes: string[]
   domain: string
+  basic_auth?: BasicAuthConfig
   status: DeploymentStatus
   error?: string
 }
@@ -144,6 +154,7 @@ export type CreateDeploymentInput = {
   ports: string[]
   volumes: string[]
   domain: string
+  basic_auth?: BasicAuthConfig
 }
 
 export async function createDeployment(data: CreateDeploymentInput): Promise<Deployment> {
@@ -163,6 +174,7 @@ export type UpdateDeploymentInput = {
   ports: string[]
   volumes: string[]
   domain: string
+  basic_auth?: BasicAuthConfig
 }
 
 export async function updateDeployment(id: string, data: UpdateDeploymentInput): Promise<Deployment> {

--- a/dashboard/src/lib/password.ts
+++ b/dashboard/src/lib/password.ts
@@ -1,0 +1,8 @@
+const BCRYPT_PREFIX_RE = /^\$2[aby]\$\d\d\$/
+
+export async function hashPasswordIfNeeded(password: string): Promise<string> {
+  if (BCRYPT_PREFIX_RE.test(password)) {
+    return password
+  }
+  return password
+}

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -173,7 +173,9 @@ func redirectToHTTPS(httpsAddr string) http.HandlerFunc {
 	}
 }
 
-func hostPolicyFromTable(table interface{ Get(string) (string, bool) }) autocert.HostPolicy {
+func hostPolicyFromTable(table interface {
+	Get(string) (routing.Route, bool)
+}) autocert.HostPolicy {
 	return func(_ context.Context, host string) error {
 		host = normalizeDomain(host)
 		if host == "" {

--- a/proxy/cmd/proxy/main_test.go
+++ b/proxy/cmd/proxy/main_test.go
@@ -11,28 +11,30 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/ercadev/dirigent/proxy/internal/handler"
+	"github.com/ercadev/dirigent/proxy/internal/routing"
+	"github.com/ercadev/dirigent/store"
 )
 
 type tableStub struct {
 	mu     sync.RWMutex
-	routes map[string]string
+	routes map[string]routing.Route
 }
 
 func newTableStub() *tableStub {
-	return &tableStub{routes: make(map[string]string)}
+	return &tableStub{routes: make(map[string]routing.Route)}
 }
 
-func (t *tableStub) Get(domain string) (string, bool) {
+func (t *tableStub) Get(domain string) (routing.Route, bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	u, ok := t.routes[domain]
-	return u, ok
+	route, ok := t.routes[domain]
+	return route, ok
 }
 
-func (t *tableStub) Set(domain, upstream string) {
+func (t *tableStub) Set(domain, upstream string, basicAuth *store.BasicAuthConfig) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.routes[domain] = upstream
+	t.routes[domain] = routing.Route{Upstream: upstream, BasicAuth: basicAuth}
 }
 
 func TestRedirectToHTTPS_DefaultPort(t *testing.T) {
@@ -106,7 +108,7 @@ func TestHTTPMux_InternalRoutesCanBeUpdated(t *testing.T) {
 
 func TestHostPolicyFromTable(t *testing.T) {
 	tbl := newTableStub()
-	tbl.Set("example.com", "localhost:3000")
+	tbl.Set("example.com", "localhost:3000", nil)
 	policy := hostPolicyFromTable(tbl)
 
 	if err := policy(context.Background(), "example.com"); err != nil {

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -16,13 +16,15 @@ import (
 	"time"
 
 	"github.com/ercadev/dirigent/proxy/internal/middleware"
+	"github.com/ercadev/dirigent/proxy/internal/routing"
+	"github.com/ercadev/dirigent/store"
 )
 
 // RoutingTable is the interface the handler reads from when proxying requests
 // and the control API writes to when swapping upstreams.
 type RoutingTable interface {
-	Get(domain string) (string, bool)
-	Set(domain, upstream string)
+	Get(domain string) (routing.Route, bool)
+	Set(domain, upstream string, basicAuth *store.BasicAuthConfig)
 }
 
 // Handler serves inbound HTTP requests by routing them to the upstream
@@ -191,6 +193,13 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 	}
 	host = normalizeDomain(host)
 
+	route, ok := h.table.Get(host)
+	if !ok {
+		outcome = "unknown_domain"
+		http.Error(rw, "unknown domain", http.StatusNotFound)
+		return
+	}
+
 	if h.dashboardAuth != nil && host == h.dashboardAuth.Domain {
 		if !middleware.ValidBasicAuth(r, h.dashboardAuth.Username, h.dashboardAuth.Password) {
 			outcome = "unauthorized"
@@ -199,16 +208,15 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	upstream, ok := h.table.Get(host)
-	if !ok {
-		outcome = "unknown_domain"
-		http.Error(rw, "unknown domain", http.StatusNotFound)
+	if !middleware.ValidBasicAuthUsers(r, route.BasicAuth) {
+		outcome = "unauthorized"
+		middleware.WriteBasicAuthChallenge(rw, "Dirigent")
 		return
 	}
 
 	target := &url.URL{
 		Scheme: "http",
-		Host:   upstream,
+		Host:   route.Upstream,
 	}
 
 	rp := &httputil.ReverseProxy{
@@ -219,7 +227,7 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			outcome = "upstream_error"
-			log.Printf("proxy: upstream %s: %v", upstream, err)
+			log.Printf("proxy: upstream %s: %v", route.Upstream, err)
 			http.Error(w, "upstream unavailable", http.StatusBadGateway)
 		},
 	}
@@ -357,7 +365,7 @@ func (h *Handler) setRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.table.Set(normalizeDomain(body.Domain), body.Upstream)
+	h.table.Set(normalizeDomain(body.Domain), body.Upstream, nil)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -15,29 +15,32 @@ import (
 	"time"
 
 	"github.com/ercadev/dirigent/proxy/internal/handler"
+	"github.com/ercadev/dirigent/proxy/internal/routing"
+	"github.com/ercadev/dirigent/store"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // testTable is an in-memory routing table used only in tests.
 type testTable struct {
 	mu     sync.RWMutex
-	routes map[string]string
+	routes map[string]routing.Route
 }
 
 func newTestTable() *testTable {
-	return &testTable{routes: make(map[string]string)}
+	return &testTable{routes: make(map[string]routing.Route)}
 }
 
-func (t *testTable) Set(domain, upstream string) {
+func (t *testTable) Set(domain, upstream string, basicAuth *store.BasicAuthConfig) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.routes[domain] = upstream
+	t.routes[domain] = routing.Route{Upstream: upstream, BasicAuth: basicAuth}
 }
 
-func (t *testTable) Get(domain string) (string, bool) {
+func (t *testTable) Get(domain string) (routing.Route, bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	u, ok := t.routes[domain]
-	return u, ok
+	route, ok := t.routes[domain]
+	return route, ok
 }
 
 func newProxyServer(tbl *testTable) *httptest.Server {
@@ -67,7 +70,7 @@ func TestProxy_KnownDomainReachesBackend(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", backend.Listener.Addr().String())
+	tbl.Set("example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServer(tbl)
 	defer proxy.Close()
@@ -116,7 +119,7 @@ func TestProxy_RemovedDeploymentIsUnreachable(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", backend.Listener.Addr().String())
+	tbl.Set("example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServer(tbl)
 	defer proxy.Close()
@@ -172,12 +175,12 @@ func TestSetRoute_SetsUpstream(t *testing.T) {
 		t.Fatalf("want 204, got %d", resp.StatusCode)
 	}
 
-	upstream, ok := tbl.Get("example.com")
+	route, ok := tbl.Get("example.com")
 	if !ok {
 		t.Fatal("want route registered, got not found")
 	}
-	if upstream != "localhost:3000" {
-		t.Errorf("want upstream localhost:3000, got %s", upstream)
+	if route.Upstream != "localhost:3000" {
+		t.Errorf("want upstream localhost:3000, got %s", route.Upstream)
 	}
 }
 
@@ -236,7 +239,7 @@ func TestProxy_AtomicSwap_KeepsInflightRequestsAndRoutesNewTraffic(t *testing.T)
 	defer newBackend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", oldBackend.Listener.Addr().String())
+	tbl.Set("example.com", oldBackend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServer(tbl)
 	defer proxy.Close()
@@ -333,7 +336,7 @@ func TestHealth_Returns200(t *testing.T) {
 func TestProxy_UpstreamUnavailableReturns502(t *testing.T) {
 	tbl := newTestTable()
 	// Point to a port nobody is listening on.
-	tbl.Set("example.com", "localhost:1")
+	tbl.Set("example.com", "localhost:1", nil)
 
 	proxy := newProxyServer(tbl)
 	defer proxy.Close()
@@ -359,7 +362,7 @@ func TestProxy_HTTPSKnownDomainReachesBackend(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", backend.Listener.Addr().String())
+	tbl.Set("example.com", backend.Listener.Addr().String(), nil)
 
 	mux := http.NewServeMux()
 	handler.New(tbl, nil).RegisterRoutes(mux)
@@ -387,7 +390,7 @@ func TestProxy_DashboardDomainRequiresBasicAuth(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("dashboard.example.com", backend.Listener.Addr().String())
+	tbl.Set("dashboard.example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServerWithDashboardAuth(tbl, &handler.DashboardAuth{
 		Domain:   "dashboard.example.com",
@@ -420,7 +423,7 @@ func TestProxy_DashboardDomainWithValidBasicAuth(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("dashboard.example.com", backend.Listener.Addr().String())
+	tbl.Set("dashboard.example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServerWithDashboardAuth(tbl, &handler.DashboardAuth{
 		Domain:   "dashboard.example.com",
@@ -451,7 +454,7 @@ func TestProxy_NonDashboardDomainDoesNotRequireBasicAuth(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("app.example.com", backend.Listener.Addr().String())
+	tbl.Set("app.example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServerWithDashboardAuth(tbl, &handler.DashboardAuth{
 		Domain:   "dashboard.example.com",
@@ -481,7 +484,7 @@ func TestProxy_StandardHardeningBlocksSensitivePaths(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", backend.Listener.Addr().String())
+	tbl.Set("example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServer(tbl)
 	defer proxy.Close()
@@ -510,7 +513,7 @@ func TestProxy_OffHardeningAllowsSensitivePaths(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", backend.Listener.Addr().String())
+	tbl.Set("example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServerWithOptions(tbl, handler.WithHardeningProfile(handler.HardeningOff))
 	defer proxy.Close()
@@ -536,7 +539,7 @@ func TestProxy_StrictHardeningBlocksScannerPaths(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", backend.Listener.Addr().String())
+	tbl.Set("example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServerWithOptions(tbl, handler.WithHardeningProfile(handler.HardeningStrict))
 	defer proxy.Close()
@@ -562,7 +565,7 @@ func TestProxy_StandardHardeningRateLimitsRepeatedScans(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", backend.Listener.Addr().String())
+	tbl.Set("example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServer(tbl)
 	defer proxy.Close()
@@ -599,7 +602,7 @@ func TestInternalTraffic_ReportsBlockedIPsAndCounters(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", backend.Listener.Addr().String())
+	tbl.Set("example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServer(tbl)
 	defer proxy.Close()
@@ -688,7 +691,7 @@ func TestProxy_WritesAccessLogWithWhitelistedHeaders(t *testing.T) {
 	defer backend.Close()
 
 	tbl := newTestTable()
-	tbl.Set("example.com", backend.Listener.Addr().String())
+	tbl.Set("example.com", backend.Listener.Addr().String(), nil)
 
 	proxy := newProxyServerWithOptions(tbl, handler.WithAccessLogger(logger))
 	defer proxy.Close()
@@ -758,5 +761,77 @@ func TestProxy_WritesAccessLogWithWhitelistedHeaders(t *testing.T) {
 	}
 	if entry.Headers["user-agent"] != "dirigent-test" {
 		t.Fatalf("want user-agent header, got %q", entry.Headers["user-agent"])
+	}
+}
+
+func TestProxy_DeploymentBasicAuthRequiresCredentials(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("bcrypt hash: %v", err)
+	}
+
+	tbl := newTestTable()
+	tbl.Set("private.example.com", backend.Listener.Addr().String(), &store.BasicAuthConfig{Users: []store.BasicAuthUser{{
+		Username: "admin",
+		Password: string(hash),
+	}}})
+
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "private.example.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("WWW-Authenticate"); got != `Basic realm="Dirigent"` {
+		t.Fatalf("want Basic realm challenge, got %q", got)
+	}
+}
+
+func TestProxy_DeploymentBasicAuthWithValidCredentials(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("bcrypt hash: %v", err)
+	}
+
+	tbl := newTestTable()
+	tbl.Set("private.example.com", backend.Listener.Addr().String(), &store.BasicAuthConfig{Users: []store.BasicAuthUser{{
+		Username: "admin",
+		Password: string(hash),
+	}}})
+
+	proxy := newProxyServer(tbl)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "private.example.com"
+	req.SetBasicAuth("admin", "secret")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
 	}
 }

--- a/proxy/internal/middleware/basicauth.go
+++ b/proxy/internal/middleware/basicauth.go
@@ -5,6 +5,9 @@ import (
 	"crypto/subtle"
 	"fmt"
 	"net/http"
+
+	"github.com/ercadev/dirigent/store"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // ValidBasicAuth compares HTTP Basic Auth credentials in constant time.
@@ -23,6 +26,29 @@ func ValidBasicAuth(r *http.Request, username, password string) bool {
 	passMatch := subtle.ConstantTimeCompare(providedPassHash[:], expectedPassHash[:])
 
 	return userMatch == 1 && passMatch == 1
+}
+
+// ValidBasicAuthUsers checks request credentials against configured user hashes.
+func ValidBasicAuthUsers(r *http.Request, auth *store.BasicAuthConfig) bool {
+	if auth == nil || len(auth.Users) == 0 {
+		return true
+	}
+	providedUser, providedPass, ok := r.BasicAuth()
+	if !ok {
+		return false
+	}
+
+	providedUserHash := sha256.Sum256([]byte(providedUser))
+	for _, user := range auth.Users {
+		expectedUserHash := sha256.Sum256([]byte(user.Username))
+		if subtle.ConstantTimeCompare(providedUserHash[:], expectedUserHash[:]) != 1 {
+			continue
+		}
+		if bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(providedPass)) == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // WriteBasicAuthChallenge writes a 401 challenge for Basic Auth.

--- a/proxy/internal/middleware/basicauth_test.go
+++ b/proxy/internal/middleware/basicauth_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/ercadev/dirigent/proxy/internal/middleware"
+	"github.com/ercadev/dirigent/store"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestValidBasicAuth(t *testing.T) {
@@ -36,5 +38,31 @@ func TestWriteBasicAuthChallenge(t *testing.T) {
 	}
 	if got := w.Header().Get("WWW-Authenticate"); got != `Basic realm="Dirigent"` {
 		t.Fatalf("want Basic realm challenge, got %q", got)
+	}
+}
+
+func TestValidBasicAuthUsers(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.SetBasicAuth("admin", "secret")
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("bcrypt hash: %v", err)
+	}
+	auth := &store.BasicAuthConfig{Users: []store.BasicAuthUser{{Username: "admin", Password: string(hash)}}}
+	if !middleware.ValidBasicAuthUsers(req, auth) {
+		t.Fatal("want credentials to be accepted")
+	}
+}
+
+func TestValidBasicAuthUsers_Invalid(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.SetBasicAuth("admin", "wrong")
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("bcrypt hash: %v", err)
+	}
+	auth := &store.BasicAuthConfig{Users: []store.BasicAuthUser{{Username: "admin", Password: string(hash)}}}
+	if middleware.ValidBasicAuthUsers(req, auth) {
+		t.Fatal("want credentials to be rejected")
 	}
 }

--- a/proxy/internal/poller/poller.go
+++ b/proxy/internal/poller/poller.go
@@ -2,6 +2,7 @@ package poller
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"strings"
 	"time"
@@ -11,8 +12,13 @@ import (
 
 // Table is the routing table the poller updates as deployments change.
 type Table interface {
-	Set(domain, upstream string)
+	Set(domain, upstream string, basicAuth *store.BasicAuthConfig)
 	Delete(domain string)
+}
+
+type routeState struct {
+	Upstream      string
+	BasicAuthJSON string
 }
 
 // Store is the persistence interface the poller reads from.
@@ -26,7 +32,7 @@ type Poller struct {
 	store    Store
 	table    Table
 	interval time.Duration
-	last     map[string]string // domain → upstream from the previous sync
+	last     map[string]routeState // domain → route state from the previous sync
 }
 
 // New creates a Poller that reads from s and updates t every interval.
@@ -35,7 +41,7 @@ func New(s Store, t Table, interval time.Duration) *Poller {
 		store:    s,
 		table:    t,
 		interval: interval,
-		last:     make(map[string]string),
+		last:     make(map[string]routeState),
 	}
 }
 
@@ -65,9 +71,9 @@ func (p *Poller) sync() {
 		return
 	}
 
-	// Build the current snapshot: domain → upstream for deployments that have
+	// Build the current snapshot: domain → route for deployments that have
 	// both a domain and at least one port binding.
-	current := make(map[string]string, len(deployments))
+	current := make(map[string]routeState, len(deployments))
 	for _, d := range deployments {
 		if d.Domain == "" {
 			continue
@@ -80,13 +86,20 @@ func (p *Poller) sync() {
 		if upstream == "" {
 			continue
 		}
-		current[domain] = upstream
+		current[domain] = routeState{Upstream: upstream, BasicAuthJSON: mustBasicAuthJSON(d.BasicAuth)}
 	}
 
 	// Register new routes and update changed upstreams.
-	for domain, upstream := range current {
-		if p.last[domain] != upstream {
-			p.table.Set(domain, upstream)
+	for domain, route := range current {
+		if p.last[domain] != route {
+			var basicAuth *store.BasicAuthConfig
+			if route.BasicAuthJSON != "" {
+				if err := json.Unmarshal([]byte(route.BasicAuthJSON), &basicAuth); err != nil {
+					log.Printf("proxy poller: decode basic auth for %s: %v", domain, err)
+					continue
+				}
+			}
+			p.table.Set(domain, route.Upstream, basicAuth)
 		}
 	}
 
@@ -98,6 +111,17 @@ func (p *Poller) sync() {
 	}
 
 	p.last = current
+}
+
+func mustBasicAuthJSON(auth *store.BasicAuthConfig) string {
+	if auth == nil {
+		return ""
+	}
+	b, err := json.Marshal(auth)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 // upstreamFromPorts extracts "localhost:<hostPort>" from the first usable

--- a/proxy/internal/poller/poller_test.go
+++ b/proxy/internal/poller/poller_test.go
@@ -28,18 +28,18 @@ func (m *memStore) List() ([]store.Deployment, error) {
 // spyTable records Set and Delete calls.
 type spyTable struct {
 	mu      sync.Mutex
-	routes  map[string]string
+	routes  map[string]routing.Route
 	deleted []string
 }
 
 func newSpyTable() *spyTable {
-	return &spyTable{routes: make(map[string]string)}
+	return &spyTable{routes: make(map[string]routing.Route)}
 }
 
-func (s *spyTable) Set(domain, upstream string) {
+func (s *spyTable) Set(domain, upstream string, basicAuth *store.BasicAuthConfig) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.routes[domain] = upstream
+	s.routes[domain] = routing.Route{Upstream: upstream, BasicAuth: basicAuth}
 }
 
 func (s *spyTable) Delete(domain string) {
@@ -49,11 +49,11 @@ func (s *spyTable) Delete(domain string) {
 	s.deleted = append(s.deleted, domain)
 }
 
-func (s *spyTable) get(domain string) (string, bool) {
+func (s *spyTable) get(domain string) (routing.Route, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	u, ok := s.routes[domain]
-	return u, ok
+	route, ok := s.routes[domain]
+	return route, ok
 }
 
 func (s *spyTable) wasDeleted(domain string) bool {
@@ -82,12 +82,12 @@ func TestPoller_RegistersDeploymentWithDomainAndPort(t *testing.T) {
 	go p.Run(ctx)
 	time.Sleep(50 * time.Millisecond)
 
-	u, ok := tbl.get("example.com")
+	route, ok := tbl.get("example.com")
 	if !ok {
 		t.Fatal("want example.com registered, got not found")
 	}
-	if u != "localhost:8080" {
-		t.Errorf("want upstream localhost:8080, got %s", u)
+	if route.Upstream != "localhost:8080" {
+		t.Errorf("want upstream localhost:8080, got %s", route.Upstream)
 	}
 }
 
@@ -180,8 +180,8 @@ func TestPoller_UpdatesChangedUpstream(t *testing.T) {
 	go p.Run(ctx)
 	time.Sleep(50 * time.Millisecond)
 
-	if u, _ := tbl.get("example.com"); u != "localhost:8080" {
-		t.Fatalf("initial upstream: want localhost:8080, got %s", u)
+	if route, _ := tbl.get("example.com"); route.Upstream != "localhost:8080" {
+		t.Fatalf("initial upstream: want localhost:8080, got %s", route.Upstream)
 	}
 
 	// Simulate a port change (e.g. after zero-downtime redeploy).
@@ -191,8 +191,8 @@ func TestPoller_UpdatesChangedUpstream(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	if u, _ := tbl.get("example.com"); u != "localhost:9090" {
-		t.Errorf("updated upstream: want localhost:9090, got %s", u)
+	if route, _ := tbl.get("example.com"); route.Upstream != "localhost:9090" {
+		t.Errorf("updated upstream: want localhost:9090, got %s", route.Upstream)
 	}
 }
 
@@ -208,7 +208,7 @@ func TestPoller_DoesNotDeleteStaticRoutes(t *testing.T) {
 	go p.Run(ctx)
 	time.Sleep(50 * time.Millisecond)
 
-	if u, ok := tbl.Get("dashboard.example.com"); !ok || u != "localhost:3000" {
-		t.Fatalf("want static dashboard route preserved, got %q (ok=%v)", u, ok)
+	if route, ok := tbl.Get("dashboard.example.com"); !ok || route.Upstream != "localhost:3000" {
+		t.Fatalf("want static dashboard route preserved, got %q (ok=%v)", route.Upstream, ok)
 	}
 }

--- a/proxy/internal/routing/table.go
+++ b/proxy/internal/routing/table.go
@@ -1,27 +1,37 @@
 package routing
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/ercadev/dirigent/store"
+)
+
+// Route stores upstream and optional basic auth config.
+type Route struct {
+	Upstream  string
+	BasicAuth *store.BasicAuthConfig
+}
 
 // Table is an in-memory domain→upstream routing table safe for concurrent use.
 type Table struct {
 	mu            sync.RWMutex
-	dynamicRoutes map[string]string
+	dynamicRoutes map[string]Route
 	staticRoutes  map[string]string
 }
 
 // NewTable creates an empty Table.
 func NewTable() *Table {
 	return &Table{
-		dynamicRoutes: make(map[string]string),
+		dynamicRoutes: make(map[string]Route),
 		staticRoutes:  make(map[string]string),
 	}
 }
 
-// Set registers or replaces the upstream for domain.
-func (t *Table) Set(domain, upstream string) {
+// Set registers or replaces the route for domain.
+func (t *Table) Set(domain, upstream string, basicAuth *store.BasicAuthConfig) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.dynamicRoutes[domain] = upstream
+	t.dynamicRoutes[domain] = Route{Upstream: upstream, BasicAuth: basicAuth}
 }
 
 // SetStatic registers or replaces a static upstream for domain.
@@ -31,15 +41,15 @@ func (t *Table) SetStatic(domain, upstream string) {
 	t.staticRoutes[domain] = upstream
 }
 
-// Get returns the upstream for domain and whether it exists.
-func (t *Table) Get(domain string) (string, bool) {
+// Get returns the route for domain and whether it exists.
+func (t *Table) Get(domain string) (Route, bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if u, ok := t.staticRoutes[domain]; ok {
-		return u, true
+		return Route{Upstream: u}, true
 	}
-	u, ok := t.dynamicRoutes[domain]
-	return u, ok
+	route, ok := t.dynamicRoutes[domain]
+	return route, ok
 }
 
 // Delete removes domain from the table. No-op if domain is not registered.

--- a/proxy/internal/routing/table_test.go
+++ b/proxy/internal/routing/table_test.go
@@ -8,34 +8,34 @@ import (
 
 func TestTable_SetAndGet(t *testing.T) {
 	tbl := routing.NewTable()
-	tbl.Set("example.com", "localhost:8080")
+	tbl.Set("example.com", "localhost:8080", nil)
 
-	upstream, ok := tbl.Get("example.com")
+	route, ok := tbl.Get("example.com")
 	if !ok {
 		t.Fatal("want route to exist, got not found")
 	}
-	if upstream != "localhost:8080" {
-		t.Errorf("want upstream localhost:8080, got %s", upstream)
+	if route.Upstream != "localhost:8080" {
+		t.Errorf("want upstream localhost:8080, got %s", route.Upstream)
 	}
 }
 
 func TestTable_Update(t *testing.T) {
 	tbl := routing.NewTable()
-	tbl.Set("example.com", "localhost:8080")
-	tbl.Set("example.com", "localhost:9090")
+	tbl.Set("example.com", "localhost:8080", nil)
+	tbl.Set("example.com", "localhost:9090", nil)
 
-	upstream, ok := tbl.Get("example.com")
+	route, ok := tbl.Get("example.com")
 	if !ok {
 		t.Fatal("want route to exist, got not found")
 	}
-	if upstream != "localhost:9090" {
-		t.Errorf("want updated upstream localhost:9090, got %s", upstream)
+	if route.Upstream != "localhost:9090" {
+		t.Errorf("want updated upstream localhost:9090, got %s", route.Upstream)
 	}
 }
 
 func TestTable_Delete(t *testing.T) {
 	tbl := routing.NewTable()
-	tbl.Set("example.com", "localhost:8080")
+	tbl.Set("example.com", "localhost:8080", nil)
 	tbl.Delete("example.com")
 
 	if _, ok := tbl.Get("example.com"); ok {
@@ -60,29 +60,29 @@ func TestTable_UnknownDomain(t *testing.T) {
 func TestTable_StaticRoutePersistsWhenDynamicDeleted(t *testing.T) {
 	tbl := routing.NewTable()
 	tbl.SetStatic("dashboard.example.com", "localhost:3000")
-	tbl.Set("dashboard.example.com", "localhost:8080")
+	tbl.Set("dashboard.example.com", "localhost:8080", nil)
 
 	tbl.Delete("dashboard.example.com")
 
-	upstream, ok := tbl.Get("dashboard.example.com")
+	route, ok := tbl.Get("dashboard.example.com")
 	if !ok {
 		t.Fatal("want static route to exist after dynamic delete")
 	}
-	if upstream != "localhost:3000" {
-		t.Errorf("want static upstream localhost:3000, got %s", upstream)
+	if route.Upstream != "localhost:3000" {
+		t.Errorf("want static upstream localhost:3000, got %s", route.Upstream)
 	}
 }
 
 func TestTable_MultipleDomains(t *testing.T) {
 	tbl := routing.NewTable()
-	tbl.Set("foo.com", "localhost:3000")
-	tbl.Set("bar.com", "localhost:4000")
+	tbl.Set("foo.com", "localhost:3000", nil)
+	tbl.Set("bar.com", "localhost:4000", nil)
 
-	if u, ok := tbl.Get("foo.com"); !ok || u != "localhost:3000" {
-		t.Errorf("foo.com: want localhost:3000, got %s (ok=%v)", u, ok)
+	if route, ok := tbl.Get("foo.com"); !ok || route.Upstream != "localhost:3000" {
+		t.Errorf("foo.com: want localhost:3000, got %s (ok=%v)", route.Upstream, ok)
 	}
-	if u, ok := tbl.Get("bar.com"); !ok || u != "localhost:4000" {
-		t.Errorf("bar.com: want localhost:4000, got %s (ok=%v)", u, ok)
+	if route, ok := tbl.Get("bar.com"); !ok || route.Upstream != "localhost:4000" {
+		t.Errorf("bar.com: want localhost:4000, got %s (ok=%v)", route.Upstream, ok)
 	}
 
 	tbl.Delete("foo.com")
@@ -90,7 +90,7 @@ func TestTable_MultipleDomains(t *testing.T) {
 	if _, ok := tbl.Get("foo.com"); ok {
 		t.Error("want foo.com deleted")
 	}
-	if u, ok := tbl.Get("bar.com"); !ok || u != "localhost:4000" {
-		t.Errorf("bar.com must survive after foo.com deleted: got %s (ok=%v)", u, ok)
+	if route, ok := tbl.Get("bar.com"); !ok || route.Upstream != "localhost:4000" {
+		t.Errorf("bar.com must survive after foo.com deleted: got %s (ok=%v)", route.Upstream, ok)
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -28,15 +28,25 @@ const (
 
 // Deployment holds the full configuration and runtime state of a container deployment.
 type Deployment struct {
-	ID      string            `json:"id"`
-	Name    string            `json:"name"`
-	Image   string            `json:"image"`
-	Envs    map[string]string `json:"envs"`
-	Ports   []string          `json:"ports"`
-	Volumes []string          `json:"volumes"`
-	Domain  string            `json:"domain"`
-	Status  Status            `json:"status"`
-	Error   string            `json:"error,omitempty"`
+	ID        string            `json:"id"`
+	Name      string            `json:"name"`
+	Image     string            `json:"image"`
+	Envs      map[string]string `json:"envs"`
+	Ports     []string          `json:"ports"`
+	Volumes   []string          `json:"volumes"`
+	Domain    string            `json:"domain"`
+	BasicAuth *BasicAuthConfig  `json:"basic_auth,omitempty"`
+	Status    Status            `json:"status"`
+	Error     string            `json:"error,omitempty"`
+}
+
+type BasicAuthConfig struct {
+	Users []BasicAuthUser `json:"users"`
+}
+
+type BasicAuthUser struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 // JSONStore persists deployments as a JSON array on disk.
@@ -246,7 +256,7 @@ func (s *JSONStore) Update(d Deployment) (Deployment, error) {
 }
 
 // Patch merges the non-zero fields of patch into the stored deployment and persists atomically.
-// Only image, envs, ports, volumes, domain, status, and error are merged; id and name are immutable.
+// Only image, envs, ports, volumes, domain, basic auth config, status, and error are merged; id and name are immutable.
 // Returns ErrNotFound if no deployment with that ID exists.
 func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
 	var result Deployment
@@ -273,6 +283,9 @@ func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
 		}
 		if patch.Domain != "" {
 			d.Domain = patch.Domain
+		}
+		if patch.BasicAuth != nil {
+			d.BasicAuth = patch.BasicAuth
 		}
 		if patch.Status != "" {
 			d.Status = patch.Status


### PR DESCRIPTION
### Motivation
- Provide lightweight per-deployment access control by enforcing HTTP Basic Auth at the proxy/load‑balancer before forwarding traffic. 
- Ensure passwords are never stored in plaintext in the JSON state file and allow the dashboard to manage per-deployment users.

### Description
- Store model: added an optional `basic_auth` block to `store.Deployment` (`BasicAuthConfig` with `users[]`) so each deployment may carry per‑deployment credentials in the JSON store.
- API: extended create/update/patch request schemas to accept `basic_auth`, added `sanitizeAndHashBasicAuth` to validate and bcrypt‑hash passwords before persisting, and wired sanitized auth into persisting handlers so plaintext passwords are never written to the store.
- Proxy/poller/routing: extended the routing table and poller to carry per‑domain `BasicAuthConfig`; poller marshals auth from the store and registers it with the routing table when a domain is added/updated.
- Enforcement/middleware: added proxy middleware to validate incoming HTTP Basic credentials against bcrypt hashes in the stored per‑deployment config and return `401 Unauthorized` with a `WWW-Authenticate: Basic` header when missing/invalid.
- Dashboard UI: added form controls to enable/disable basic auth per deployment and to add/remove username+password rows in both create and edit flows; the UI sends a `basic_auth` payload to the API (client contains a `hashPasswordIfNeeded` helper that preserves existing bcrypt values — backend hashing remains authoritative).
- Tests: added API tests asserting passwords are hashed and invalid input is rejected, and added proxy/middleware tests for both unauthorized and valid credential flows.

### Testing
- Ran Go unit tests: `go test ./store/... ./api/... ./proxy/...` and all reported OK (store, API, proxy internal packages and tests passed).
- Built the dashboard: `cd dashboard && bun run build` completed successfully and a UI screenshot of the new basic‑auth form was produced.
- `cd dashboard && bun install` failed in this environment due to registry access returning 403 while attempting to fetch a new client dependency (this environment limitation was worked around by keeping hashing authoritative on the backend and preserving existing bcrypt values in the UI helper).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2b7fac5a8833386165dc5b14fa181)