### PR TITLE
fix(orchestrator): reduce cpu spike during image pulls

### DIFF
--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -50,6 +50,7 @@ type ManagedContainer struct {
 type Client interface {
 	Ping(ctx context.Context) (dockertypes.Ping, error)
 	ImagePull(ctx context.Context, refStr string, options image.PullOptions) (io.ReadCloser, error)
+	ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
 	ContainerList(ctx context.Context, options container.ListOptions) ([]dockertypes.Container, error)
@@ -90,15 +91,9 @@ func (d *Docker) Start(ctx context.Context, dep store.Deployment) ([]string, err
 		return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 	}
 
-	rc, err := d.client.ImagePull(ctx, dep.Image, image.PullOptions{})
-	if err != nil {
-		if dockerclient.IsErrConnectionFailed(err) {
-			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
-		}
-		return nil, fmt.Errorf("docker: pull image %s: %w", dep.Image, err)
+	if err := d.pullImage(dep.Image); err != nil {
+		return nil, err
 	}
-	_, _ = io.Copy(io.Discard, rc)
-	rc.Close()
 
 	env := envsToSlice(dep.Envs)
 
@@ -228,15 +223,9 @@ func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldC
 		return d.Start(ctx, dep)
 	}
 
-	rc, err := d.client.ImagePull(ctx, dep.Image, image.PullOptions{})
-	if err != nil {
-		if dockerclient.IsErrConnectionFailed(err) {
-			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
-		}
-		return nil, fmt.Errorf("docker: pull image %s: %w", dep.Image, err)
+	if err := d.pullImage(dep.Image); err != nil {
+		return nil, err
 	}
-	_, _ = io.Copy(io.Discard, rc)
-	rc.Close()
 
 	env := envsToSlice(dep.Envs)
 
@@ -313,6 +302,54 @@ func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldC
 	}
 
 	return runtimePorts, nil
+}
+
+// pullImage pulls imageRef from the registry, unless the image already exists
+// locally under an immutable (non-latest) tag, in which case the pull is
+// skipped to avoid an unnecessary CPU spike from layer decompression.
+//
+// The pull runs with its own 10-minute context, decoupled from the reconcile
+// loop's short deadline. Without this, a large image on a slow connection
+// would time out, be retried on every reconcile cycle, and cause multiple
+// concurrent decompression jobs that saturate the host CPU.
+func (d *Docker) pullImage(imageRef string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	// For pinned tags and digest refs, skip the pull when the image already
+	// exists locally — re-pulling is unnecessary and causes a CPU spike.
+	if !isLatestTag(imageRef) {
+		f := filters.NewArgs(filters.Arg("reference", imageRef))
+		imgs, err := d.client.ImageList(ctx, image.ListOptions{Filters: f})
+		if err == nil && len(imgs) > 0 {
+			return nil
+		}
+	}
+
+	log.Printf("docker: pulling image %s", imageRef)
+	rc, err := d.client.ImagePull(ctx, imageRef, image.PullOptions{})
+	if err != nil {
+		if dockerclient.IsErrConnectionFailed(err) {
+			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		}
+		return fmt.Errorf("docker: pull image %s: %w", imageRef, err)
+	}
+	_, _ = io.Copy(io.Discard, rc)
+	rc.Close()
+	return nil
+}
+
+// isLatestTag reports whether imageRef resolves to the mutable :latest tag.
+// Digest-pinned refs (image@sha256:…) and explicit non-latest tags are
+// considered immutable.
+func isLatestTag(imageRef string) bool {
+	// Digest-pinned refs are immutable.
+	if strings.Contains(imageRef, "@") {
+		return false
+	}
+	_, tag, found := strings.Cut(imageRef, ":")
+	// No tag specified → Docker defaults to :latest.
+	return !found || tag == "" || tag == "latest"
 }
 
 // envsToSlice converts a map of environment variables to the KEY=VALUE slice

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -25,6 +25,9 @@ import (
 type mockClient struct {
 	pingErr          error
 	imagePullErr     error
+	imagePulled      bool
+	imageList        []image.Summary
+	imageListErr     error
 	containerCreate  container.CreateResponse
 	createErr        error
 	startErr         error
@@ -50,7 +53,12 @@ func (m *mockClient) ImagePull(_ context.Context, _ string, _ image.PullOptions)
 	if m.imagePullErr != nil {
 		return nil, m.imagePullErr
 	}
+	m.imagePulled = true
 	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func (m *mockClient) ImageList(_ context.Context, _ image.ListOptions) ([]image.Summary, error) {
+	return m.imageList, m.imageListErr
 }
 
 func (m *mockClient) ContainerCreate(_ context.Context, _ *container.Config, hostCfg *container.HostConfig, _ *network.NetworkingConfig, _ *ocispec.Platform, _ string) (container.CreateResponse, error) {
@@ -445,9 +453,63 @@ func TestDocker_StartAndReplace_ProxySwapFails_CleansUpNewAndKeepsOld(t *testing
 	}
 }
 
+func TestDocker_Start_PinnedImageExistsLocally_SkipsPull(t *testing.T) {
+	mock := &mockClient{
+		imageList:        []image.Summary{{ID: "sha256:abc"}},
+		containerCreate:  container.CreateResponse{ID: "c1"},
+		inspectContainer: inspectWithPort("80/tcp", "80"),
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.Image = "nginx:1.25.3" // pinned tag — should not be re-pulled
+	if _, err := d.Start(context.Background(), dep); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if mock.imagePulled {
+		t.Error("want pull skipped for pinned image that exists locally, but ImagePull was called")
+	}
+}
+
+func TestDocker_Start_LatestTagAlwaysPulls(t *testing.T) {
+	mock := &mockClient{
+		imageList:        []image.Summary{{ID: "sha256:abc"}}, // image exists locally
+		containerCreate:  container.CreateResponse{ID: "c1"},
+		inspectContainer: inspectWithPort("80/tcp", "80"),
+	}
+	d := docker.New(mock)
+
+	dep := deployment() // image is "nginx:latest"
+	if _, err := d.Start(context.Background(), dep); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if !mock.imagePulled {
+		t.Error("want pull for :latest tag even when image exists locally, but ImagePull was not called")
+	}
+}
+
+func TestDocker_Start_PinnedImageNotLocal_Pulls(t *testing.T) {
+	mock := &mockClient{
+		imageList:        []image.Summary{}, // image not present locally
+		containerCreate:  container.CreateResponse{ID: "c1"},
+		inspectContainer: inspectWithPort("80/tcp", "80"),
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.Image = "nginx:1.25.3"
+	if _, err := d.Start(context.Background(), dep); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if !mock.imagePulled {
+		t.Error("want pull when pinned image is not cached locally, but ImagePull was not called")
+	}
+}
+
 // Ensure the mock satisfies the docker.Client interface at compile time.
 var _ interface {
 	ContainerList(context.Context, container.ListOptions) ([]dockertypes.Container, error)
+	ImageList(context.Context, image.ListOptions) ([]image.Summary, error)
 	Ping(context.Context) (dockertypes.Ping, error)
 } = (*mockClient)(nil)
 


### PR DESCRIPTION
## Summary

- **Decouples image pulls from the reconcile deadline** — pulls now run with their own 10-minute context instead of the reconcile loop's 13.5s window. Previously, any image larger than what could be pulled in 13.5s would time out, flip to `StatusFailed`, and be retried on the next cycle — stacking multiple concurrent decompression jobs and pinning the host CPU at 100%.
- **Skips redundant pulls for pinned tags** — if an image like `nginx:1.25.3` already exists locally, the pull is skipped entirely. Redeployments that only change env vars or other config no longer trigger a full re-pull and its associated CPU spike. `:latest` tags and untagged images always pull as before.
- **Adds `ImageList` to the `Client` interface** to support the local cache check, with full mock support and three new test cases.

## Note for operators

For the initial pull of a brand-new image, CPU will still spike temporarily — that's Docker decompressing layers and can't be controlled from the API. The most effective system-level mitigation is:

```bash
# /etc/docker/daemon.json
{ "max-concurrent-downloads": 1 }

# or cap the Docker daemon via systemd
systemctl set-property docker.service CPUQuota=50%
```

## Test plan

- [x] All existing tests pass
- [x] `TestDocker_Start_PinnedImageExistsLocally_SkipsPull` — pull skipped when pinned image is cached
- [x] `TestDocker_Start_LatestTagAlwaysPulls` — `:latest` always pulls even when cached
- [x] `TestDocker_Start_PinnedImageNotLocal_Pulls` — pull happens when pinned image is not cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)