### PR TITLE
orchestrator: remove reconcile timeout context

### DIFF
--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -135,12 +135,9 @@ func main() {
 				log.Printf("orchestrator: notify heartbeat: %v", err)
 			}
 
-			// Reconcile with a deadline shorter than the interval so it cannot starve the next tick.
-			reconcileCtx, reconcileCancel := context.WithTimeout(ctx, interval*9/10)
-			if err := r.Reconcile(reconcileCtx); err != nil {
+			if err := r.Reconcile(ctx); err != nil {
 				log.Printf("orchestrator: reconcile: %v", err)
 			}
-			reconcileCancel()
 		case <-ctx.Done():
 			log.Println("orchestrator: shutting down")
 			return


### PR DESCRIPTION
### Motivation
- The per-tick reconcile timeout `context.WithTimeout(interval*9/10)` could expire during long `ImagePull` operations and cause subsequent Docker calls (e.g. `ContainerCreate`) to fail with `context deadline exceeded`, so the reconcile pass should not share a tight interval-bound deadline.

### Description
- Stop wrapping each reconcile pass in `context.WithTimeout(interval*9/10)` and call `r.Reconcile(ctx)` with the root signal context instead (change made in `orchestrator/cmd/orchestrator/main.go`).

### Testing
- Ran `cd orchestrator && go test ./...` and the `orchestrator` package tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2cdc368dc83339bd6dd4d0b48c1d8)