### PR TITLE
fix(orchestrator): prevent redeploy host-port bind collisions

### DIFF
--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -442,31 +442,29 @@ func (d *Docker) shouldStopBeforeStart(ctx context.Context, oldContainerID strin
 		return false, nil
 	}
 
-	current := make(map[string]string, len(inspect.NetworkSettings.Ports))
-	for p, bindings := range inspect.NetworkSettings.Ports {
+	current := make(map[string]struct{}, len(inspect.NetworkSettings.Ports))
+	for _, bindings := range inspect.NetworkSettings.Ports {
 		for _, b := range bindings {
 			if b.HostPort == "" {
 				continue
 			}
-			current[p.Port()] = b.HostPort
+			current[b.HostPort] = struct{}{}
 			break
 		}
 	}
 
-	if len(current) != len(desired) {
-		return false, nil
-	}
-	for containerPort, hostPort := range desired {
-		if current[containerPort] != hostPort {
-			return false, nil
+	for _, hostPort := range desired {
+		if _, overlap := current[hostPort]; overlap {
+			return true, nil
 		}
 	}
-	return true, nil
+
+	return false, nil
 }
 
-func desiredExplicitHostPorts(ports []string) (map[string]string, error) {
+func desiredExplicitHostPorts(ports []string) ([]string, error) {
 	if len(ports) == 0 {
-		return map[string]string{}, nil
+		return []string{}, nil
 	}
 
 	_, bindings, err := parsePorts(ports)
@@ -474,8 +472,8 @@ func desiredExplicitHostPorts(ports []string) (map[string]string, error) {
 		return nil, err
 	}
 
-	result := make(map[string]string, len(bindings))
-	for p, b := range bindings {
+	result := make([]string, 0, len(bindings))
+	for _, b := range bindings {
 		if len(b) == 0 {
 			continue
 		}
@@ -483,7 +481,7 @@ func desiredExplicitHostPorts(ports []string) (map[string]string, error) {
 		if hostPort == "" || hostPort == "0" {
 			continue
 		}
-		result[p.Port()] = hostPort
+		result = append(result, hostPort)
 	}
 	return result, nil
 }

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -363,6 +363,34 @@ func TestDocker_StartAndReplace_SameExplicitPorts_FallsBackToStopThenStart(t *te
 	}
 }
 
+func TestDocker_StartAndReplace_OverlappingExplicitHostPort_FallsBackToStopThenStart(t *testing.T) {
+	mock := &mockClient{
+		containerCreate:  container.CreateResponse{ID: "new-c1"},
+		inspectContainer: inspectWithPort("8080/tcp", "32770"),
+		listContainers:   []dockertypes.Container{},
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.Ports = []string{"32770:8080"}
+
+	ports, err := d.StartAndReplace(context.Background(), dep, "old-c1")
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+
+	if len(ports) != 1 || ports[0] != "32770:8080" {
+		t.Fatalf("want runtime ports [32770:8080], got %v", ports)
+	}
+
+	if len(mock.stopped) != 1 || mock.stopped[0] != "old-c1" {
+		t.Fatalf("want old-c1 stopped first, got %v", mock.stopped)
+	}
+	if len(mock.removed) != 1 || mock.removed[0] != "old-c1" {
+		t.Fatalf("want old-c1 removed first, got %v", mock.removed)
+	}
+}
+
 func TestDocker_StartAndReplace_DomainConfigured_SwapsProxyBeforeStoppingOld(t *testing.T) {
 	var stopCalled atomic.Bool
 	var swapCalled atomic.Bool

--- a/orchestrator/internal/reconciler/reconciler.go
+++ b/orchestrator/internal/reconciler/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -106,10 +107,10 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		return fmt.Errorf("reconcile: list containers: %w", err)
 	}
 
-	// Build a map of deploymentID → container for quick lookup.
-	containerByDeployment := make(map[string]docker.ManagedContainer, len(containers))
+	// Build a map of deploymentID → containers for quick lookup.
+	containersByDeployment := make(map[string][]docker.ManagedContainer, len(containers))
 	for _, c := range containers {
-		containerByDeployment[c.DeploymentID] = c
+		containersByDeployment[c.DeploymentID] = append(containersByDeployment[c.DeploymentID], c)
 	}
 
 	// Build a set of known deployment IDs for orphan detection.
@@ -124,7 +125,17 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			r.clearRetryState(d.ID)
 		}
 
-		c, hasContainer := containerByDeployment[d.ID]
+		candidates := containersByDeployment[d.ID]
+		c, hasContainer := choosePrimaryContainer(d.Name, candidates)
+		for _, extra := range candidates {
+			if hasContainer && extra.ID == c.ID {
+				continue
+			}
+			if err := r.docker.StopAndRemove(ctx, extra.ID); err != nil {
+				log.Printf("reconciler: stop+remove stale container %s for deployment %s: %v", extra.ID, d.ID, err)
+			}
+		}
+
 		if r.dashboardDomain != "" && normalizeDomain(d.Domain) == r.dashboardDomain {
 			if d.Status == store.StatusDeploying {
 				r.updateStatus(d.ID, store.StatusFailed, fmt.Sprintf("domain %q is reserved for dashboard", r.dashboardDomain))
@@ -327,4 +338,38 @@ func normalizeDomain(domain string) string {
 	domain = strings.TrimSpace(domain)
 	domain = strings.TrimSuffix(domain, ".")
 	return strings.ToLower(domain)
+}
+
+func choosePrimaryContainer(deploymentName string, containers []docker.ManagedContainer) (docker.ManagedContainer, bool) {
+	if len(containers) == 0 {
+		return docker.ManagedContainer{}, false
+	}
+
+	canonical := strings.TrimSpace(deploymentName)
+	sort.Slice(containers, func(i, j int) bool {
+		scoreI := containerSelectionScore(containers[i], canonical)
+		scoreJ := containerSelectionScore(containers[j], canonical)
+		if scoreI == scoreJ {
+			return containers[i].ID < containers[j].ID
+		}
+		return scoreI > scoreJ
+	})
+
+	return containers[0], true
+}
+
+func containerSelectionScore(c docker.ManagedContainer, canonicalName string) int {
+	name := strings.TrimPrefix(strings.TrimSpace(c.Name), "/")
+	canonical := canonicalName != "" && name == canonicalName
+
+	switch {
+	case c.Running && canonical:
+		return 4
+	case c.Running:
+		return 3
+	case canonical:
+		return 2
+	default:
+		return 1
+	}
 }

--- a/orchestrator/internal/reconciler/reconciler_test.go
+++ b/orchestrator/internal/reconciler/reconciler_test.go
@@ -244,6 +244,35 @@ func TestReconcile_DeployingWithRunningContainer_RedeploysAndBecomesHealthy(t *t
 	}
 }
 
+func TestReconcile_DeployingWithMultipleContainers_PrefersCanonicalAndCleansUpStale(t *testing.T) {
+	s := &mockStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Name: "web", Image: "nginx:2", Status: store.StatusDeploying},
+		},
+	}
+	d := &mockDocker{
+		containers: []docker.ManagedContainer{
+			{ID: "c-next", Name: "/web-next", DeploymentID: "d1", Running: true},
+			{ID: "c-old", Name: "/web", DeploymentID: "d1", Running: true},
+		},
+	}
+	r := reconciler.New(s, d, nil)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if len(d.replaced) != 1 || d.replaced[0] != "c-old" {
+		t.Fatalf("want StartAndReplace called with canonical container c-old, got %v", d.replaced)
+	}
+	if len(d.removed) != 1 || d.removed[0] != "c-next" {
+		t.Fatalf("want stale c-next removed, got %v", d.removed)
+	}
+	if s.getStatus("d1") != store.StatusHealthy {
+		t.Fatalf("want status healthy, got %s", s.getStatus("d1"))
+	}
+}
+
 func TestReconcile_DeployingNoContainer_StoresRuntimePorts(t *testing.T) {
 	s := &mockStore{
 		deployments: []store.Deployment{


### PR DESCRIPTION
## Summary
- detect any overlap in explicit host-port bindings during redeploy and fall back to stop-old-then-start, which avoids Docker bind conflicts like `port is already allocated`
- keep start-then-stop behavior for non-overlapping ports while making overlap detection robust across changed container ports
- make reconciler pick a deterministic primary container per deployment and clean up stale extras (like lingering `-next` containers) before redeploying

## Testing
- go test ./orchestrator/internal/docker ./orchestrator/internal/reconciler
- go test ./orchestrator/...