### PR TITLE
feat(deployments): add restart flow and no-op edit protection

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -201,6 +201,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/deployments/{id}/logs", h.deploymentLogs)
 	mux.HandleFunc("GET /api/deployments/{id}", h.getDeployment)
 	mux.HandleFunc("PUT /api/deployments/{id}", h.updateDeployment)
+	mux.HandleFunc("POST /api/deployments/{id}/restart", h.restartDeployment)
 	mux.HandleFunc("DELETE /api/deployments/{id}", h.deleteDeployment)
 	mux.HandleFunc("PATCH /api/deployments/{id}/status", h.updateDeploymentStatus)
 	mux.HandleFunc("PATCH /api/deployments/{id}", h.patchDeployment)
@@ -492,4 +493,41 @@ func equalBasicAuthConfig(existing *store.BasicAuthConfig, request *basicAuthReq
 		}
 	}
 	return true
+}
+
+func equalStoredBasicAuthConfig(a, b *store.BasicAuthConfig) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if len(a.Users) != len(b.Users) {
+		return false
+	}
+	for i := range a.Users {
+		if a.Users[i].Username != b.Users[i].Username || a.Users[i].Password != b.Users[i].Password {
+			return false
+		}
+	}
+	return true
+}
+
+func equalSecurityConfig(existing, request *store.SecurityConfig) bool {
+	if existing == nil || request == nil {
+		return existing == request
+	}
+
+	return existing.WAFEnabled == request.WAFEnabled &&
+		slices.Equal(existing.IPDenylist, request.IPDenylist) &&
+		slices.Equal(existing.IPAllowlist, request.IPAllowlist) &&
+		slices.Equal(existing.CustomRules, request.CustomRules)
+}
+
+func updateRequestMatchesExisting(existing store.Deployment, body deploymentRequest, basicAuth *store.BasicAuthConfig) bool {
+	return existing.Name == body.Name &&
+		existing.Image == body.Image &&
+		equalStringMap(existing.Envs, body.Envs) &&
+		slices.Equal(existing.Ports, body.Ports) &&
+		slices.Equal(existing.Volumes, body.Volumes) &&
+		existing.Domain == body.Domain &&
+		equalStoredBasicAuthConfig(existing.BasicAuth, basicAuth) &&
+		equalSecurityConfig(existing.Security, body.Security)
 }

--- a/api/internal/api/handler_restart_deployment.go
+++ b/api/internal/api/handler_restart_deployment.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/ercadev/dirigent/internal/events"
+	"github.com/ercadev/dirigent/store"
+)
+
+func (h *Handler) restartDeployment(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if _, err := h.store.Get(id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(w, "deployment not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to get deployment", http.StatusInternalServerError)
+		return
+	}
+
+	updated, err := h.store.Patch(id, store.Deployment{Status: store.StatusDeploying})
+	if err != nil {
+		http.Error(w, "failed to restart deployment", http.StatusInternalServerError)
+		return
+	}
+
+	h.events.Publish(events.StatusEvent{
+		DeploymentID: id,
+		Status:       string(store.StatusDeploying),
+	})
+
+	writeJSON(w, http.StatusAccepted, updated)
+}

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -1866,6 +1866,52 @@ func TestUpdateDeployment(t *testing.T) {
 	}
 }
 
+func TestUpdateDeployment_NoChanges_SkipsStoreUpdate(t *testing.T) {
+	base := newMemStore()
+	base.deployments["d1"] = store.Deployment{
+		ID:      "d1",
+		Name:    "web",
+		Image:   "nginx:1",
+		Envs:    map[string]string{"PORT": "80"},
+		Ports:   []string{"32768:80"},
+		Volumes: []string{"/data:/data"},
+		Domain:  "app.example.com",
+		Status:  store.StatusHealthy,
+	}
+
+	srv := newTestServer(&failUpdateStore{memStore: base})
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"name":    "web",
+		"image":   "nginx:1",
+		"envs":    map[string]string{"PORT": "80"},
+		"ports":   []string{"80"},
+		"volumes": []string{"/data:/data"},
+		"domain":  "app.example.com",
+	})
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/deployments/d1: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var updated store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if updated.Status != store.StatusHealthy {
+		t.Errorf("want status healthy, got %s", updated.Status)
+	}
+}
+
 func TestUpdateDeployment_NotFound(t *testing.T) {
 	srv := newTestServer(newMemStore())
 	defer srv.Close()
@@ -2111,6 +2157,89 @@ func TestUpdateDeployment_DashboardDomainConflict(t *testing.T) {
 
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("want 409, got %d", resp.StatusCode)
+	}
+}
+
+func TestRestartDeployment(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{
+		ID:     "d1",
+		Name:   "web",
+		Image:  "nginx:1",
+		Status: store.StatusHealthy,
+	}
+
+	broker := events.NewBroker()
+	srv := newTestServerWithBroker(s, broker)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	evtCh := readSSEEvents(ctx, t, srv.URL+"/api/deployments/events")
+	time.Sleep(50 * time.Millisecond)
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/deployments/d1/restart", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/deployments/d1/restart: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", resp.StatusCode)
+	}
+
+	var updated store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if updated.Status != store.StatusDeploying {
+		t.Errorf("want status deploying, got %s", updated.Status)
+	}
+
+	select {
+	case event := <-evtCh:
+		if event.DeploymentID != "d1" {
+			t.Errorf("want deployment id d1, got %s", event.DeploymentID)
+		}
+		if event.Status != string(store.StatusDeploying) {
+			t.Errorf("want status deploying, got %s", event.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: no SSE event after restart")
+	}
+}
+
+func TestRestartDeployment_NotFound(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/deployments/nonexistent/restart", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/deployments/nonexistent/restart: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestRestartDeployment_StoreError(t *testing.T) {
+	srv := newTestServer(&errStore{})
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/deployments/any/restart", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/deployments/any/restart: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", resp.StatusCode)
 	}
 }
 

--- a/api/internal/api/handler_update_deployment.go
+++ b/api/internal/api/handler_update_deployment.go
@@ -64,6 +64,11 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 	}
 	body.Ports = assignedPorts
 
+	if updateRequestMatchesExisting(existing, body, basicAuth) {
+		writeJSON(w, http.StatusOK, existing)
+		return
+	}
+
 	nextStatus := existing.Status
 	if updateRequiresRedeploy(existing, body) {
 		nextStatus = store.StatusDeploying

--- a/dashboard/src/deployments/EditDeploymentForm.tsx
+++ b/dashboard/src/deployments/EditDeploymentForm.tsx
@@ -21,7 +21,7 @@ export default function EditDeploymentForm({ deployment, onClose, className, hid
   const {
     name, setName, image, setImage, domain, setDomain,
     envRows, portRows, volumeRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
-    errors, handleSubmit, isPending,
+    errors, handleSubmit, isDirty, isPending,
   } = useEditDeploymentForm(deployment, onClose)
 
   return (
@@ -136,7 +136,7 @@ export default function EditDeploymentForm({ deployment, onClose, className, hid
 
         {errors.form && <p className={fieldErrorCls}>{errors.form}</p>}
         <div className="flex items-center gap-3">
-          <Button type="submit" disabled={isPending}>
+          <Button type="submit" disabled={isPending || !isDirty}>
             {isPending ? 'Saving…' : 'Save'}
           </Button>
           <Button type="button" onClick={onClose} disabled={isPending} variant="outline">

--- a/dashboard/src/deployments/useEditDeploymentForm.ts
+++ b/dashboard/src/deployments/useEditDeploymentForm.ts
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { updateDeployment, type Deployment } from '../lib/api'
+import { updateDeployment, type BasicAuthConfig, type Deployment, type UpdateDeploymentInput } from '../lib/api'
 import { hashPasswordIfNeeded } from '../lib/password'
 import { useDynamicRows } from './useDynamicRows'
 import type { BasicAuthUserRow, EnvRow, FormErrors, PairRow, PortRow } from './useCreateDeploymentForm'
@@ -29,6 +29,20 @@ function toBasicAuthRows(deployment: Deployment): BasicAuthUserRow[] {
   return (deployment.basic_auth?.users ?? []).map((user, i) => ({ id: i, username: user.username, password: user.password }))
 }
 
+function equalBasicAuth(a?: BasicAuthConfig, b?: BasicAuthConfig): boolean {
+  if (!a || !b) {
+    return a === b
+  }
+  if (a.users.length !== b.users.length) {
+    return false
+  }
+
+  return a.users.every((user, index) => {
+    const other = b.users[index]
+    return Boolean(other) && user.username === other.username && user.password === other.password
+  })
+}
+
 export function useEditDeploymentForm(deployment: Deployment, onClose: () => void) {
   const queryClient = useQueryClient()
 
@@ -42,6 +56,83 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
   const portRows = useDynamicRows<PortRow>(id => ({ id, port: '' }), toPortRows(deployment.ports))
   const volumeRows = useDynamicRows<PairRow>(id => ({ id, left: '', right: '' }), toPairRows(deployment.volumes))
   const basicAuthRows = useDynamicRows<BasicAuthUserRow>(id => ({ id, username: '', password: '' }), toBasicAuthRows(deployment))
+
+  const normalizedInput = useMemo<UpdateDeploymentInput>(() => {
+    const envs: Record<string, string> = {}
+    for (const row of envRows.rows) {
+      envs[row.key.trim()] = row.value
+    }
+
+    return {
+      name: name.trim(),
+      image: image.trim(),
+      envs,
+      ports: portRows.rows.map(r => r.port.trim()),
+      volumes: volumeRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
+      domain: domain.trim(),
+      basic_auth: basicAuthEnabled
+        ? {
+            users: basicAuthRows.rows.map(row => ({
+              username: row.username.trim(),
+              password: row.password.trim(),
+            })),
+          }
+        : undefined,
+      security: deployment.security,
+    }
+  }, [name, image, domain, envRows.rows, portRows.rows, volumeRows.rows, basicAuthEnabled, basicAuthRows.rows, deployment.security])
+
+  const isDirty = useMemo(() => {
+    const initial: UpdateDeploymentInput = {
+      name: deployment.name,
+      image: deployment.image,
+      envs: deployment.envs,
+      ports: deployment.ports.map(port => {
+        const separator = port.indexOf(':')
+        return separator >= 0 ? port.slice(separator + 1) : port
+      }),
+      volumes: deployment.volumes,
+      domain: deployment.domain,
+      basic_auth: deployment.basic_auth,
+      security: deployment.security,
+    }
+
+    if (initial.name !== normalizedInput.name ||
+      initial.image !== normalizedInput.image ||
+      initial.domain !== normalizedInput.domain) {
+      return true
+    }
+
+    if (initial.ports.length !== normalizedInput.ports.length || initial.volumes.length !== normalizedInput.volumes.length) {
+      return true
+    }
+
+    for (let i = 0; i < initial.ports.length; i += 1) {
+      if (initial.ports[i] !== normalizedInput.ports[i]) {
+        return true
+      }
+    }
+
+    for (let i = 0; i < initial.volumes.length; i += 1) {
+      if (initial.volumes[i] !== normalizedInput.volumes[i]) {
+        return true
+      }
+    }
+
+    const initialEnvEntries = Object.entries(initial.envs)
+    const currentEnvEntries = Object.entries(normalizedInput.envs)
+    if (initialEnvEntries.length !== currentEnvEntries.length) {
+      return true
+    }
+
+    for (const [key, value] of initialEnvEntries) {
+      if (normalizedInput.envs[key] !== value) {
+        return true
+      }
+    }
+
+    return !equalBasicAuth(initial.basic_auth, normalizedInput.basic_auth)
+  }, [deployment, normalizedInput])
 
   const mutation = useMutation({
     mutationFn: (data: Parameters<typeof updateDeployment>[1]) => updateDeployment(deployment.id, data),
@@ -88,9 +179,6 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!validate()) return
-    const envs: Record<string, string> = {}
-    for (const row of envRows.rows) envs[row.key.trim()] = row.value
-
     const basicAuth = basicAuthEnabled
       ? {
           users: await Promise.all(
@@ -103,12 +191,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
       : undefined
 
     mutation.mutate({
-      name: name.trim(),
-      image: image.trim(),
-      envs,
-      ports: portRows.rows.map(r => r.port.trim()),
-      volumes: volumeRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
-      domain: domain.trim(),
+      ...normalizedInput,
       basic_auth: basicAuth,
     })
   }
@@ -124,6 +207,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
     basicAuthRows,
     errors,
     handleSubmit,
+    isDirty,
     isPending: mutation.isPending,
   }
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -248,6 +248,12 @@ export async function deleteDeployment(id: string): Promise<void> {
   if (!res.ok) throw new Error('Failed to delete deployment')
 }
 
+export async function restartDeployment(id: string): Promise<Deployment> {
+  const res = await fetch(`/api/deployments/${id}/restart`, { method: 'POST' })
+  if (!res.ok) throw new Error('Failed to restart deployment')
+  return res.json()
+}
+
 export async function getSystemStatus(): Promise<SystemStatusSnapshot> {
   const res = await fetch('/api/system-status')
   if (!res.ok) throw new Error('Failed to fetch system status')

--- a/dashboard/src/pages/DeploymentDetailPage.tsx
+++ b/dashboard/src/pages/DeploymentDetailPage.tsx
@@ -1,17 +1,18 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, useParams } from '@tanstack/react-router'
-import { AlertTriangle, ArrowLeft, ChevronDown, ExternalLink, Globe, Hash, Package, Pencil } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, ChevronDown, ExternalLink, Globe, Hash, Package, Pencil, RotateCcw } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../components/ui/dialog'
 import EditDeploymentForm from '../deployments/EditDeploymentForm'
 import { DeploymentLogsPanel } from '../deployments/DeploymentLogsPanel'
 import { DeploymentSecurityPanel } from '../deployments/DeploymentSecurityPanel'
 import { StatusBadge } from '../deployments/StatusBadge'
-import { getDeployments } from '../lib/api'
+import { getDeployments, restartDeployment, type Deployment } from '../lib/api'
 
 export function DeploymentDetailPage() {
   const { deploymentId } = useParams({ from: '/deployments/$deploymentId' })
+  const queryClient = useQueryClient()
   const { data: deployments, isLoading, isError } = useQuery({
     queryKey: ['deployments'],
     queryFn: getDeployments,
@@ -19,6 +20,15 @@ export function DeploymentDetailPage() {
   })
   const [debugOpen, setDebugOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
+
+  const restartMutation = useMutation({
+    mutationFn: (id: string) => restartDeployment(id),
+    onSuccess: updated => {
+      queryClient.setQueryData<Deployment[]>(['deployments'], prev =>
+        prev?.map(item => (item.id === updated.id ? updated : item))
+      )
+    },
+  })
 
   const backLink = (
     <Link
@@ -61,6 +71,13 @@ export function DeploymentDetailPage() {
   const envEntries = Object.entries(deployment.envs)
   const stats = deployment.status === 'healthy' ? deployment.stats : undefined
 
+  const handleRestart = () => {
+    if (!window.confirm(`Restart ${deployment.name}? This will redeploy the current configuration.`)) {
+      return
+    }
+    restartMutation.mutate(deployment.id)
+  }
+
   return (
     <div className="space-y-4">
       {backLink}
@@ -81,16 +98,32 @@ export function DeploymentDetailPage() {
             </div>
           </div>
           <div className="flex flex-col gap-2 sm:items-end">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1.5 px-2.5 text-xs"
-              onClick={() => setEditOpen(true)}
-            >
-              <Pencil className="h-3 w-3" />
-              Edit
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 px-2.5 text-xs"
+                onClick={handleRestart}
+                disabled={restartMutation.isPending || deployment.status === 'deploying'}
+              >
+                <RotateCcw className="h-3 w-3" />
+                {restartMutation.isPending ? 'Restarting…' : 'Restart'}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 px-2.5 text-xs"
+                onClick={() => setEditOpen(true)}
+              >
+                <Pencil className="h-3 w-3" />
+                Edit
+              </Button>
+            </div>
+            {restartMutation.isError ? (
+              <p className="text-xs text-destructive">Failed to restart deployment.</p>
+            ) : null}
             {deployment.domain && (
               <div className="flex items-center gap-1.5">
                 <Globe className="h-3 w-3 shrink-0 text-muted-foreground/50" />


### PR DESCRIPTION
## Summary
- add a dedicated `POST /api/deployments/{id}/restart` endpoint and wire the deployment detail page Restart button through it with a confirmation prompt
- disable the edit form Save action until the form diverges from current deployment config, and keep backend update requests idempotent by short-circuiting unchanged payloads
- extend API tests to cover no-op update short-circuit behavior and restart endpoint success/error paths

Closes #148
Closes #149