### PR TITLE
Add force-refresh for version check, shorten version cache TTL, and update dashboard to request fresh info

### DIFF
--- a/api/internal/api/handler_upgrade_version_test.go
+++ b/api/internal/api/handler_upgrade_version_test.go
@@ -29,6 +29,23 @@ func (s *versionProviderStub) Snapshot(_ context.Context) (version.Snapshot, err
 	return s.snapshot, nil
 }
 
+type versionProviderWithRefreshStub struct {
+	snapshot        version.Snapshot
+	refreshSnapshot version.Snapshot
+	snapshotCalls   int
+	refreshCalls    int
+}
+
+func (s *versionProviderWithRefreshStub) Snapshot(_ context.Context) (version.Snapshot, error) {
+	s.snapshotCalls++
+	return s.snapshot, nil
+}
+
+func (s *versionProviderWithRefreshStub) RefreshSnapshot(_ context.Context) (version.Snapshot, error) {
+	s.refreshCalls++
+	return s.refreshSnapshot, nil
+}
+
 type upgradeRunnerStub struct {
 	startErr error
 	lines    chan string
@@ -115,6 +132,40 @@ func TestGetVersion_ReturnsExpectedJSON(t *testing.T) {
 	}
 	if !body.CachedAt.Equal(now) {
 		t.Fatalf("cachedAt = %s, want %s", body.CachedAt, now)
+	}
+}
+
+func TestGetVersion_RefreshQueryUsesFreshSnapshot(t *testing.T) {
+	provider := &versionProviderWithRefreshStub{
+		snapshot:        version.Snapshot{CurrentVersion: "v1.0.0", LatestVersion: "v1.1.0"},
+		refreshSnapshot: version.Snapshot{CurrentVersion: "v1.0.0", LatestVersion: "v1.2.0", UpgradeAvailable: true},
+	}
+
+	srv := newTestServerWithUpgradeAndVersion(newMemStore(), provider, &upgradeRunnerStub{})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/version?refresh=1")
+	if err != nil {
+		t.Fatalf("GET /api/version?refresh=1: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		LatestVersion string `json:"latestVersion"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.LatestVersion != "v1.2.0" {
+		t.Fatalf("latestVersion = %q, want v1.2.0", body.LatestVersion)
+	}
+	if provider.refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1", provider.refreshCalls)
 	}
 }
 

--- a/api/internal/api/handler_version.go
+++ b/api/internal/api/handler_version.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/ercadev/dirigent/internal/version"
 )
 
 type versionResponse struct {
@@ -15,8 +18,17 @@ type versionResponse struct {
 	CachedAt         *time.Time `json:"cachedAt,omitempty"`
 }
 
+type versionInfoRefresher interface {
+	RefreshSnapshot(ctx context.Context) (version.Snapshot, error)
+}
+
 func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request) {
 	snapshot, err := h.versions.Snapshot(r.Context())
+	if r.URL.Query().Get("refresh") == "1" {
+		if refresher, ok := h.versions.(versionInfoRefresher); ok {
+			snapshot, err = refresher.RefreshSnapshot(r.Context())
+		}
+	}
 	if err != nil {
 		log.Printf("getVersion: check latest release: %v", err)
 	}

--- a/api/internal/version/service.go
+++ b/api/internal/version/service.go
@@ -13,6 +13,8 @@ import (
 
 var latestReleaseURL = "https://api.github.com/repos/ercadev/dirigent-releases/releases/latest"
 
+const defaultCacheTTL = 5 * time.Minute
+
 type Snapshot struct {
 	CurrentVersion   string
 	LatestVersion    string
@@ -61,7 +63,7 @@ func New(currentVersion string) *Service {
 		currentVersion: currentVersion,
 		client:         &http.Client{Timeout: 10 * time.Second},
 		now:            time.Now,
-		ttl:            time.Hour,
+		ttl:            defaultCacheTTL,
 	}
 }
 
@@ -76,15 +78,23 @@ func NewWithOptions(currentVersion string, client *http.Client, now func() time.
 		now = time.Now
 	}
 	if ttl <= 0 {
-		ttl = time.Hour
+		ttl = defaultCacheTTL
 	}
 
 	return &Service{currentVersion: currentVersion, client: client, now: now, ttl: ttl}
 }
 
 func (s *Service) Snapshot(ctx context.Context) (Snapshot, error) {
+	return s.snapshot(ctx, false)
+}
+
+func (s *Service) RefreshSnapshot(ctx context.Context) (Snapshot, error) {
+	return s.snapshot(ctx, true)
+}
+
+func (s *Service) snapshot(ctx context.Context, forceRefresh bool) (Snapshot, error) {
 	s.mu.RLock()
-	if s.hasHit && s.now().Sub(s.cached.cachedAt) < s.ttl {
+	if !forceRefresh && s.hasHit && s.now().Sub(s.cached.cachedAt) < s.ttl {
 		snap := s.snapshotFromCache(s.cached)
 		s.mu.RUnlock()
 		return snap, nil

--- a/api/internal/version/service_test.go
+++ b/api/internal/version/service_test.go
@@ -10,6 +10,13 @@ import (
 	"time"
 )
 
+func TestNew_DefaultsToShortCacheTTL(t *testing.T) {
+	svc := New("v1.0.0")
+	if svc.ttl != defaultCacheTTL {
+		t.Fatalf("ttl = %s, want %s", svc.ttl, defaultCacheTTL)
+	}
+}
+
 func TestSnapshot_UpgradeAvailableComparison(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -225,8 +225,9 @@ export async function getLoadBalancerAccessLogs(
   return res.json()
 }
 
-export async function getVersionInfo(): Promise<VersionInfo> {
-  const res = await fetch('/api/version')
+export async function getVersionInfo(options?: { forceRefresh?: boolean }): Promise<VersionInfo> {
+  const suffix = options?.forceRefresh ? "?refresh=1" : ""
+  const res = await fetch(`/api/version${suffix}`)
   if (!res.ok) throw new Error('Failed to fetch version info')
   return res.json()
 }

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -28,11 +28,28 @@ export function SettingsPage() {
 
   const { currentVersion, latestVersion, publishedAt, releaseNotes, upgradeAvailable, cachedAt, isLoading, isError } =
     useVersionCheck()
+
+  useEffect(() => {
+    let active = true
+
+    getVersionInfo({ forceRefresh: true })
+      .then(snapshot => {
+        if (!active) return
+        queryClient.setQueryData(['version-check'], snapshot)
+      })
+      .catch(() => {
+        // keep cached version info if force refresh fails
+      })
+
+    return () => {
+      active = false
+    }
+  }, [queryClient])
   const { lines, streamClosed } = useUpgradeLogsSSE(isUpgradeRunning)
 
   const reconnectProbe = useQuery({
     queryKey: ['upgrade-reconnect-probe', attemptId],
-    queryFn: getVersionInfo,
+    queryFn: () => getVersionInfo(),
     enabled: awaitingReconnect,
     retry: false,
     refetchInterval: 3000,

--- a/dashboard/src/settings/useVersionCheck.ts
+++ b/dashboard/src/settings/useVersionCheck.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { getVersionInfo, type VersionInfo } from '../lib/api'
 
-const VERSION_CHECK_INTERVAL_MS = 60 * 60 * 1000
+const VERSION_CHECK_INTERVAL_MS = 5 * 60 * 1000
 
 const FALLBACK_VERSION_INFO: VersionInfo = {
   currentVersion: 'unknown',
@@ -11,9 +11,11 @@ const FALLBACK_VERSION_INFO: VersionInfo = {
 export function useVersionCheck() {
   const query = useQuery({
     queryKey: ['version-check'],
-    queryFn: getVersionInfo,
+    queryFn: () => getVersionInfo(),
     staleTime: VERSION_CHECK_INTERVAL_MS,
     refetchInterval: VERSION_CHECK_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: true,
   })
 
   return {


### PR DESCRIPTION
### Motivation

- Allow clients to request a fresh version snapshot bypassing the cache when needed (e.g. after an upgrade run). 
- Reduce the default version cache TTL to surface new releases faster. 
- Make the dashboard proactively refresh version info on the Settings page and expose an option to force a refresh from the frontend.

### Description

- Add `RefreshSnapshot(ctx context.Context) (version.Snapshot, error)` to the `version` service and implement `snapshot(ctx, forceRefresh bool)` to share logic between cached and forced refresh flows. 
- Introduce `defaultCacheTTL` (5 minutes) and set it as the default TTL in `New` and `NewWithOptions`. 
- Modify `Handler.getVersion` to accept `?refresh=1` and call `RefreshSnapshot` when `h.versions` implements the refresher interface. 
- Add `versionProviderWithRefreshStub` and a handler test `TestGetVersion_RefreshQueryUsesFreshSnapshot` to verify the refresh query uses a fresh snapshot. 
- Update dashboard API `getVersionInfo` to accept `options?: { forceRefresh?: boolean }` and append `?refresh=1` when requested. 
- Update `SettingsPage` to attempt a forced refresh on mount and merge the result into the query cache while keeping the cached info if the refresh fails. 
- Reduce the version check polling interval in `useVersionCheck` to 5 minutes and enable background refetching and refetch-on-focus. 

### Testing

- Ran Go unit tests including `TestNew_DefaultsToShortCacheTTL`, `TestGetVersion_RefreshQueryUsesFreshSnapshot` and existing version/handler tests; all tests passed. 
- Verified existing handler tests for upgrade endpoints still return expected statuses (they passed as part of the test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c899a9bc8333839de83eb9239a21)