### PR TITLE
feat(dashboard): add WAF security config UI and telemetry

### DIFF
--- a/dashboard/src/deployments/DeploymentSecurityPanel.test.tsx
+++ b/dashboard/src/deployments/DeploymentSecurityPanel.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { DeploymentSecurityPanel } from './DeploymentSecurityPanel'
+import * as api from '../lib/api'
+
+vi.mock('../lib/api', () => ({
+  getSecurityConfig: vi.fn(),
+  patchDeployment: vi.fn(),
+}))
+
+function renderWithQuery(ui: React.ReactElement) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+const deployment: api.Deployment = {
+  id: 'dep-1',
+  name: 'app',
+  image: 'nginx:latest',
+  envs: {},
+  ports: [],
+  volumes: [],
+  domain: 'app.example.com',
+  status: 'healthy',
+}
+
+describe('DeploymentSecurityPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.getSecurityConfig).mockResolvedValue({
+      profile: 'standard',
+      suspiciousWindowSeconds: 30,
+      suspiciousThreshold: 10,
+      suspiciousBlockForSeconds: 120,
+      wafEnabled: true,
+      wafMode: 'detection',
+      globalIpDenylist: [],
+      globalIpAllowlist: [],
+    })
+  })
+
+  it('rejects invalid CIDR entries client-side', async () => {
+    const user = userEvent.setup()
+    renderWithQuery(<DeploymentSecurityPanel deployment={deployment} />)
+
+    await user.type(screen.getByLabelText('IP denylist'), 'not-an-ip{enter}')
+
+    expect(screen.getByText('IP filters must be valid CIDR ranges or IP addresses.')).toBeInTheDocument()
+    expect(vi.mocked(api.patchDeployment)).not.toHaveBeenCalled()
+  })
+
+  it('submits security config via patch endpoint', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.patchDeployment).mockResolvedValue({
+      ...deployment,
+      security: {
+        waf_enabled: false,
+        ip_denylist: ['10.0.0.0/8'],
+        ip_allowlist: ['203.0.113.0/24'],
+        custom_rules: ['SecRule REQUEST_URI "@contains blocked" "id:10001,phase:1,deny,status:403"'],
+      },
+    })
+
+    renderWithQuery(<DeploymentSecurityPanel deployment={deployment} />)
+
+    await user.click(screen.getByRole('checkbox', { name: /enable waf for this deployment/i }))
+    await user.type(screen.getByLabelText('IP denylist'), '10.0.0.0/8{enter}')
+    await user.type(screen.getByLabelText('IP allowlist'), '203.0.113.0/24{enter}')
+    await user.type(
+      screen.getByLabelText('Custom rules'),
+      'SecRule REQUEST_URI "@contains blocked" "id:10001,phase:1,deny,status:403"'
+    )
+    await user.click(screen.getByRole('button', { name: /save security/i }))
+
+    await waitFor(() => {
+      expect(vi.mocked(api.patchDeployment)).toHaveBeenCalledWith('dep-1', {
+        security: {
+          waf_enabled: false,
+          ip_denylist: ['10.0.0.0/8'],
+          ip_allowlist: ['203.0.113.0/24'],
+          custom_rules: ['SecRule REQUEST_URI "@contains blocked" "id:10001,phase:1,deny,status:403"'],
+        },
+      })
+    })
+  })
+})

--- a/dashboard/src/deployments/DeploymentSecurityPanel.tsx
+++ b/dashboard/src/deployments/DeploymentSecurityPanel.tsx
@@ -1,0 +1,106 @@
+import { type FormEvent } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Badge } from '../components/ui/badge'
+import { Button } from '../components/ui/button'
+import { Label } from '../components/ui/label'
+import { getSecurityConfig, type Deployment } from '../lib/api'
+import { SecurityCIDRListField } from './SecurityCIDRListField'
+import { useDeploymentSecurityForm } from './useDeploymentSecurityForm'
+
+type Props = {
+  deployment: Deployment
+}
+
+export function DeploymentSecurityPanel({ deployment }: Props) {
+  const securityQuery = useQuery({
+    queryKey: ['security-config'],
+    queryFn: getSecurityConfig,
+  })
+  const globalWAFEnabled = securityQuery.data?.wafEnabled ?? true
+
+  const form = useDeploymentSecurityForm(deployment, globalWAFEnabled)
+
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault()
+    form.submit()
+  }
+
+  return (
+    <section className="rounded-xl border border-border/60 bg-card p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/60">Security</p>
+          <p className="mt-1 text-xs text-muted-foreground">Configure per-deployment WAF, IP filtering, and custom rules.</p>
+        </div>
+        {securityQuery.data?.wafMode ? (
+          <Badge variant="info" className="capitalize">
+            Global mode: {securityQuery.data.wafMode}
+          </Badge>
+        ) : null}
+      </div>
+
+      {!securityQuery.isLoading && securityQuery.data?.wafEnabled === false ? (
+        <p className="mt-3 rounded-md border border-amber-300/50 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+          Global WAF is disabled. Enabling WAF here will not take effect until global WAF is enabled.
+        </p>
+      ) : null}
+
+      <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+        <label className="flex items-center gap-2 text-sm text-foreground">
+          <input
+            type="checkbox"
+            checked={form.config.waf_enabled}
+            onChange={event => form.setWAFEnabled(event.target.checked)}
+          />
+          Enable WAF for this deployment
+        </label>
+
+        <SecurityCIDRListField
+          id={`security-denylist-${deployment.id}`}
+          label="IP denylist"
+          value={form.denyInput}
+          entries={form.config.ip_denylist}
+          emptyLabel="No denylist entries configured."
+          badgeVariant="warning"
+          onChange={form.setDenyInput}
+          onAdd={form.addDenyEntry}
+          onRemove={form.removeDenyEntry}
+        />
+
+        <SecurityCIDRListField
+          id={`security-allowlist-${deployment.id}`}
+          label="IP allowlist"
+          value={form.allowInput}
+          entries={form.config.ip_allowlist}
+          emptyLabel="No allowlist entries configured."
+          badgeVariant="info"
+          onChange={form.setAllowInput}
+          onAdd={form.addAllowEntry}
+          onRemove={form.removeAllowEntry}
+        />
+
+        <div className="space-y-2">
+          <Label htmlFor={`security-custom-rules-${deployment.id}`}>Custom rules</Label>
+          <textarea
+            id={`security-custom-rules-${deployment.id}`}
+            value={form.customRulesText}
+            onChange={event => form.setCustomRules(event.target.value)}
+            placeholder={'SecRule REQUEST_URI "@contains blocked" "id:10001,phase:1,deny,status:403"'}
+            className="min-h-28 w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs text-foreground shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+          />
+          <p className="text-xs text-muted-foreground">Use one ModSecurity SecRule per line.</p>
+        </div>
+
+        {form.inputError ? <p className="text-xs text-destructive">{form.inputError}</p> : null}
+        {form.formError ? <p className="text-xs text-destructive">{form.formError}</p> : null}
+
+        <div className="flex items-center gap-3">
+          <Button type="submit" disabled={form.isSaving || !form.hasChanges}>
+            {form.isSaving ? 'Saving security...' : 'Save security'}
+          </Button>
+          {!form.hasChanges && !form.isDirty ? <p className="text-xs text-muted-foreground">No pending security changes.</p> : null}
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/dashboard/src/deployments/SecurityCIDRListField.tsx
+++ b/dashboard/src/deployments/SecurityCIDRListField.tsx
@@ -1,0 +1,72 @@
+import { X } from 'lucide-react'
+import { Badge } from '../components/ui/badge'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+
+type Props = {
+  id: string
+  label: string
+  value: string
+  entries: string[]
+  emptyLabel: string
+  badgeVariant: 'warning' | 'info'
+  onChange: (value: string) => void
+  onAdd: (value: string) => void
+  onRemove: (value: string) => void
+}
+
+export function SecurityCIDRListField({
+  id,
+  label,
+  value,
+  entries,
+  emptyLabel,
+  badgeVariant,
+  onChange,
+  onAdd,
+  onRemove,
+}: Props) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <div className="flex gap-2">
+        <Input
+          id={id}
+          placeholder="Enter CIDR or IP and press Enter"
+          value={value}
+          onChange={event => onChange(event.target.value)}
+          onKeyDown={event => {
+            if (event.key !== 'Enter') {
+              return
+            }
+            event.preventDefault()
+            onAdd(value)
+          }}
+        />
+        <Button type="button" variant="outline" onClick={() => onAdd(value)}>
+          Add
+        </Button>
+      </div>
+      {entries.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {entries.map(item => (
+            <Badge key={`${id}-${item}`} variant={badgeVariant} className="gap-1 pr-1">
+              <span className="font-mono">{item}</span>
+              <button
+                type="button"
+                className="rounded p-0.5 hover:bg-accent"
+                onClick={() => onRemove(item)}
+                aria-label={`Remove ${item}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">{emptyLabel}</p>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/deployments/securityConfig.ts
+++ b/dashboard/src/deployments/securityConfig.ts
@@ -1,0 +1,79 @@
+import type { Deployment, SecurityConfig } from '../lib/api'
+
+function isValidIPv4(input: string) {
+  if (!/^(\d{1,3}\.){3}\d{1,3}$/.test(input)) {
+    return false
+  }
+
+  return input.split('.').every(part => Number(part) >= 0 && Number(part) <= 255)
+}
+
+function isValidIPv6(input: string) {
+  if (!input.includes(':')) {
+    return false
+  }
+
+  return /^[0-9a-fA-F:]+$/.test(input)
+}
+
+export function isValidCIDROrIP(input: string) {
+  const value = input.trim()
+  if (!value) {
+    return false
+  }
+
+  if (!value.includes('/')) {
+    return isValidIPv4(value) || isValidIPv6(value)
+  }
+
+  const [ip, prefix, ...rest] = value.split('/')
+  if (rest.length > 0 || !prefix) {
+    return false
+  }
+
+  const prefixNum = Number(prefix)
+  if (!Number.isInteger(prefixNum) || prefixNum < 0) {
+    return false
+  }
+
+  if (isValidIPv4(ip)) {
+    return prefixNum <= 32
+  }
+  if (isValidIPv6(ip)) {
+    return prefixNum <= 128
+  }
+  return false
+}
+
+export function toSecurityConfig(security: Deployment['security'], defaultWAFEnabled: boolean): SecurityConfig {
+  return {
+    waf_enabled: security?.waf_enabled ?? defaultWAFEnabled,
+    ip_denylist: security?.ip_denylist ?? [],
+    ip_allowlist: security?.ip_allowlist ?? [],
+    custom_rules: security?.custom_rules ?? [],
+  }
+}
+
+export function joinRules(rules: string[]) {
+  return rules.join('\n')
+}
+
+export function splitRules(value: string) {
+  return value
+    .split('\n')
+    .map(rule => rule.trim())
+    .filter(Boolean)
+}
+
+export function hasSecurityChanges(config: SecurityConfig, existing: Deployment['security'], globalWAFEnabled: boolean) {
+  if (!existing) {
+    return (
+      config.waf_enabled !== globalWAFEnabled ||
+      config.ip_denylist.length > 0 ||
+      config.ip_allowlist.length > 0 ||
+      config.custom_rules.length > 0
+    )
+  }
+
+  return JSON.stringify(existing) !== JSON.stringify(config)
+}

--- a/dashboard/src/deployments/useDeploymentSecurityForm.ts
+++ b/dashboard/src/deployments/useDeploymentSecurityForm.ts
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { patchDeployment, type Deployment, type SecurityConfig } from '../lib/api'
+import { hasSecurityChanges, isValidCIDROrIP, joinRules, splitRules, toSecurityConfig } from './securityConfig'
+
+type ListKey = 'ip_denylist' | 'ip_allowlist'
+
+const invalidEntryError = 'IP filters must be valid CIDR ranges or IP addresses.'
+
+export function useDeploymentSecurityForm(deployment: Deployment, globalWAFEnabled: boolean) {
+  const queryClient = useQueryClient()
+  const [config, setConfig] = useState<SecurityConfig>(() => toSecurityConfig(deployment.security, globalWAFEnabled))
+  const [customRulesText, setCustomRulesText] = useState(() => joinRules(deployment.security?.custom_rules ?? []))
+  const [denyInput, setDenyInput] = useState('')
+  const [allowInput, setAllowInput] = useState('')
+  const [inputError, setInputError] = useState<string>()
+  const [formError, setFormError] = useState<string>()
+  const [isDirty, setIsDirty] = useState(false)
+
+  useEffect(() => {
+    setConfig(toSecurityConfig(deployment.security, globalWAFEnabled))
+    setCustomRulesText(joinRules(deployment.security?.custom_rules ?? []))
+    setDenyInput('')
+    setAllowInput('')
+    setInputError(undefined)
+    setFormError(undefined)
+    setIsDirty(false)
+  }, [deployment.id, deployment.security, globalWAFEnabled])
+
+  const mutation = useMutation({
+    mutationFn: (security: SecurityConfig) => patchDeployment(deployment.id, { security }),
+    onSuccess: updated => {
+      queryClient.setQueryData<Deployment[]>(['deployments'], prev =>
+        prev?.map(item => (item.id === deployment.id ? updated : item))
+      )
+      setFormError(undefined)
+      setIsDirty(false)
+    },
+    onError: (error: Error) => {
+      setFormError(error.message)
+    },
+  })
+
+  const hasChanges = useMemo(
+    () => hasSecurityChanges(config, deployment.security, globalWAFEnabled),
+    [config, deployment.security, globalWAFEnabled]
+  )
+
+  function setWAFEnabled(enabled: boolean) {
+    setConfig(prev => ({ ...prev, waf_enabled: enabled }))
+    setIsDirty(true)
+  }
+
+  function setCustomRules(value: string) {
+    setCustomRulesText(value)
+    setIsDirty(true)
+  }
+
+  function addEntry(key: ListKey, value: string) {
+    const next = value.trim()
+    if (!next) {
+      return
+    }
+
+    if (!isValidCIDROrIP(next)) {
+      setInputError(invalidEntryError)
+      return
+    }
+
+    setInputError(undefined)
+    setIsDirty(true)
+    setConfig(prev => {
+      if (prev[key].includes(next)) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        [key]: [...prev[key], next],
+      }
+    })
+
+    if (key === 'ip_denylist') {
+      setDenyInput('')
+      return
+    }
+    setAllowInput('')
+  }
+
+  function removeEntry(key: ListKey, value: string) {
+    setIsDirty(true)
+    setConfig(prev => ({
+      ...prev,
+      [key]: prev[key].filter(item => item !== value),
+    }))
+  }
+
+  function submit() {
+    const security = {
+      ...config,
+      custom_rules: splitRules(customRulesText),
+    }
+    setConfig(security)
+    setFormError(undefined)
+    mutation.mutate(security)
+  }
+
+  return {
+    config,
+    customRulesText,
+    denyInput,
+    allowInput,
+    inputError,
+    formError,
+    hasChanges,
+    isDirty,
+    isSaving: mutation.isPending,
+    setDenyInput,
+    setAllowInput,
+    setWAFEnabled,
+    setCustomRules,
+    addDenyEntry: (value: string) => addEntry('ip_denylist', value),
+    addAllowEntry: (value: string) => addEntry('ip_allowlist', value),
+    removeDenyEntry: (value: string) => removeEntry('ip_denylist', value),
+    removeAllowEntry: (value: string) => removeEntry('ip_allowlist', value),
+    submit,
+  }
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -9,6 +9,13 @@ export type BasicAuthConfig = {
   users: BasicAuthUser[]
 }
 
+export type SecurityConfig = {
+  waf_enabled: boolean
+  ip_denylist: string[]
+  ip_allowlist: string[]
+  custom_rules: string[]
+}
+
 export type Deployment = {
   id: string
   name: string
@@ -18,6 +25,7 @@ export type Deployment = {
   volumes: string[]
   domain: string
   basic_auth?: BasicAuthConfig
+  security?: SecurityConfig
   status: DeploymentStatus
   error?: string
 }
@@ -84,12 +92,25 @@ export type LoadBalancerSystemStatus = {
     totalRequests: number
     suspiciousRequests: number
     blockedRequests: number
+    wafBlockedRequests?: number
+    uaBlockedRequests?: number
     activeBlockedIps: number
     blockedIps?: Array<{
       ip: string
       blockedUntil?: string
     }>
   }
+}
+
+export type ProxySecurityConfig = {
+  profile: string
+  suspiciousWindowSeconds: number
+  suspiciousThreshold: number
+  suspiciousBlockForSeconds: number
+  wafEnabled: boolean
+  wafMode?: string
+  globalIpDenylist?: string[]
+  globalIpAllowlist?: string[]
 }
 
 export type DockerSystemStatus = {
@@ -181,6 +202,7 @@ export type UpdateDeploymentInput = {
   volumes: string[]
   domain: string
   basic_auth?: BasicAuthConfig
+  security?: SecurityConfig
 }
 
 export async function updateDeployment(id: string, data: UpdateDeploymentInput): Promise<Deployment> {
@@ -190,6 +212,26 @@ export async function updateDeployment(id: string, data: UpdateDeploymentInput):
     body: JSON.stringify(data),
   })
   if (!res.ok) throw new Error('Failed to update deployment')
+  return res.json()
+}
+
+export type PatchDeploymentInput = {
+  image?: string
+  envs?: Record<string, string>
+  ports?: string[]
+  volumes?: string[]
+  domain?: string
+  basic_auth?: BasicAuthConfig
+  security?: SecurityConfig
+}
+
+export async function patchDeployment(id: string, data: PatchDeploymentInput): Promise<Deployment> {
+  const res = await fetch(`/api/deployments/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) throw new Error('Failed to patch deployment')
   return res.json()
 }
 
@@ -235,6 +277,12 @@ export async function getVersionInfo(options?: { forceRefresh?: boolean }): Prom
   const suffix = options?.forceRefresh ? "?refresh=1" : ""
   const res = await fetch(`/api/version${suffix}`)
   if (!res.ok) throw new Error('Failed to fetch version info')
+  return res.json()
+}
+
+export async function getSecurityConfig(): Promise<ProxySecurityConfig> {
+  const res = await fetch('/api/security-config')
+  if (!res.ok) throw new Error('Failed to fetch security config')
   return res.json()
 }
 

--- a/dashboard/src/pages/DeploymentDetailPage.tsx
+++ b/dashboard/src/pages/DeploymentDetailPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '../components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../components/ui/dialog'
 import EditDeploymentForm from '../deployments/EditDeploymentForm'
 import { DeploymentLogsPanel } from '../deployments/DeploymentLogsPanel'
+import { DeploymentSecurityPanel } from '../deployments/DeploymentSecurityPanel'
 import { StatusBadge } from '../deployments/StatusBadge'
 import { getDeployments } from '../lib/api'
 
@@ -189,6 +190,9 @@ export function DeploymentDetailPage() {
           <p className="text-xs text-muted-foreground/50">None configured</p>
         )}
       </div>
+
+      {/* Live logs */}
+      <DeploymentSecurityPanel deployment={deployment} />
 
       {/* Live logs */}
       <DeploymentLogsPanel deploymentId={deployment.id} status={deployment.status} error={deployment.error} />

--- a/dashboard/src/pages/TrafficPage.tsx
+++ b/dashboard/src/pages/TrafficPage.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
+import { getSecurityConfig } from '../lib/api'
 import { useLoadBalancerAccessLogs } from '../system-status/useLoadBalancerAccessLogs'
 import { useSystemStatus } from '../system-status/useSystemStatus'
 
@@ -16,6 +18,10 @@ function statusVariant(status?: number): 'secondary' | 'success' | 'warning' | '
 
 export function TrafficPage() {
   const { status, isLoading, isError } = useSystemStatus()
+  const securityConfig = useQuery({
+    queryKey: ['security-config'],
+    queryFn: getSecurityConfig,
+  })
   const [methodFilter, setMethodFilter] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
   const [hostFilter, setHostFilter] = useState('')
@@ -91,6 +97,18 @@ export function TrafficPage() {
     return `Blocked until ${date.toLocaleTimeString()}`
   }
 
+  const wafMode = securityConfig.data?.wafMode ?? 'off'
+
+  const wafModeVariant = () => {
+    if (wafMode === 'enforcement') {
+      return 'destructive' as const
+    }
+    if (wafMode === 'detection') {
+      return 'warning' as const
+    }
+    return 'secondary' as const
+  }
+
   return (
     <div className="space-y-5">
       <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">
@@ -138,6 +156,20 @@ export function TrafficPage() {
                   </p>
                 </article>
               </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <article className="rounded-lg border border-border/60 bg-background/70 p-3">
+                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">WAF blocked</p>
+                  <p className="mt-1 text-lg font-semibold text-foreground">
+                    {formatCount(status.loadBalancer.traffic.wafBlockedRequests)}
+                  </p>
+                </article>
+                <article className="rounded-lg border border-border/60 bg-background/70 p-3">
+                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">UA blocked</p>
+                  <p className="mt-1 text-lg font-semibold text-foreground">
+                    {formatCount(status.loadBalancer.traffic.uaBlockedRequests)}
+                  </p>
+                </article>
+              </div>
               {status.loadBalancer.traffic.blockedIps && status.loadBalancer.traffic.blockedIps.length > 0 ? (
                 <div className="space-y-2">
                   <p className="text-xs font-semibold uppercase tracking-[0.13em] text-muted-foreground">Currently blocked IPs</p>
@@ -159,6 +191,59 @@ export function TrafficPage() {
             </div>
           )}
         </div>
+      </section>
+
+      <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Global security</p>
+            <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">
+              Effective WAF and IP filtering mode
+            </h2>
+          </div>
+          {securityConfig.isLoading ? null : securityConfig.isError ? null : (
+            <Badge variant={wafModeVariant()} className="capitalize">
+              WAF mode: {wafMode}
+            </Badge>
+          )}
+        </div>
+
+        {securityConfig.isLoading ? (
+          <p className="mt-4 text-sm text-muted-foreground">Loading global security config...</p>
+        ) : securityConfig.isError || !securityConfig.data ? (
+          <p className="mt-4 text-sm text-destructive">Unable to load global security config.</p>
+        ) : (
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <article className="rounded-lg border border-border/60 bg-background/70 p-3">
+              <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Global IP denylist</p>
+              {securityConfig.data.globalIpDenylist && securityConfig.data.globalIpDenylist.length > 0 ? (
+                <ul className="mt-2 space-y-1 text-xs">
+                  {securityConfig.data.globalIpDenylist.map(entry => (
+                    <li key={`global-deny-${entry}`} className="font-mono text-foreground">
+                      {entry}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-xs text-muted-foreground">No global denylist entries configured.</p>
+              )}
+            </article>
+            <article className="rounded-lg border border-border/60 bg-background/70 p-3">
+              <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Global IP allowlist</p>
+              {securityConfig.data.globalIpAllowlist && securityConfig.data.globalIpAllowlist.length > 0 ? (
+                <ul className="mt-2 space-y-1 text-xs">
+                  {securityConfig.data.globalIpAllowlist.map(entry => (
+                    <li key={`global-allow-${entry}`} className="font-mono text-foreground">
+                      {entry}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-xs text-muted-foreground">No global allowlist entries configured.</p>
+              )}
+            </article>
+          </div>
+        )}
       </section>
 
       <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">

--- a/dashboard/src/system-status/SystemStatusPanel.test.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.test.tsx
@@ -276,6 +276,8 @@ describe('SystemStatusPanel', () => {
           totalRequests: 1200,
           suspiciousRequests: 34,
           blockedRequests: 7,
+          wafBlockedRequests: 5,
+          uaBlockedRequests: 2,
           activeBlockedIps: 2,
           blockedIps: [
             { ip: '203.0.113.7', blockedUntil },
@@ -304,8 +306,10 @@ describe('SystemStatusPanel', () => {
     renderWithQuery(<SystemStatusPanel />)
 
     await waitFor(() => expect(screen.getByText('Traffic and security')).toBeInTheDocument())
-    expect(screen.getByText('Total requests: 1,200')).toBeInTheDocument()
-    expect(screen.getByText('Active blocked IPs: 2')).toBeInTheDocument()
+    expect(screen.getByText(/Total requests:/)).toBeInTheDocument()
+    expect(screen.getByText(/Active blocked IPs:/)).toBeInTheDocument()
+    expect(screen.getByText(/WAF blocked:/)).toBeInTheDocument()
+    expect(screen.getByText(/UA blocked:/)).toBeInTheDocument()
     expect(screen.getByText('203.0.113.7')).toBeInTheDocument()
   })
 

--- a/dashboard/src/system-status/SystemStatusPanel.tsx
+++ b/dashboard/src/system-status/SystemStatusPanel.tsx
@@ -335,6 +335,8 @@ export function SystemStatusPanel() {
                       <p>Suspicious: {formatCount(status.loadBalancer.traffic.suspiciousRequests)}</p>
                       <p>Blocked requests: {formatCount(status.loadBalancer.traffic.blockedRequests)}</p>
                       <p>Active blocked IPs: {formatCount(status.loadBalancer.traffic.activeBlockedIps)}</p>
+                      <p>WAF blocked: {formatCount(status.loadBalancer.traffic.wafBlockedRequests)}</p>
+                      <p>UA blocked: {formatCount(status.loadBalancer.traffic.uaBlockedRequests)}</p>
                     </div>
                     {status.loadBalancer.traffic.blockedIps && status.loadBalancer.traffic.blockedIps.length > 0 ? (
                       <ul className="mt-2 max-h-32 space-y-1.5 overflow-auto text-xs">


### PR DESCRIPTION
## Summary
- add a deployment-level Security panel to edit `waf_enabled`, IP deny/allow lists, and custom ModSecurity rules via `PATCH /api/deployments/{id}`
- surface global security posture from `/api/security-config` with WAF mode and read-only global allow/deny lists on the traffic page
- extend traffic/system status UI and API types to show `wafBlockedRequests` and `uaBlockedRequests`, with focused frontend tests

## Validation
- `bunx vitest run --environment happy-dom src/deployments/DeploymentSecurityPanel.test.tsx src/system-status/SystemStatusPanel.test.tsx`
- `bun run build`

Closes #151.