### PR TITLE
feat: show container resource usage in deployment views

### DIFF
--- a/api/internal/api/container_stats_cache.go
+++ b/api/internal/api/container_stats_cache.go
@@ -1,0 +1,61 @@
+package api
+
+import "sync"
+
+type ContainerStats struct {
+	CPUPercent       float64 `json:"cpuPercent"`
+	MemoryUsedBytes  uint64  `json:"memoryUsedBytes"`
+	MemoryLimitBytes uint64  `json:"memoryLimitBytes"`
+	MemoryPercent    float64 `json:"memoryPercent"`
+}
+
+type ContainerStatsCache struct {
+	mu             sync.RWMutex
+	byDeploymentID map[string]ContainerStats
+}
+
+func NewContainerStatsCache() *ContainerStatsCache {
+	return &ContainerStatsCache{byDeploymentID: make(map[string]ContainerStats)}
+}
+
+func (c *ContainerStatsCache) ReplaceAll(stats map[string]ContainerStats) {
+	if c == nil {
+		return
+	}
+
+	next := make(map[string]ContainerStats, len(stats))
+	for deploymentID, stat := range stats {
+		next[deploymentID] = stat
+	}
+
+	c.mu.Lock()
+	c.byDeploymentID = next
+	c.mu.Unlock()
+}
+
+func (c *ContainerStatsCache) Get(deploymentID string) (ContainerStats, bool) {
+	if c == nil {
+		return ContainerStats{}, false
+	}
+
+	c.mu.RLock()
+	stat, ok := c.byDeploymentID[deploymentID]
+	c.mu.RUnlock()
+
+	return stat, ok
+}
+
+func (c *ContainerStatsCache) Snapshot() map[string]ContainerStats {
+	if c == nil {
+		return nil
+	}
+
+	c.mu.RLock()
+	out := make(map[string]ContainerStats, len(c.byDeploymentID))
+	for deploymentID, stat := range c.byDeploymentID {
+		out[deploymentID] = stat
+	}
+	c.mu.RUnlock()
+
+	return out
+}

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -89,21 +89,22 @@ type patchDeploymentRequest struct {
 
 // Handler holds the dependencies for the API layer.
 type Handler struct {
-	store        Store
-	events       EventBus
-	dockerLogs   DockerLogs
-	statusEvents *systemStatusBroker
-	accessLogDir string
-	statusSource SystemStatusProvider
-	heartbeats   OrchestratorHeartbeatIngestor
-	docker       DockerConnectivityIngestor
-	loadBalancer LoadBalancerHealthIngestor
-	proxyClient  *http.Client
-	proxyBaseURL string
-	cpu          CPUUtilizationIngestor
-	ram          RAMUtilizationIngestor
-	versions     VersionInfoProvider
-	upgrade      UpgradeRunner
+	store          Store
+	events         EventBus
+	dockerLogs     DockerLogs
+	statusEvents   *systemStatusBroker
+	accessLogDir   string
+	statusSource   SystemStatusProvider
+	heartbeats     OrchestratorHeartbeatIngestor
+	docker         DockerConnectivityIngestor
+	loadBalancer   LoadBalancerHealthIngestor
+	proxyClient    *http.Client
+	proxyBaseURL   string
+	cpu            CPUUtilizationIngestor
+	ram            RAMUtilizationIngestor
+	versions       VersionInfoProvider
+	upgrade        UpgradeRunner
+	containerStats *ContainerStatsCache
 }
 
 const defaultOrchestratorStaleAfter = 30 * time.Second
@@ -152,21 +153,22 @@ func NewWithDependencies(s Store, eb EventBus, dl DockerLogs, statusSource Syste
 	ramIngestor, _ := statusSource.(RAMUtilizationIngestor)
 
 	return &Handler{
-		store:        s,
-		events:       eb,
-		dockerLogs:   dl,
-		statusEvents: newSystemStatusBroker(),
-		accessLogDir: proxyAccessLogDirFromEnv(),
-		statusSource: statusSource,
-		heartbeats:   heartbeatIngestor,
-		docker:       dockerIngestor,
-		loadBalancer: loadBalancerIngestor,
-		proxyClient:  &http.Client{Timeout: 3 * time.Second},
-		proxyBaseURL: proxyInternalBaseURLFromEnv(),
-		cpu:          cpuIngestor,
-		ram:          ramIngestor,
-		versions:     versions,
-		upgrade:      upgrader,
+		store:          s,
+		events:         eb,
+		dockerLogs:     dl,
+		statusEvents:   newSystemStatusBroker(),
+		accessLogDir:   proxyAccessLogDirFromEnv(),
+		statusSource:   statusSource,
+		heartbeats:     heartbeatIngestor,
+		docker:         dockerIngestor,
+		loadBalancer:   loadBalancerIngestor,
+		proxyClient:    &http.Client{Timeout: 3 * time.Second},
+		proxyBaseURL:   proxyInternalBaseURLFromEnv(),
+		cpu:            cpuIngestor,
+		ram:            ramIngestor,
+		versions:       versions,
+		upgrade:        upgrader,
+		containerStats: NewContainerStatsCache(),
 	}
 }
 

--- a/api/internal/api/handler_get_deployment.go
+++ b/api/internal/api/handler_get_deployment.go
@@ -20,5 +20,13 @@ func (h *Handler) getDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, d)
+	response := deploymentResponse{Deployment: d}
+	if h.containerStats != nil {
+		if stats, ok := h.containerStats.Get(d.ID); ok {
+			statsCopy := stats
+			response.Stats = &statsCopy
+		}
+	}
+
+	writeJSON(w, http.StatusOK, response)
 }

--- a/api/internal/api/handler_list_deployments.go
+++ b/api/internal/api/handler_list_deployments.go
@@ -6,6 +6,11 @@ import (
 	"github.com/ercadev/dirigent/store"
 )
 
+type deploymentResponse struct {
+	store.Deployment
+	Stats *ContainerStats `json:"stats,omitempty"`
+}
+
 func (h *Handler) listDeployments(w http.ResponseWriter, _ *http.Request) {
 	deployments, err := h.store.List()
 	if err != nil {
@@ -15,5 +20,18 @@ func (h *Handler) listDeployments(w http.ResponseWriter, _ *http.Request) {
 	if deployments == nil {
 		deployments = []store.Deployment{}
 	}
-	writeJSON(w, http.StatusOK, deployments)
+
+	responses := make([]deploymentResponse, 0, len(deployments))
+	for _, deployment := range deployments {
+		response := deploymentResponse{Deployment: deployment}
+		if h.containerStats != nil {
+			if stats, ok := h.containerStats.Get(deployment.ID); ok {
+				statsCopy := stats
+				response.Stats = &statsCopy
+			}
+		}
+		responses = append(responses, response)
+	}
+
+	writeJSON(w, http.StatusOK, responses)
 }

--- a/api/internal/api/handler_record_orchestrator_heartbeat.go
+++ b/api/internal/api/handler_record_orchestrator_heartbeat.go
@@ -51,6 +51,12 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 				CheckedAt    *time.Time `json:"checkedAt"`
 			} `json:"ram"`
 		} `json:"host"`
+		ContainerStats *map[string]struct {
+			CPUPercent       *float64 `json:"cpuPercent"`
+			MemoryUsedBytes  *uint64  `json:"memoryUsedBytes"`
+			MemoryLimitBytes *uint64  `json:"memoryLimitBytes"`
+			MemoryPercent    *float64 `json:"memoryPercent"`
+		} `json:"containerStats"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
@@ -153,6 +159,42 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 				return
 			}
 		}
+	}
+
+	if body.ContainerStats != nil {
+		if h.containerStats == nil {
+			http.Error(w, "system status unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		statsByDeployment := make(map[string]ContainerStats, len(*body.ContainerStats))
+		for deploymentID, payload := range *body.ContainerStats {
+			stats := ContainerStats{}
+			if payload.CPUPercent != nil {
+				if *payload.CPUPercent < 0 {
+					http.Error(w, "invalid container stats", http.StatusBadRequest)
+					return
+				}
+				stats.CPUPercent = *payload.CPUPercent
+			}
+			if payload.MemoryUsedBytes != nil {
+				stats.MemoryUsedBytes = *payload.MemoryUsedBytes
+			}
+			if payload.MemoryLimitBytes != nil {
+				stats.MemoryLimitBytes = *payload.MemoryLimitBytes
+			}
+			if payload.MemoryPercent != nil {
+				if !isValidUsagePercent(*payload.MemoryPercent) {
+					http.Error(w, "invalid container stats", http.StatusBadRequest)
+					return
+				}
+				stats.MemoryPercent = *payload.MemoryPercent
+			}
+
+			statsByDeployment[deploymentID] = stats
+		}
+
+		h.containerStats.ReplaceAll(statsByDeployment)
 	}
 
 	if h.statusEvents != nil {

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -535,6 +535,57 @@ func TestRecordOrchestratorHeartbeat_UpdatesLoadBalancerTrafficTelemetry(t *test
 	}
 }
 
+func TestRecordOrchestratorHeartbeat_ReplacesContainerStatsCache(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Status: store.StatusHealthy}
+
+	srv := newTestServer(s)
+	defer srv.Close()
+
+	firstHeartbeat := `{"containerStats":{"d1":{"cpuPercent":22.5,"memoryUsedBytes":268435456,"memoryLimitBytes":536870912,"memoryPercent":50}}}`
+	firstReq, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString(firstHeartbeat))
+	if err != nil {
+		t.Fatalf("build first heartbeat request: %v", err)
+	}
+	firstReq.Header.Set("Content-Type", "application/json")
+
+	firstResp, err := http.DefaultClient.Do(firstReq)
+	if err != nil {
+		t.Fatalf("POST first heartbeat: %v", err)
+	}
+	firstResp.Body.Close()
+
+	secondHeartbeat := `{"containerStats":{}}`
+	secondReq, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString(secondHeartbeat))
+	if err != nil {
+		t.Fatalf("build second heartbeat request: %v", err)
+	}
+	secondReq.Header.Set("Content-Type", "application/json")
+
+	secondResp, err := http.DefaultClient.Do(secondReq)
+	if err != nil {
+		t.Fatalf("POST second heartbeat: %v", err)
+	}
+	secondResp.Body.Close()
+
+	getResp, err := http.Get(srv.URL + "/api/deployments/d1")
+	if err != nil {
+		t.Fatalf("GET /api/deployments/d1: %v", err)
+	}
+	defer getResp.Body.Close()
+
+	var body struct {
+		Stats any `json:"stats"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.Stats != nil {
+		t.Fatalf("want stats omitted after cache replace, got %+v", body.Stats)
+	}
+}
+
 func TestSystemStatusEvents_StreamSendsHeartbeatUpdates(t *testing.T) {
 	srv := newTestServer(newMemStore())
 	defer srv.Close()
@@ -841,6 +892,56 @@ func TestListDeployments_WithItems(t *testing.T) {
 	}
 }
 
+func TestListDeployments_IncludesContainerStatsWhenCached(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Status: store.StatusHealthy}
+
+	srv := newTestServer(s)
+	defer srv.Close()
+
+	heartbeat := `{"containerStats":{"d1":{"cpuPercent":22.5,"memoryUsedBytes":268435456,"memoryLimitBytes":536870912,"memoryPercent":50}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString(heartbeat))
+	if err != nil {
+		t.Fatalf("build heartbeat request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST heartbeat: %v", err)
+	}
+	resp.Body.Close()
+
+	listResp, err := http.Get(srv.URL + "/api/deployments")
+	if err != nil {
+		t.Fatalf("GET /api/deployments: %v", err)
+	}
+	defer listResp.Body.Close()
+
+	var body []struct {
+		ID    string `json:"id"`
+		Stats *struct {
+			CPUPercent       float64 `json:"cpuPercent"`
+			MemoryUsedBytes  uint64  `json:"memoryUsedBytes"`
+			MemoryLimitBytes uint64  `json:"memoryLimitBytes"`
+			MemoryPercent    float64 `json:"memoryPercent"`
+		} `json:"stats"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(body) != 1 {
+		t.Fatalf("want 1 deployment, got %d", len(body))
+	}
+	if body[0].Stats == nil {
+		t.Fatal("want stats payload")
+	}
+	if body[0].Stats.MemoryPercent != 50 {
+		t.Fatalf("want memory percent 50, got %v", body[0].Stats.MemoryPercent)
+	}
+}
+
 func TestGetDeployment_Found(t *testing.T) {
 	s := newMemStore()
 	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Status: store.StatusHealthy}
@@ -867,6 +968,50 @@ func TestGetDeployment_Found(t *testing.T) {
 	}
 	if d.Status != store.StatusHealthy {
 		t.Errorf("want status healthy, got %s", d.Status)
+	}
+}
+
+func TestGetDeployment_IncludesContainerStatsWhenCached(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Status: store.StatusHealthy}
+
+	srv := newTestServer(s)
+	defer srv.Close()
+
+	heartbeat := `{"containerStats":{"d1":{"cpuPercent":11.1,"memoryUsedBytes":134217728,"memoryLimitBytes":268435456,"memoryPercent":50}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString(heartbeat))
+	if err != nil {
+		t.Fatalf("build heartbeat request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST heartbeat: %v", err)
+	}
+	resp.Body.Close()
+
+	getResp, err := http.Get(srv.URL + "/api/deployments/d1")
+	if err != nil {
+		t.Fatalf("GET /api/deployments/d1: %v", err)
+	}
+	defer getResp.Body.Close()
+
+	var body struct {
+		ID    string `json:"id"`
+		Stats *struct {
+			CPUPercent float64 `json:"cpuPercent"`
+		} `json:"stats"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.ID != "d1" {
+		t.Fatalf("want id d1, got %s", body.ID)
+	}
+	if body.Stats == nil || body.Stats.CPUPercent != 11.1 {
+		t.Fatalf("want cpu stats 11.1, got %+v", body.Stats)
 	}
 }
 

--- a/dashboard/src/deployments/DeploymentRow.tsx
+++ b/dashboard/src/deployments/DeploymentRow.tsx
@@ -17,6 +17,7 @@ export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: P
   const hasDomain = Boolean(d.domain)
   const hasPorts = d.ports.length > 0
   const hasVolumes = d.volumes.length > 0
+  const stats = d.status === 'healthy' ? d.stats : undefined
 
   return (
     <article className="rounded-xl border border-border/60 bg-card px-4 py-4 transition-colors hover:bg-muted/20">
@@ -65,6 +66,16 @@ export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: P
             <Badge variant="secondary" className="px-2 py-0.5 text-[11px]">
               {Object.keys(d.envs).length} env var{Object.keys(d.envs).length === 1 ? '' : 's'}
             </Badge>
+            {stats && (
+              <>
+                <Badge variant="outline" className="px-2 py-0.5 font-mono text-[11px]">
+                  CPU {formatPercent(stats.cpuPercent)}
+                </Badge>
+                <Badge variant="outline" className="px-2 py-0.5 font-mono text-[11px]">
+                  Mem {formatBytes(stats.memoryUsedBytes)} / {formatBytes(stats.memoryLimitBytes)}
+                </Badge>
+              </>
+            )}
           </div>
         </div>
 
@@ -100,4 +111,31 @@ export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: P
       </div>
     </article>
   )
+}
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '0.0%'
+  }
+  return `${value.toFixed(1)}%`
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  if (value >= 100 || unitIndex === 0) {
+    return `${Math.round(value)} ${units[unitIndex]}`
+  }
+
+  return `${value.toFixed(1)} ${units[unitIndex]}`
 }

--- a/dashboard/src/deployments/useDeploymentList.ts
+++ b/dashboard/src/deployments/useDeploymentList.ts
@@ -7,6 +7,7 @@ export function useDeploymentList() {
   const { data: deployments, isLoading, isError, refetch } = useQuery({
     queryKey: ['deployments'],
     queryFn: getDeployments,
+    refetchInterval: 30_000,
   })
 
   const deleteMutation = useMutation({

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -28,6 +28,14 @@ export type Deployment = {
   security?: SecurityConfig
   status: DeploymentStatus
   error?: string
+  stats?: ContainerStats
+}
+
+export type ContainerStats = {
+  cpuPercent: number
+  memoryUsedBytes: number
+  memoryLimitBytes: number
+  memoryPercent: number
 }
 
 export type StatusEvent = {

--- a/dashboard/src/pages/DeploymentDetailPage.tsx
+++ b/dashboard/src/pages/DeploymentDetailPage.tsx
@@ -15,6 +15,7 @@ export function DeploymentDetailPage() {
   const { data: deployments, isLoading, isError } = useQuery({
     queryKey: ['deployments'],
     queryFn: getDeployments,
+    refetchInterval: 30_000,
   })
   const [debugOpen, setDebugOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
@@ -58,6 +59,7 @@ export function DeploymentDetailPage() {
   }
 
   const envEntries = Object.entries(deployment.envs)
+  const stats = deployment.status === 'healthy' ? deployment.stats : undefined
 
   return (
     <div className="space-y-4">
@@ -118,6 +120,41 @@ export function DeploymentDetailPage() {
           <div className="space-y-0.5">
             <p className="text-sm font-medium">Container exited with error</p>
             <p className="font-mono text-xs opacity-80">{deployment.error}</p>
+          </div>
+        </div>
+      )}
+
+      {stats && (
+        <div className="rounded-xl border border-border/60 bg-card p-4">
+          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/60">Resources</p>
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            <div className="rounded-md border border-border/60 bg-background/70 p-3">
+              <div className="flex items-end justify-between gap-2">
+                <p className="text-xs text-muted-foreground">CPU</p>
+                <p className="font-mono text-sm text-foreground">{formatPercent(stats.cpuPercent)}</p>
+              </div>
+              <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted/60">
+                <div
+                  className="h-full rounded-full bg-emerald-500 transition-[width] duration-300"
+                  style={{ width: `${Math.min(stats.cpuPercent, 100)}%` }}
+                />
+              </div>
+            </div>
+            <div className="rounded-md border border-border/60 bg-background/70 p-3">
+              <div className="flex items-end justify-between gap-2">
+                <p className="text-xs text-muted-foreground">Memory</p>
+                <p className="font-mono text-sm text-foreground">
+                  {formatBytes(stats.memoryUsedBytes)} / {formatBytes(stats.memoryLimitBytes)}
+                </p>
+              </div>
+              <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted/60">
+                <div
+                  className="h-full rounded-full bg-sky-500 transition-[width] duration-300"
+                  style={{ width: `${Math.min(stats.memoryPercent, 100)}%` }}
+                />
+              </div>
+              <p className="mt-2 font-mono text-xs text-muted-foreground">{formatPercent(stats.memoryPercent)}</p>
+            </div>
           </div>
         </div>
       )}
@@ -238,4 +275,31 @@ export function DeploymentDetailPage() {
       </div>
     </div>
   )
+}
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '0.0%'
+  }
+  return `${value.toFixed(1)}%`
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  if (value >= 100 || unitIndex === 0) {
+    return `${Math.round(value)} ${units[unitIndex]}`
+  }
+
+  return `${value.toFixed(1)} ${units[unitIndex]}`
 }

--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -87,6 +87,7 @@ func main() {
 		case <-ticker.C:
 			now := time.Now().UTC()
 			dockerReachable := true
+			containerStats := map[string]apiclient.HeartbeatContainerStats{}
 			loadBalancerResponding := false
 			var loadBalancerTraffic *apiclient.HeartbeatLoadBalancerTraffic
 			storeAccessible := true
@@ -98,6 +99,22 @@ func main() {
 			if err := d.Ping(pingCtx); err != nil {
 				dockerReachable = false
 				log.Printf("orchestrator: docker unreachable: %v", err)
+			} else {
+				statsCtx, statsCancel := context.WithTimeout(ctx, 5*time.Second)
+				statsByDeployment, statsErr := d.CollectStats(statsCtx)
+				statsCancel()
+				if statsErr != nil {
+					log.Printf("orchestrator: collect container stats: %v", statsErr)
+				} else {
+					for deploymentID, stats := range statsByDeployment {
+						containerStats[deploymentID] = apiclient.HeartbeatContainerStats{
+							CPUPercent:       stats.CPUPercent,
+							MemoryUsedBytes:  stats.MemoryUsedBytes,
+							MemoryLimitBytes: stats.MemoryLimitBytes,
+							MemoryPercent:    stats.MemoryPercent,
+						}
+					}
+				}
 			}
 			pingCancel()
 
@@ -131,7 +148,7 @@ func main() {
 			}
 
 			// Heartbeat is always sent, regardless of Docker state.
-			if err := notifier.NotifyHeartbeat(dockerReachable, loadBalancerResponding, loadBalancerTraffic, storeAccessible, now, cpuUsagePercent, ramUsagePercent); err != nil {
+			if err := notifier.NotifyHeartbeat(dockerReachable, loadBalancerResponding, loadBalancerTraffic, storeAccessible, now, cpuUsagePercent, ramUsagePercent, containerStats); err != nil {
 				log.Printf("orchestrator: notify heartbeat: %v", err)
 			}
 

--- a/orchestrator/internal/apiclient/client.go
+++ b/orchestrator/internal/apiclient/client.go
@@ -17,11 +17,12 @@ type Client struct {
 }
 
 type heartbeatRequest struct {
-	At           time.Time                  `json:"at"`
-	Orchestrator heartbeatOrchestratorState `json:"orchestrator"`
-	Docker       heartbeatDockerState       `json:"docker"`
-	LoadBalancer heartbeatLoadBalancerState `json:"loadBalancer"`
-	Host         *heartbeatHostState        `json:"host,omitempty"`
+	At             time.Time                          `json:"at"`
+	Orchestrator   heartbeatOrchestratorState         `json:"orchestrator"`
+	Docker         heartbeatDockerState               `json:"docker"`
+	LoadBalancer   heartbeatLoadBalancerState         `json:"loadBalancer"`
+	Host           *heartbeatHostState                `json:"host,omitempty"`
+	ContainerStats map[string]HeartbeatContainerStats `json:"containerStats"`
 }
 
 type heartbeatOrchestratorState struct {
@@ -62,6 +63,13 @@ type heartbeatHostState struct {
 type heartbeatHostMetric struct {
 	UsagePercent float64   `json:"usagePercent"`
 	CheckedAt    time.Time `json:"checkedAt"`
+}
+
+type HeartbeatContainerStats struct {
+	CPUPercent       float64 `json:"cpuPercent"`
+	MemoryUsedBytes  uint64  `json:"memoryUsedBytes"`
+	MemoryLimitBytes uint64  `json:"memoryLimitBytes"`
+	MemoryPercent    float64 `json:"memoryPercent"`
 }
 
 // New creates a Client that targets the given API base URL (e.g. "http://localhost:8080").
@@ -105,7 +113,7 @@ func (c *Client) NotifyStatus(id string, status store.Status, errorMessage strin
 
 // NotifyHeartbeat calls POST /api/system-status/orchestrator-heartbeat so the
 // API can update orchestrator liveness, Docker connectivity, and host metrics.
-func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bool, loadBalancerTraffic *HeartbeatLoadBalancerTraffic, storeAccessible bool, checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64) error {
+func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bool, loadBalancerTraffic *HeartbeatLoadBalancerTraffic, storeAccessible bool, checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64, containerStats map[string]HeartbeatContainerStats) error {
 	if checkedAt.IsZero() {
 		checkedAt = time.Now().UTC()
 	} else {
@@ -128,7 +136,8 @@ func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bo
 			CheckedAt:  checkedAt,
 			Traffic:    cloneHeartbeatLoadBalancerTraffic(loadBalancerTraffic),
 		},
-		Host: host,
+		Host:           host,
+		ContainerStats: cloneHeartbeatContainerStats(containerStats),
 	})
 	if err != nil {
 		return fmt.Errorf("apiclient: marshal heartbeat body: %w", err)
@@ -151,6 +160,19 @@ func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bo
 	}
 
 	return nil
+}
+
+func cloneHeartbeatContainerStats(in map[string]HeartbeatContainerStats) map[string]HeartbeatContainerStats {
+	if len(in) == 0 {
+		return map[string]HeartbeatContainerStats{}
+	}
+
+	out := make(map[string]HeartbeatContainerStats, len(in))
+	for deploymentID, stats := range in {
+		out[deploymentID] = stats
+	}
+
+	return out
 }
 
 func cloneHeartbeatLoadBalancerTraffic(in *HeartbeatLoadBalancerTraffic) *HeartbeatLoadBalancerTraffic {

--- a/orchestrator/internal/apiclient/client_test.go
+++ b/orchestrator/internal/apiclient/client_test.go
@@ -21,6 +21,14 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 		ActiveBlockedIPs:   1,
 		BlockedIPs:         []HeartbeatLoadBalancerBlockedIPState{{IP: "203.0.113.7", BlockedUntil: &checkedAt}},
 	}
+	containerStats := map[string]HeartbeatContainerStats{
+		"d1": {
+			CPUPercent:       21.4,
+			MemoryUsedBytes:  536870912,
+			MemoryLimitBytes: 1073741824,
+			MemoryPercent:    50,
+		},
+	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -63,6 +71,12 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 					CheckedAt    time.Time `json:"checkedAt"`
 				} `json:"ram"`
 			} `json:"host"`
+			ContainerStats map[string]struct {
+				CPUPercent       float64 `json:"cpuPercent"`
+				MemoryUsedBytes  uint64  `json:"memoryUsedBytes"`
+				MemoryLimitBytes uint64  `json:"memoryLimitBytes"`
+				MemoryPercent    float64 `json:"memoryPercent"`
+			} `json:"containerStats"`
 		}
 
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -110,13 +124,19 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 		if !body.Host.RAM.CheckedAt.Equal(checkedAt) {
 			t.Fatalf("want ram checkedAt %s, got %s", checkedAt, body.Host.RAM.CheckedAt)
 		}
+		if len(body.ContainerStats) != 1 {
+			t.Fatalf("want 1 container stats entry, got %d", len(body.ContainerStats))
+		}
+		if body.ContainerStats["d1"].MemoryPercent != 50 {
+			t.Fatalf("want memory percent 50, got %v", body.ContainerStats["d1"].MemoryPercent)
+		}
 
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(false, false, traffic, false, checkedAt, &cpu, &ram); err != nil {
+	if err := client.NotifyHeartbeat(false, false, traffic, false, checkedAt, &cpu, &ram, containerStats); err != nil {
 		t.Fatalf("NotifyHeartbeat: %v", err)
 	}
 }
@@ -144,7 +164,7 @@ func TestClient_NotifyHeartbeat_WithoutHostMetrics(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(false, true, nil, true, checkedAt, nil, nil); err != nil {
+	if err := client.NotifyHeartbeat(false, true, nil, true, checkedAt, nil, nil, nil); err != nil {
 		t.Fatalf("NotifyHeartbeat: %v", err)
 	}
 }
@@ -156,7 +176,7 @@ func TestClient_NotifyHeartbeat_UnexpectedResponse(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(true, true, nil, true, time.Time{}, nil, nil); err == nil {
+	if err := client.NotifyHeartbeat(true, true, nil, true, time.Time{}, nil, nil, nil); err == nil {
 		t.Fatal("want error for non-204 heartbeat response")
 	}
 }

--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -54,10 +54,19 @@ type Client interface {
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
 	ContainerList(ctx context.Context, options container.ListOptions) ([]dockertypes.Container, error)
+	ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error)
 	ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error
 	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
 	ContainerRename(ctx context.Context, containerID string, newName string) error
 	ContainerInspect(ctx context.Context, containerID string) (dockertypes.ContainerJSON, error)
+}
+
+// ContainerStats captures point-in-time runtime usage for a running container.
+type ContainerStats struct {
+	CPUPercent       float64
+	MemoryUsedBytes  uint64
+	MemoryLimitBytes uint64
+	MemoryPercent    float64
 }
 
 // Docker manages container lifecycle for Dirigent deployments.
@@ -181,6 +190,49 @@ func (d *Docker) ListManagedContainers(ctx context.Context) ([]ManagedContainer,
 	}
 
 	return result, nil
+}
+
+// CollectStats returns runtime CPU and memory usage for each running managed
+// container keyed by deployment ID.
+func (d *Docker) CollectStats(ctx context.Context) (map[string]ContainerStats, error) {
+	f := filters.NewArgs(
+		filters.Arg("label", "dirigent.managed=true"),
+		filters.Arg("status", "running"),
+	)
+
+	containers, err := d.client.ContainerList(ctx, container.ListOptions{All: false, Filters: f})
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		}
+		return nil, fmt.Errorf("docker: list running containers: %w", err)
+	}
+
+	statsByDeployment := make(map[string]ContainerStats, len(containers))
+	for _, c := range containers {
+		deploymentID := strings.TrimSpace(c.Labels["dirigent.id"])
+		if deploymentID == "" {
+			continue
+		}
+
+		reader, err := d.client.ContainerStats(ctx, c.ID, false)
+		if err != nil {
+			if dockerclient.IsErrConnectionFailed(err) {
+				return nil, fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+			}
+			return nil, fmt.Errorf("docker: stats for container %s: %w", c.ID, err)
+		}
+
+		stat, decodeErr := decodeContainerStats(reader.Body)
+		_ = reader.Body.Close()
+		if decodeErr != nil {
+			return nil, fmt.Errorf("docker: decode stats for container %s: %w", c.ID, decodeErr)
+		}
+
+		statsByDeployment[deploymentID] = stat
+	}
+
+	return statsByDeployment, nil
 }
 
 // StopAndRemove stops and removes the container with the given ID.
@@ -548,4 +600,89 @@ func normalizeDomain(domain string) string {
 	domain = strings.TrimSpace(domain)
 	domain = strings.TrimSuffix(domain, ".")
 	return strings.ToLower(domain)
+}
+
+func decodeContainerStats(body io.Reader) (ContainerStats, error) {
+	var payload struct {
+		CPUStats struct {
+			CPUUsage struct {
+				TotalUsage uint64 `json:"total_usage"`
+			} `json:"cpu_usage"`
+			SystemUsage uint64 `json:"system_cpu_usage"`
+			OnlineCPUs  uint32 `json:"online_cpus"`
+		} `json:"cpu_stats"`
+		PreCPUStats struct {
+			CPUUsage struct {
+				TotalUsage uint64 `json:"total_usage"`
+			} `json:"cpu_usage"`
+			SystemUsage uint64 `json:"system_cpu_usage"`
+		} `json:"precpu_stats"`
+		MemoryStats struct {
+			Usage uint64            `json:"usage"`
+			Limit uint64            `json:"limit"`
+			Stats map[string]uint64 `json:"stats"`
+		} `json:"memory_stats"`
+	}
+
+	if err := json.NewDecoder(body).Decode(&payload); err != nil {
+		return ContainerStats{}, fmt.Errorf("decode body: %w", err)
+	}
+
+	return ContainerStats{
+		CPUPercent:       calculateCPUPercent(payload.CPUStats, payload.PreCPUStats),
+		MemoryUsedBytes:  calculateMemoryUsedBytes(payload.MemoryStats.Usage, payload.MemoryStats.Stats),
+		MemoryLimitBytes: payload.MemoryStats.Limit,
+		MemoryPercent:    calculateMemoryPercent(payload.MemoryStats.Usage, payload.MemoryStats.Limit, payload.MemoryStats.Stats),
+	}, nil
+}
+
+func calculateCPUPercent(current struct {
+	CPUUsage struct {
+		TotalUsage uint64 `json:"total_usage"`
+	} `json:"cpu_usage"`
+	SystemUsage uint64 `json:"system_cpu_usage"`
+	OnlineCPUs  uint32 `json:"online_cpus"`
+}, previous struct {
+	CPUUsage struct {
+		TotalUsage uint64 `json:"total_usage"`
+	} `json:"cpu_usage"`
+	SystemUsage uint64 `json:"system_cpu_usage"`
+}) float64 {
+	cpuDelta := int64(current.CPUUsage.TotalUsage) - int64(previous.CPUUsage.TotalUsage)
+	systemDelta := int64(current.SystemUsage) - int64(previous.SystemUsage)
+	if cpuDelta <= 0 || systemDelta <= 0 {
+		return 0
+	}
+
+	onlineCPUs := current.OnlineCPUs
+	if onlineCPUs == 0 {
+		onlineCPUs = 1
+	}
+
+	return (float64(cpuDelta) / float64(systemDelta)) * float64(onlineCPUs) * 100
+}
+
+func calculateMemoryUsedBytes(usage uint64, stats map[string]uint64) uint64 {
+	if usage == 0 {
+		return 0
+	}
+
+	cache := stats["total_inactive_file"]
+	if cache == 0 {
+		cache = stats["inactive_file"]
+	}
+	if usage > cache {
+		return usage - cache
+	}
+
+	return usage
+}
+
+func calculateMemoryPercent(usage uint64, limit uint64, stats map[string]uint64) float64 {
+	if limit == 0 {
+		return 0
+	}
+
+	used := calculateMemoryUsedBytes(usage, stats)
+	return (float64(used) / float64(limit)) * 100
 }

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -2,6 +2,7 @@ package docker_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -33,6 +34,8 @@ type mockClient struct {
 	startErr         error
 	listContainers   []dockertypes.Container
 	listErr          error
+	statsByContainer map[string]container.StatsResponseReader
+	statsErr         error
 	stopErr          error
 	removeErr        error
 	renameErr        error
@@ -72,6 +75,20 @@ func (m *mockClient) ContainerStart(_ context.Context, _ string, _ container.Sta
 
 func (m *mockClient) ContainerList(_ context.Context, _ container.ListOptions) ([]dockertypes.Container, error) {
 	return m.listContainers, m.listErr
+}
+
+func (m *mockClient) ContainerStats(_ context.Context, containerID string, _ bool) (container.StatsResponseReader, error) {
+	if m.statsErr != nil {
+		return container.StatsResponseReader{}, m.statsErr
+	}
+	if m.statsByContainer == nil {
+		return container.StatsResponseReader{}, errors.New("missing stats")
+	}
+	stats, ok := m.statsByContainer[containerID]
+	if !ok {
+		return container.StatsResponseReader{}, errors.New("missing container stats")
+	}
+	return stats, nil
 }
 
 func (m *mockClient) ContainerStop(_ context.Context, id string, _ container.StopOptions) error {
@@ -238,6 +255,70 @@ func TestDocker_ListManagedContainers_OOMKilled_PopulatesExitDetails(t *testing.
 	}
 	if c.ExitDetails.ExitCode != 137 {
 		t.Errorf("want exit code 137, got %d", c.ExitDetails.ExitCode)
+	}
+}
+
+func TestDocker_CollectStats_CollectsRunningManagedContainers(t *testing.T) {
+	statsForC1 := newStatsReader(t, map[string]any{
+		"cpu_stats": map[string]any{
+			"cpu_usage":        map[string]any{"total_usage": uint64(4_500_000_000)},
+			"system_cpu_usage": uint64(10_000_000_000),
+			"online_cpus":      uint32(2),
+		},
+		"precpu_stats": map[string]any{
+			"cpu_usage":        map[string]any{"total_usage": uint64(4_000_000_000)},
+			"system_cpu_usage": uint64(9_000_000_000),
+		},
+		"memory_stats": map[string]any{
+			"usage": uint64(600 * 1024 * 1024),
+			"limit": uint64(1024 * 1024 * 1024),
+			"stats": map[string]any{"inactive_file": uint64(100 * 1024 * 1024)},
+		},
+	})
+
+	mock := &mockClient{
+		listContainers: []dockertypes.Container{
+			{ID: "c1", Labels: map[string]string{"dirigent.id": "d1"}, State: "running"},
+		},
+		statsByContainer: map[string]container.StatsResponseReader{"c1": statsForC1},
+	}
+
+	d := docker.New(mock)
+	stats, err := d.CollectStats(context.Background())
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+
+	collected, ok := stats["d1"]
+	if !ok {
+		t.Fatal("want stats for deployment d1")
+	}
+	if collected.CPUPercent <= 0 {
+		t.Fatalf("want positive cpu percent, got %v", collected.CPUPercent)
+	}
+	if collected.MemoryUsedBytes != uint64(500*1024*1024) {
+		t.Fatalf("want memory used 524288000, got %d", collected.MemoryUsedBytes)
+	}
+	if collected.MemoryLimitBytes != uint64(1024*1024*1024) {
+		t.Fatalf("want memory limit 1073741824, got %d", collected.MemoryLimitBytes)
+	}
+	if collected.MemoryPercent <= 0 {
+		t.Fatalf("want positive memory percent, got %v", collected.MemoryPercent)
+	}
+}
+
+func TestDocker_CollectStats_ReturnsErrorOnStatsFailure(t *testing.T) {
+	mock := &mockClient{
+		listContainers: []dockertypes.Container{
+			{ID: "c1", Labels: map[string]string{"dirigent.id": "d1"}, State: "running"},
+		},
+		statsErr: errors.New("stats unavailable"),
+	}
+
+	d := docker.New(mock)
+	_, err := d.CollectStats(context.Background())
+	if err == nil {
+		t.Fatal("want error, got nil")
 	}
 }
 
@@ -537,6 +618,7 @@ func TestDocker_Start_PinnedImageNotLocal_Pulls(t *testing.T) {
 // Ensure the mock satisfies the docker.Client interface at compile time.
 var _ interface {
 	ContainerList(context.Context, container.ListOptions) ([]dockertypes.Container, error)
+	ContainerStats(context.Context, string, bool) (container.StatsResponseReader, error)
 	ImageList(context.Context, image.ListOptions) ([]image.Summary, error)
 	Ping(context.Context) (dockertypes.Ping, error)
 } = (*mockClient)(nil)
@@ -566,4 +648,15 @@ func inspectWithPort(containerPort, hostPort string) dockertypes.ContainerJSON {
 			},
 		},
 	}
+}
+
+func newStatsReader(t *testing.T, payload map[string]any) container.StatsResponseReader {
+	t.Helper()
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal stats payload: %v", err)
+	}
+
+	return container.StatsResponseReader{Body: io.NopCloser(strings.NewReader(string(body)))}
 }


### PR DESCRIPTION
## Summary
- collect per-running-container CPU and memory stats in the orchestrator, then include them in orchestrator heartbeat payloads
- add an in-memory container stats cache in the API and merge optional `stats` into `GET /api/deployments` and `GET /api/deployments/{id}` responses
- surface CPU and memory usage in the dashboard deployment list and detail page, with automatic React Query refresh every 30s

## Testing
- go test ./... (orchestrator)
- go test ./... (api)
- bun run build (dashboard)