### PR TITLE
docs(website): add production-readiness guide and align service count

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -4,6 +4,7 @@ import DocsLayout from '@/pages/docs/DocsLayout'
 import GettingStarted from '@/pages/docs/GettingStarted'
 import DeploymentConfiguration from '@/pages/docs/DeploymentConfiguration'
 import StrictModeSetup from '@/pages/docs/StrictModeSetup'
+import ProductionReadiness from '@/pages/docs/ProductionReadiness'
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
           <Route path="getting-started" element={<GettingStarted />} />
           <Route path="deployment-configuration" element={<DeploymentConfiguration />} />
           <Route path="strict-mode-setup" element={<StrictModeSetup />} />
+          <Route path="production-readiness" element={<ProductionReadiness />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -119,6 +119,7 @@ Back on the Deployments table, wait for status to become `healthy`.
 ## Next steps
 
 - Learn all available deployment fields in [Deployment Configuration](/docs/deployment-configuration).
+- Review production caveats and runbooks in [Production Readiness](/docs/production-readiness).
 
 ## Upgrading
 

--- a/website/src/content/docs/production-readiness.md
+++ b/website/src/content/docs/production-readiness.md
@@ -1,0 +1,220 @@
+## Production Readiness
+
+This guide documents what Dirigent guarantees today, what is partial, and what is not yet built, so you can make a production trial decision quickly.
+
+## Reliability and failure behavior
+
+Dirigent runs as three systemd services with `Restart=on-failure`:
+
+- `dirigent-api`
+- `dirigent-orchestrator`
+- `dirigent-proxy`
+
+### Service crash and restart
+
+- If one Dirigent service exits unexpectedly, systemd restarts it automatically.
+- Restart backoff is `5` seconds.
+- Deployment state is persisted in `/var/lib/dirigent/deployments.json`, so desired state survives process restarts.
+
+### Host reboot behavior
+
+- All three services are enabled with systemd and start on boot.
+- On startup, the orchestrator reconnects to Docker and resumes reconciliation.
+
+### Reconciliation guarantees
+
+- The orchestrator reconciles desired state to actual Docker state every `15s` by default.
+- Proxy route table updates poll the shared state every `5s` by default.
+- If Docker is temporarily unavailable, heartbeat and retry logic continue; recovery happens automatically when Docker returns.
+
+## Backup and restore runbook
+
+Dirigent has two persistence layers:
+
+- control-plane state file: `/var/lib/dirigent/deployments.json`
+- app data in bind-mounted host paths you define in deployment volumes
+
+### Backup
+
+1. Create a backup directory:
+
+```bash
+sudo mkdir -p /var/backups/dirigent
+```
+
+2. Backup the deployment state file:
+
+```bash
+sudo cp /var/lib/dirigent/deployments.json /var/backups/dirigent/deployments.json.$(date +%F-%H%M%S)
+```
+
+3. Backup each persistent app data path (example):
+
+```bash
+sudo tar -czf /var/backups/dirigent/postgres-data.$(date +%F-%H%M%S).tar.gz /srv/postgres-data
+```
+
+4. Optional integrity check:
+
+```bash
+sudo ls -lh /var/backups/dirigent
+sudo tar -tzf /var/backups/dirigent/postgres-data.<timestamp>.tar.gz > /dev/null
+```
+
+### Restore
+
+1. Stop Dirigent services:
+
+```bash
+sudo systemctl stop dirigent-api dirigent-orchestrator dirigent-proxy
+```
+
+2. Restore `deployments.json`:
+
+```bash
+sudo cp /var/backups/dirigent/deployments.json.<timestamp> /var/lib/dirigent/deployments.json
+```
+
+3. Restore each app volume archive to its original host path.
+
+4. Start services:
+
+```bash
+sudo systemctl start dirigent-api dirigent-orchestrator dirigent-proxy
+```
+
+5. Verify recovery:
+
+```bash
+sudo systemctl status 'dirigent-*'
+journalctl -u dirigent-orchestrator -n 100
+```
+
+## Security model and hardening checklist
+
+### Security model
+
+- Dirigent is single-host by design and runs as root-managed systemd services.
+- API/dashboard default exposure is `:8080` unless dashboard domain exposure is configured.
+- Proxy enforces domain routing and optional Basic Auth for dashboard access.
+- Proxy hardening profiles (`standard` or `strict`) block common scanner and sensitive-path traffic.
+
+### Internet-facing hardening checklist
+
+1. Use `--profile strict --proxy-hardening-profile strict` for setup.
+2. Disable SSH password auth and root login (strict mode does this automatically).
+3. Keep only required inbound ports open (`80/443`, plus `22` for SSH management).
+4. Set `DIRIGENT_DASHBOARD_DOMAIN` and dashboard Basic Auth credentials.
+5. Keep OS packages and Dirigent version updated.
+6. Restrict who can read backup artifacts containing app data.
+
+For full host hardening details, see [Strict Mode Setup](/docs/strict-mode-setup).
+
+## HTTPS and TLS capability boundaries
+
+### What works today
+
+- Dashboard domain exposure supports automatic TLS via ACME when `DIRIGENT_DASHBOARD_DOMAIN` is configured.
+- HTTP requests are redirected to HTTPS for configured hosts.
+
+### What does not work today
+
+- App-domain TLS termination for arbitrary deployments is not generally available as a documented, supported workflow.
+- For production app HTTPS today, place an upstream edge (for example Cloudflare, Caddy, or Nginx) in front of Dirigent, or terminate TLS in your app container.
+
+## Feature claims matrix
+
+| Capability | Status | Notes |
+|---|---|---|
+| Web dashboard | Available | Deploy, edit, inspect state and health. |
+| Zero-downtime deploys | Available | Rolling replacement behavior in orchestrator. |
+| Automatic container reconciliation | Available | Reconcile loop default every `15s`. |
+| Integrated reverse proxy (HTTP routing) | Available | Domain-based routing on the built-in proxy. |
+| Dashboard HTTPS + Basic Auth | Available | Domain exposure via setup flow. |
+| App-domain HTTPS/TLS | Partial | Requires external edge or app-managed TLS. |
+| GitOps workflow | Partial | Existing support, but not yet full enterprise controls. |
+| RBAC / SSO / audit log | Planned | Not available in current release. |
+| Multi-node / HA control plane | Planned | Single-host architecture currently. |
+
+## Migration guides
+
+### From Docker Compose
+
+1. Pick one Compose service to migrate first.
+2. Copy image, env vars, ports, and volume paths into a Dirigent deployment.
+3. Keep host bind mount paths unchanged where possible.
+4. Deploy in Dirigent and verify health/logs.
+5. Cut traffic to the new endpoint.
+6. Repeat service by service.
+
+### From Portainer
+
+1. Export or inspect existing container settings in Portainer.
+2. Recreate each workload in Dirigent using the same image/tag and mounts.
+3. Recreate published ports or use domain routing via Dirigent proxy.
+4. Validate startup order and app connectivity.
+5. Decommission Portainer-managed copies after verification.
+
+## Production fit and non-fit
+
+| Scenario | Fit | Why |
+|---|---|---|
+| Solo developer or small team on one VPS | Good fit | Fast setup and simple operations model. |
+| Team needing basic dashboard + rolling deploys | Good fit | Good operational leverage without Kubernetes complexity. |
+| Strict compliance environments needing RBAC/SSO/audit | Not fit today | These controls are not available yet. |
+| Multi-region HA orchestration | Not fit today | Dirigent is single-host today. |
+
+## Upgrade and compatibility policy
+
+- Upgrades are in-place via `dirigent upgrade` or rerunning setup/install flow.
+- Back up `/var/lib/dirigent/deployments.json` and persistent volumes before upgrading.
+- Validate upgrade on a staging VPS before production.
+- Pin to a specific release when you need deterministic rollout.
+- Avoid skipping many releases at once; step through versions for lower risk.
+
+## Troubleshooting playbook
+
+### Dashboard unreachable
+
+```bash
+sudo systemctl status dirigent-api
+sudo journalctl -u dirigent-api -n 100
+```
+
+### Deployments stuck in failed or deploying
+
+```bash
+sudo systemctl status dirigent-orchestrator
+sudo journalctl -u dirigent-orchestrator -n 150
+docker ps -a
+```
+
+### Domain not routing correctly
+
+```bash
+sudo systemctl status dirigent-proxy
+sudo journalctl -u dirigent-proxy -n 150
+```
+
+### TLS certificate not issuing
+
+1. Confirm DNS `A` record points to your VPS.
+2. Confirm port `80` is reachable.
+3. Check proxy logs for ACME errors.
+
+## Performance envelope and day-2 checklist
+
+### Current envelope
+
+- Single VPS, single control plane, single local state file.
+- No published formal benchmark suite yet for max deployment counts or request throughput.
+- Conservative trial approach: start with non-critical workloads, observe resource use, then scale gradually.
+
+### Day-2 operations checklist
+
+1. Daily: check `systemctl status 'dirigent-*'` and recent service logs.
+2. Daily: review failed deployment events in dashboard.
+3. Weekly: verify backups for state file and app data volumes.
+4. Weekly: apply OS security updates and restart if required.
+5. Per release: upgrade in staging first, then production.
+6. Monthly: test one restore drill end to end.

--- a/website/src/pages/Landing.tsx
+++ b/website/src/pages/Landing.tsx
@@ -339,7 +339,7 @@ const features = [
     Icon: Terminal,
     title: 'One-command install',
     description:
-      'A single curl command sets up four systemd services and starts everything. No manual steps.',
+      'A single curl command sets up three systemd services and starts everything. No manual steps.',
   },
   {
     Icon: LayoutDashboard,

--- a/website/src/pages/docs/DocsLayout.tsx
+++ b/website/src/pages/docs/DocsLayout.tsx
@@ -4,6 +4,7 @@ import { Footer } from '@/components/Footer'
 import gettingStartedMarkdown from '@/content/docs/getting-started.md?raw'
 import deploymentConfigurationMarkdown from '@/content/docs/deployment-configuration.md?raw'
 import strictModeSetupMarkdown from '@/content/docs/strict-mode-setup.md?raw'
+import productionReadinessMarkdown from '@/content/docs/production-readiness.md?raw'
 
 function toSlug(text: string): string {
   return text.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
@@ -24,6 +25,11 @@ const docLinks = [
     markdown: deploymentConfigurationMarkdown,
   },
   { to: '/docs/strict-mode-setup', label: 'Strict Mode Setup', markdown: strictModeSetupMarkdown },
+  {
+    to: '/docs/production-readiness',
+    label: 'Production Readiness',
+    markdown: productionReadinessMarkdown,
+  },
 ]
 
 export default function DocsLayout() {

--- a/website/src/pages/docs/ProductionReadiness.tsx
+++ b/website/src/pages/docs/ProductionReadiness.tsx
@@ -1,0 +1,6 @@
+import DocsPage from '@/pages/docs/DocsPage'
+import productionReadinessMarkdown from '@/content/docs/production-readiness.md?raw'
+
+export default function ProductionReadiness() {
+  return <DocsPage markdown={productionReadinessMarkdown} />
+}

--- a/website/src/routes.test.tsx
+++ b/website/src/routes.test.tsx
@@ -5,6 +5,7 @@ import DocsLayout from '@/pages/docs/DocsLayout'
 import GettingStarted from '@/pages/docs/GettingStarted'
 import DeploymentConfiguration from '@/pages/docs/DeploymentConfiguration'
 import StrictModeSetup from '@/pages/docs/StrictModeSetup'
+import ProductionReadiness from '@/pages/docs/ProductionReadiness'
 
 function TestApp({ initialPath }: { initialPath: string }) {
   return (
@@ -16,6 +17,7 @@ function TestApp({ initialPath }: { initialPath: string }) {
           <Route path="getting-started" element={<GettingStarted />} />
           <Route path="deployment-configuration" element={<DeploymentConfiguration />} />
           <Route path="strict-mode-setup" element={<StrictModeSetup />} />
+          <Route path="production-readiness" element={<ProductionReadiness />} />
         </Route>
       </Routes>
     </MemoryRouter>
@@ -48,6 +50,13 @@ describe('Routes', () => {
     render(<TestApp initialPath="/docs/strict-mode-setup" />)
     expect(
       screen.getByRole('heading', { name: /strict mode setup/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the Production Readiness doc at /docs/production-readiness', () => {
+    render(<TestApp initialPath="/docs/production-readiness" />)
+    expect(
+      screen.getByRole('heading', { name: /production readiness/i }),
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary
- add a new `/docs/production-readiness` page with reliability guarantees, backup/restore runbook, security model and hardening checklist, TLS capability boundaries, feature-claims matrix, migration notes, fit/non-fit matrix, upgrade policy, troubleshooting, and day-2 checklist
- wire the new docs route into the website docs layout/router and add route coverage in tests
- fix website messaging inconsistency by updating landing copy from "four systemd services" to "three systemd services" and link the new guide from Getting Started

## Testing
- `bun test` (website) currently fails in repo due existing test environment/module alias issues (`document is not defined`, alias resolution)
- `bun run build` (website) currently fails in repo due existing TypeScript test typings setup (`describe`/`it`/`expect` not found)