### PR TITLE
feat(api): lifecycle contract v1 with explicit status reasons

### DIFF
--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -1386,6 +1386,7 @@ func TestDeploymentEvents_FailedStatusCarriesError(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]string{
 		"status": string(store.StatusFailed),
+		"reason": string(store.StatusReasonContainerExited),
 		"error":  "container exited with code 1",
 	})
 	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/d1/status", bytes.NewReader(body))
@@ -1400,6 +1401,9 @@ func TestDeploymentEvents_FailedStatusCarriesError(t *testing.T) {
 		}
 		if event.Error != "container exited with code 1" {
 			t.Errorf("want error message, got %q", event.Error)
+		}
+		if event.Reason != string(store.StatusReasonContainerExited) {
+			t.Errorf("want reason %q, got %q", store.StatusReasonContainerExited, event.Reason)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout: no SSE event received")
@@ -1436,7 +1440,7 @@ func TestUpdateDeploymentStatus(t *testing.T) {
 	srv := newTestServer(s)
 	defer srv.Close()
 
-	body, _ := json.Marshal(map[string]string{"status": "healthy"})
+	body, _ := json.Marshal(map[string]string{"status": "healthy", "reason": string(store.StatusReasonDeployStartSucceeded)})
 	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/d1/status", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
@@ -1457,6 +1461,9 @@ func TestUpdateDeploymentStatus(t *testing.T) {
 	if updated.Status != store.StatusHealthy {
 		t.Errorf("want status healthy, got %s", updated.Status)
 	}
+	if updated.Reason != store.StatusReasonDeployStartSucceeded {
+		t.Errorf("want reason %q, got %q", store.StatusReasonDeployStartSucceeded, updated.Reason)
+	}
 	if updated.Error != "" {
 		t.Errorf("want empty error, got %q", updated.Error)
 	}
@@ -1471,6 +1478,7 @@ func TestUpdateDeploymentStatus_FailedStoresError(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]string{
 		"status": "failed",
+		"reason": string(store.StatusReasonDeployStartFailed),
 		"error":  "image not found",
 	})
 	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/d1/status", bytes.NewReader(body))
@@ -1492,6 +1500,9 @@ func TestUpdateDeploymentStatus_FailedStoresError(t *testing.T) {
 	}
 	if updated.Status != store.StatusFailed {
 		t.Errorf("want status failed, got %s", updated.Status)
+	}
+	if updated.Reason != store.StatusReasonDeployStartFailed {
+		t.Errorf("want reason %q, got %q", store.StatusReasonDeployStartFailed, updated.Reason)
 	}
 	if updated.Error != "image not found" {
 		t.Errorf("want error image not found, got %q", updated.Error)

--- a/api/internal/api/handler_update_deployment_status.go
+++ b/api/internal/api/handler_update_deployment_status.go
@@ -14,6 +14,7 @@ func (h *Handler) updateDeploymentStatus(w http.ResponseWriter, r *http.Request)
 
 	var body struct {
 		Status store.Status `json:"status"`
+		Reason string       `json:"reason"`
 		Error  string       `json:"error"`
 	}
 
@@ -42,6 +43,7 @@ func (h *Handler) updateDeploymentStatus(w http.ResponseWriter, r *http.Request)
 	}
 
 	d.Status = body.Status
+	d.Reason = store.StatusReason(body.Reason)
 	d.Error = body.Error
 	updated, err := h.store.Update(d)
 	if err != nil {
@@ -52,6 +54,7 @@ func (h *Handler) updateDeploymentStatus(w http.ResponseWriter, r *http.Request)
 	h.events.Publish(events.StatusEvent{
 		DeploymentID: id,
 		Status:       string(body.Status),
+		Reason:       body.Reason,
 		Error:        body.Error,
 	})
 

--- a/api/internal/events/broker.go
+++ b/api/internal/events/broker.go
@@ -6,6 +6,7 @@ import "sync"
 type StatusEvent struct {
 	DeploymentID string `json:"deploymentId"`
 	Status       string `json:"status"`
+	Reason       string `json:"reason,omitempty"`
 	Error        string `json:"error,omitempty"`
 }
 

--- a/orchestrator/internal/apiclient/client.go
+++ b/orchestrator/internal/apiclient/client.go
@@ -82,11 +82,12 @@ func New(baseURL string) *Client {
 
 // NotifyStatus calls PATCH /api/deployments/{id}/status so the API's event
 // broker emits an SSE event to all connected clients.
-func (c *Client) NotifyStatus(id string, status store.Status, errorMessage string) error {
+func (c *Client) NotifyStatus(id string, status store.Status, reason store.StatusReason, errorMessage string) error {
 	body, err := json.Marshal(struct {
-		Status store.Status `json:"status"`
-		Error  string       `json:"error,omitempty"`
-	}{Status: status, Error: errorMessage})
+		Status store.Status       `json:"status"`
+		Reason store.StatusReason `json:"reason,omitempty"`
+		Error  string             `json:"error,omitempty"`
+	}{Status: status, Reason: reason, Error: errorMessage})
 	if err != nil {
 		return fmt.Errorf("apiclient: marshal body: %w", err)
 	}

--- a/orchestrator/internal/apiclient/client_test.go
+++ b/orchestrator/internal/apiclient/client_test.go
@@ -190,8 +190,9 @@ func TestClient_NotifyStatus(t *testing.T) {
 			t.Fatalf("want path /api/deployments/d1/status, got %s", r.URL.Path)
 		}
 		var body struct {
-			Status store.Status `json:"status"`
-			Error  string       `json:"error"`
+			Status store.Status       `json:"status"`
+			Reason store.StatusReason `json:"reason"`
+			Error  string             `json:"error"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode body: %v", err)
@@ -202,12 +203,15 @@ func TestClient_NotifyStatus(t *testing.T) {
 		if body.Error != "" {
 			t.Fatalf("want empty error, got %q", body.Error)
 		}
+		if body.Reason != store.StatusReasonDeployStartSucceeded {
+			t.Fatalf("want deploy_start_succeeded reason, got %q", body.Reason)
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyStatus("d1", store.StatusHealthy, ""); err != nil {
+	if err := client.NotifyStatus("d1", store.StatusHealthy, store.StatusReasonDeployStartSucceeded, ""); err != nil {
 		t.Fatalf("NotifyStatus: %v", err)
 	}
 }
@@ -215,8 +219,9 @@ func TestClient_NotifyStatus(t *testing.T) {
 func TestClient_NotifyStatus_WithError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
-			Status store.Status `json:"status"`
-			Error  string       `json:"error"`
+			Status store.Status       `json:"status"`
+			Reason store.StatusReason `json:"reason"`
+			Error  string             `json:"error"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode body: %v", err)
@@ -227,12 +232,15 @@ func TestClient_NotifyStatus_WithError(t *testing.T) {
 		if body.Error == "" {
 			t.Fatal("want failure error message")
 		}
+		if body.Reason != store.StatusReasonDeployStartFailed {
+			t.Fatalf("want deploy_start_failed reason, got %q", body.Reason)
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyStatus("d1", store.StatusFailed, "image not found"); err != nil {
+	if err := client.NotifyStatus("d1", store.StatusFailed, store.StatusReasonDeployStartFailed, "image not found"); err != nil {
 		t.Fatalf("NotifyStatus: %v", err)
 	}
 }

--- a/orchestrator/internal/reconciler/reconciler.go
+++ b/orchestrator/internal/reconciler/reconciler.go
@@ -32,7 +32,7 @@ type Store interface {
 // Notifier notifies the API of deployment status transitions so the event
 // broker can push real-time updates to SSE subscribers.
 type Notifier interface {
-	NotifyStatus(id string, status store.Status, errorMessage string) error
+	NotifyStatus(id string, status store.Status, reason store.StatusReason, errorMessage string) error
 }
 
 // Reconciler syncs the desired state in the store with actual Docker containers.
@@ -91,7 +91,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		r.recordDockerReachability(false)
 		for _, d := range deployments {
 			if d.Status == store.StatusHealthy || d.Status == store.StatusDeploying {
-				r.updateStatus(d.ID, store.StatusFailed, dockerUnavailableError)
+				r.updateStatus(d.ID, store.StatusFailed, store.StatusReasonDockerUnavailable, dockerUnavailableError)
 			}
 		}
 		return fmt.Errorf("reconcile: docker unavailable: %w", err)
@@ -138,7 +138,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 
 		if r.dashboardDomain != "" && normalizeDomain(d.Domain) == r.dashboardDomain {
 			if d.Status == store.StatusDeploying {
-				r.updateStatus(d.ID, store.StatusFailed, fmt.Sprintf("domain %q is reserved for dashboard", r.dashboardDomain))
+				r.updateStatus(d.ID, store.StatusFailed, store.StatusReasonDomainReserved, fmt.Sprintf("domain %q is reserved for dashboard", r.dashboardDomain))
 				continue
 			}
 		}
@@ -150,26 +150,26 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 				runtimePorts, err := r.docker.Start(ctx, d)
 				if err != nil {
 					log.Printf("reconciler: start %s (%s): %v", d.ID, d.Name, err)
-					r.updateStatus(d.ID, store.StatusFailed, err.Error())
+					r.updateStatus(d.ID, store.StatusFailed, store.StatusReasonDeployStartFailed, err.Error())
 				} else {
-					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy)
+					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy, store.StatusReasonDeployStartSucceeded)
 				}
 			} else if c.Running {
 				// Container already running — this is a redeploy; apply start-then-stop.
 				runtimePorts, err := r.docker.StartAndReplace(ctx, d, c.ID)
 				if err != nil {
 					log.Printf("reconciler: redeploy %s (%s): %v", d.ID, d.Name, err)
-					r.updateStatus(d.ID, store.StatusFailed, err.Error())
+					r.updateStatus(d.ID, store.StatusFailed, store.StatusReasonRedeployStartFailed, err.Error())
 				} else {
-					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy)
+					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy, store.StatusReasonRedeployStartSucceeded)
 				}
 			} else {
-				r.updateStatus(d.ID, store.StatusFailed, exitMessage(c.ExitDetails))
+				r.updateStatus(d.ID, store.StatusFailed, exitReason(c.ExitDetails), exitMessage(c.ExitDetails))
 			}
 
 		case store.StatusHealthy:
 			if !hasContainer || !c.Running {
-				r.updateStatus(d.ID, store.StatusFailed, exitMessage(c.ExitDetails))
+				r.updateStatus(d.ID, store.StatusFailed, exitReason(c.ExitDetails), exitMessage(c.ExitDetails))
 			}
 
 		case store.StatusFailed, store.StatusIdle:
@@ -183,7 +183,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 
 			if hasContainer && c.Running {
 				r.clearRetryState(d.ID)
-				r.updateStatus(d.ID, store.StatusHealthy, "")
+				r.updateStatus(d.ID, store.StatusHealthy, store.StatusReasonRetryRecoveredRunning, "")
 				continue
 			}
 
@@ -200,12 +200,12 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			if err != nil {
 				log.Printf("reconciler: heal failed deployment %s (%s): %v", d.ID, d.Name, err)
 				r.recordRetryFailure(d.ID, now)
-				r.updateStatus(d.ID, store.StatusFailed, err.Error())
+				r.updateStatus(d.ID, store.StatusFailed, store.StatusReasonRetryStartFailedTransient, err.Error())
 				continue
 			}
 
 			r.clearRetryState(d.ID)
-			r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy)
+			r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy, store.StatusReasonRetryStartSucceeded)
 		}
 	}
 
@@ -308,27 +308,34 @@ func exitMessage(d *docker.ExitDetails) string {
 	return fmt.Sprintf("container exited unexpectedly (exit code %d)", d.ExitCode)
 }
 
-func (r *Reconciler) updateStatus(id string, status store.Status, errorMessage string) {
-	if _, err := r.store.Patch(id, store.Deployment{Status: status, Error: errorMessage}); err != nil {
-		log.Printf("reconciler: update status %s → %s: %v", id, status, err)
+func exitReason(d *docker.ExitDetails) store.StatusReason {
+	if d == nil {
+		return store.StatusReasonContainerNotRunning
 	}
-	r.notifyStatus(id, status, errorMessage)
+	return store.StatusReasonContainerExited
 }
 
-func (r *Reconciler) updatePortsAndStatus(id string, ports []string, status store.Status) {
-	patch := store.Deployment{Status: status, Error: ""}
+func (r *Reconciler) updateStatus(id string, status store.Status, reason store.StatusReason, errorMessage string) {
+	if _, err := r.store.Patch(id, store.Deployment{Status: status, Reason: reason, Error: errorMessage}); err != nil {
+		log.Printf("reconciler: update status %s → %s: %v", id, status, err)
+	}
+	r.notifyStatus(id, status, reason, errorMessage)
+}
+
+func (r *Reconciler) updatePortsAndStatus(id string, ports []string, status store.Status, reason store.StatusReason) {
+	patch := store.Deployment{Status: status, Reason: reason, Error: ""}
 	if ports != nil {
 		patch.Ports = ports
 	}
 	if _, err := r.store.Patch(id, patch); err != nil {
 		log.Printf("reconciler: patch deployment %s: %v", id, err)
 	}
-	r.notifyStatus(id, status, "")
+	r.notifyStatus(id, status, reason, "")
 }
 
-func (r *Reconciler) notifyStatus(id string, status store.Status, errorMessage string) {
+func (r *Reconciler) notifyStatus(id string, status store.Status, reason store.StatusReason, errorMessage string) {
 	if r.notifier != nil {
-		if err := r.notifier.NotifyStatus(id, status, errorMessage); err != nil {
+		if err := r.notifier.NotifyStatus(id, status, reason, errorMessage); err != nil {
 			log.Printf("reconciler: notify api status %s → %s: %v", id, status, err)
 		}
 	}

--- a/orchestrator/internal/reconciler/reconciler_test.go
+++ b/orchestrator/internal/reconciler/reconciler_test.go
@@ -21,13 +21,14 @@ type mockNotifier struct {
 type notifyCall struct {
 	id     string
 	status store.Status
+	reason store.StatusReason
 	error  string
 }
 
-func (m *mockNotifier) NotifyStatus(id string, status store.Status, errorMessage string) error {
+func (m *mockNotifier) NotifyStatus(id string, status store.Status, reason store.StatusReason, errorMessage string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.calls = append(m.calls, notifyCall{id: id, status: status, error: errorMessage})
+	m.calls = append(m.calls, notifyCall{id: id, status: status, reason: reason, error: errorMessage})
 	return m.notifyErr
 }
 
@@ -77,6 +78,7 @@ func (m *mockStore) Patch(id string, patch store.Deployment) (store.Deployment, 
 		}
 		if patch.Status != "" {
 			m.deployments[i].Status = patch.Status
+			m.deployments[i].Reason = patch.Reason
 			m.deployments[i].Error = patch.Error
 		} else if patch.Error != "" {
 			m.deployments[i].Error = patch.Error
@@ -92,6 +94,17 @@ func (m *mockStore) getStatus(id string) store.Status {
 	for _, d := range m.deployments {
 		if d.ID == id {
 			return d.Status
+		}
+	}
+	return ""
+}
+
+func (m *mockStore) getReason(id string) store.StatusReason {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, d := range m.deployments {
+		if d.ID == id {
+			return d.Reason
 		}
 	}
 	return ""
@@ -198,6 +211,9 @@ func TestReconcile_DeployingNoContainer_StartsAndBecomesHealthy(t *testing.T) {
 	if s.getStatus("d1") != store.StatusHealthy {
 		t.Errorf("want status healthy, got %s", s.getStatus("d1"))
 	}
+	if s.getReason("d1") != store.StatusReasonDeployStartSucceeded {
+		t.Errorf("want reason %q, got %q", store.StatusReasonDeployStartSucceeded, s.getReason("d1"))
+	}
 }
 
 func TestReconcile_DeployingNoContainer_StartFails_BecomesFailed(t *testing.T) {
@@ -215,6 +231,9 @@ func TestReconcile_DeployingNoContainer_StartFails_BecomesFailed(t *testing.T) {
 
 	if s.getStatus("d1") != store.StatusFailed {
 		t.Errorf("want status failed, got %s", s.getStatus("d1"))
+	}
+	if s.getReason("d1") != store.StatusReasonDeployStartFailed {
+		t.Errorf("want reason %q, got %q", store.StatusReasonDeployStartFailed, s.getReason("d1"))
 	}
 }
 
@@ -241,6 +260,9 @@ func TestReconcile_DeployingWithRunningContainer_RedeploysAndBecomesHealthy(t *t
 	}
 	if s.getStatus("d1") != store.StatusHealthy {
 		t.Errorf("want status healthy, got %s", s.getStatus("d1"))
+	}
+	if s.getReason("d1") != store.StatusReasonRedeployStartSucceeded {
+		t.Errorf("want reason %q, got %q", store.StatusReasonRedeployStartSucceeded, s.getReason("d1"))
 	}
 }
 
@@ -339,6 +361,9 @@ func TestReconcile_Redeploy_FailedNewContainer_KeepsOldAndBecomesFailed(t *testi
 	if s.getStatus("d1") != store.StatusFailed {
 		t.Errorf("want status failed, got %s", s.getStatus("d1"))
 	}
+	if s.getReason("d1") != store.StatusReasonRedeployStartFailed {
+		t.Errorf("want reason %q, got %q", store.StatusReasonRedeployStartFailed, s.getReason("d1"))
+	}
 }
 
 func TestReconcile_DeployingWithStoppedContainer_BecomesFailed(t *testing.T) {
@@ -361,6 +386,9 @@ func TestReconcile_DeployingWithStoppedContainer_BecomesFailed(t *testing.T) {
 	if s.getStatus("d1") != store.StatusFailed {
 		t.Errorf("want status failed, got %s", s.getStatus("d1"))
 	}
+	if s.getReason("d1") != store.StatusReasonContainerNotRunning {
+		t.Errorf("want reason %q, got %q", store.StatusReasonContainerNotRunning, s.getReason("d1"))
+	}
 }
 
 func TestReconcile_HealthyNoContainer_BecomesFailed(t *testing.T) {
@@ -378,6 +406,9 @@ func TestReconcile_HealthyNoContainer_BecomesFailed(t *testing.T) {
 
 	if s.getStatus("d1") != store.StatusFailed {
 		t.Errorf("want status failed, got %s", s.getStatus("d1"))
+	}
+	if s.getReason("d1") != store.StatusReasonContainerNotRunning {
+		t.Errorf("want reason %q, got %q", store.StatusReasonContainerNotRunning, s.getReason("d1"))
 	}
 }
 
@@ -438,6 +469,9 @@ func TestReconcile_FailedTransient_NoContainer_RetriesThenBacksOff(t *testing.T)
 	if d.startCalls != 1 {
 		t.Fatalf("want one retry attempt, got %d", d.startCalls)
 	}
+	if s.getReason("d1") != store.StatusReasonRetryStartFailedTransient {
+		t.Fatalf("want reason %q, got %q", store.StatusReasonRetryStartFailedTransient, s.getReason("d1"))
+	}
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("reconcile second attempt: %v", err)
@@ -487,6 +521,9 @@ func TestReconcile_DockerReconnect_RetriesTransientFailureImmediately(t *testing
 	if s.getStatus("d1") != store.StatusHealthy {
 		t.Fatalf("want deployment healthy after reconnect retry, got %s", s.getStatus("d1"))
 	}
+	if s.getReason("d1") != store.StatusReasonRetryStartSucceeded {
+		t.Fatalf("want reason %q, got %q", store.StatusReasonRetryStartSucceeded, s.getReason("d1"))
+	}
 }
 
 func TestReconcile_DockerReconnect_RunningContainerHealsWithoutRestart(t *testing.T) {
@@ -513,6 +550,9 @@ func TestReconcile_DockerReconnect_RunningContainerHealsWithoutRestart(t *testin
 	if s.getStatus("d1") != store.StatusHealthy {
 		t.Fatalf("want deployment healed to healthy, got %s", s.getStatus("d1"))
 	}
+	if s.getReason("d1") != store.StatusReasonRetryRecoveredRunning {
+		t.Fatalf("want reason %q, got %q", store.StatusReasonRetryRecoveredRunning, s.getReason("d1"))
+	}
 }
 
 func TestReconcile_DeployingNoContainer_NotifiesHealthy(t *testing.T) {
@@ -533,6 +573,9 @@ func TestReconcile_DeployingNoContainer_NotifiesHealthy(t *testing.T) {
 	if len(calls) != 1 || calls[0].id != "d1" || calls[0].status != store.StatusHealthy {
 		t.Errorf("want notify(d1, healthy), got %v", calls)
 	}
+	if calls[0].reason != store.StatusReasonDeployStartSucceeded {
+		t.Errorf("want reason %q, got %q", store.StatusReasonDeployStartSucceeded, calls[0].reason)
+	}
 }
 
 func TestReconcile_DeployingStartFails_NotifiesFailed(t *testing.T) {
@@ -552,6 +595,9 @@ func TestReconcile_DeployingStartFails_NotifiesFailed(t *testing.T) {
 	calls := n.getCalls()
 	if len(calls) != 1 || calls[0].id != "d1" || calls[0].status != store.StatusFailed {
 		t.Errorf("want notify(d1, failed), got %v", calls)
+	}
+	if calls[0].reason != store.StatusReasonDeployStartFailed {
+		t.Errorf("want reason %q, got %q", store.StatusReasonDeployStartFailed, calls[0].reason)
 	}
 	if calls[0].error == "" {
 		t.Error("want notify call to include failure reason")
@@ -576,6 +622,9 @@ func TestReconcile_HealthyContainerGone_NotifiesFailed(t *testing.T) {
 	if len(calls) != 1 || calls[0].id != "d1" || calls[0].status != store.StatusFailed {
 		t.Errorf("want notify(d1, failed), got %v", calls)
 	}
+	if calls[0].reason != store.StatusReasonContainerNotRunning {
+		t.Errorf("want reason %q, got %q", store.StatusReasonContainerNotRunning, calls[0].reason)
+	}
 }
 
 func TestReconcile_DeployingWithStoppedContainer_OOMKilled_ShowsOOMMessage(t *testing.T) {
@@ -599,6 +648,9 @@ func TestReconcile_DeployingWithStoppedContainer_OOMKilled_ShowsOOMMessage(t *te
 	calls := n.getCalls()
 	if len(calls) != 1 || calls[0].status != store.StatusFailed {
 		t.Fatalf("want one failed notification, got %v", calls)
+	}
+	if calls[0].reason != store.StatusReasonContainerExited {
+		t.Fatalf("want reason %q, got %q", store.StatusReasonContainerExited, calls[0].reason)
 	}
 	want := "container killed: out of memory (exit code 137)"
 	if calls[0].error != want {
@@ -628,6 +680,9 @@ func TestReconcile_DeployingWithStoppedContainer_NonZeroExit_ShowsExitMessage(t 
 	if len(calls) != 1 || calls[0].status != store.StatusFailed {
 		t.Fatalf("want one failed notification, got %v", calls)
 	}
+	if calls[0].reason != store.StatusReasonContainerExited {
+		t.Fatalf("want reason %q, got %q", store.StatusReasonContainerExited, calls[0].reason)
+	}
 	want := "container exited unexpectedly (exit code 1)"
 	if calls[0].error != want {
 		t.Errorf("want error %q, got %q", want, calls[0].error)
@@ -652,6 +707,9 @@ func TestReconcile_HealthyContainerMissing_ShowsFallbackMessage(t *testing.T) {
 	if len(calls) != 1 || calls[0].status != store.StatusFailed {
 		t.Fatalf("want one failed notification, got %v", calls)
 	}
+	if calls[0].reason != store.StatusReasonContainerNotRunning {
+		t.Fatalf("want reason %q, got %q", store.StatusReasonContainerNotRunning, calls[0].reason)
+	}
 	want := "container is not running"
 	if calls[0].error != want {
 		t.Errorf("want error %q, got %q", want, calls[0].error)
@@ -674,6 +732,9 @@ func TestReconcile_DockerUnavailable_HealthyBecomesFailed(t *testing.T) {
 	if s.getStatus("d1") != store.StatusFailed {
 		t.Errorf("want status failed when docker is unavailable, got %s", s.getStatus("d1"))
 	}
+	if s.getReason("d1") != store.StatusReasonDockerUnavailable {
+		t.Errorf("want reason %q, got %q", store.StatusReasonDockerUnavailable, s.getReason("d1"))
+	}
 }
 
 func TestReconcile_DockerUnavailable_DeployingBecomesFailed(t *testing.T) {
@@ -691,6 +752,9 @@ func TestReconcile_DockerUnavailable_DeployingBecomesFailed(t *testing.T) {
 	}
 	if s.getStatus("d1") != store.StatusFailed {
 		t.Errorf("want deploying status failed when docker is unavailable, got %s", s.getStatus("d1"))
+	}
+	if s.getReason("d1") != store.StatusReasonDockerUnavailable {
+		t.Errorf("want reason %q, got %q", store.StatusReasonDockerUnavailable, s.getReason("d1"))
 	}
 }
 
@@ -714,6 +778,9 @@ func TestReconcile_DeployingWithDashboardDomainConflict_BecomesFailedWithoutStar
 	}
 	if s.getStatus("d1") != store.StatusFailed {
 		t.Fatalf("want status failed, got %s", s.getStatus("d1"))
+	}
+	if s.getReason("d1") != store.StatusReasonDomainReserved {
+		t.Fatalf("want reason %q, got %q", store.StatusReasonDomainReserved, s.getReason("d1"))
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -26,6 +26,24 @@ const (
 	StatusFailed    Status = "failed"
 )
 
+// StatusReason is a stable machine-readable code that explains why a
+// deployment transitioned status.
+type StatusReason string
+
+const (
+	StatusReasonDeployStartSucceeded      StatusReason = "deploy_start_succeeded"
+	StatusReasonRedeployStartSucceeded    StatusReason = "redeploy_start_succeeded"
+	StatusReasonRetryStartSucceeded       StatusReason = "retry_start_succeeded"
+	StatusReasonRetryRecoveredRunning     StatusReason = "retry_recovered_running"
+	StatusReasonDockerUnavailable         StatusReason = "docker_unavailable"
+	StatusReasonDomainReserved            StatusReason = "domain_reserved"
+	StatusReasonDeployStartFailed         StatusReason = "deploy_start_failed"
+	StatusReasonRedeployStartFailed       StatusReason = "redeploy_start_failed"
+	StatusReasonContainerExited           StatusReason = "container_exited"
+	StatusReasonContainerNotRunning       StatusReason = "container_not_running"
+	StatusReasonRetryStartFailedTransient StatusReason = "retry_start_failed_transient"
+)
+
 // Deployment holds the full configuration and runtime state of a container deployment.
 type Deployment struct {
 	ID        string            `json:"id"`
@@ -38,6 +56,7 @@ type Deployment struct {
 	BasicAuth *BasicAuthConfig  `json:"basic_auth,omitempty"`
 	Security  *SecurityConfig   `json:"security,omitempty"`
 	Status    Status            `json:"status"`
+	Reason    StatusReason      `json:"reason,omitempty"`
 	Error     string            `json:"error,omitempty"`
 }
 
@@ -300,6 +319,7 @@ func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
 		}
 		if patch.Status != "" {
 			d.Status = patch.Status
+			d.Reason = patch.Reason
 			d.Error = patch.Error
 		} else if patch.Error != "" {
 			d.Error = patch.Error
@@ -346,6 +366,8 @@ func (s *JSONStore) UpdateStatus(id string, status Status) error {
 			return nil // deployment was deleted; ignore
 		}
 		d.Status = status
+		d.Reason = ""
+		d.Error = ""
 		data[id] = d
 		return s.persist(data)
 	})


### PR DESCRIPTION
## Summary
- Introduce a stable lifecycle reason-code contract by adding `reason` to deployment state and defining canonical status-reason constants in the store package.
- Propagate reason codes through reconciler transitions, API status patch notifications, and deployment SSE events while keeping existing `status` and `error` fields backward compatible.
- Expand API/orchestrator/reconciler tests to assert reason semantics across deploy success/failure, crash/missing container, docker outage, and transient retry/recovery paths.

## Testing
- go test ./... (store)
- go test ./... (api)
- go test ./... (orchestrator)