### PR TITLE
feat(security): make WAF per deployment with custom-rule defaults

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -258,6 +258,8 @@ func proxyInternalBaseURLFromEnv() string {
 const (
 	hostPortRangeMin = 32768
 	hostPortRangeMax = 60999
+	wafModeDetection = "detection"
+	wafModeEnforce   = "enforcement"
 )
 
 // containerPortOnly strips any user-supplied host port prefix and protocol suffix
@@ -516,9 +518,33 @@ func equalSecurityConfig(existing, request *store.SecurityConfig) bool {
 	}
 
 	return existing.WAFEnabled == request.WAFEnabled &&
+		normalizeWAFMode(existing.WAFMode) == normalizeWAFMode(request.WAFMode) &&
 		slices.Equal(existing.IPDenylist, request.IPDenylist) &&
 		slices.Equal(existing.IPAllowlist, request.IPAllowlist) &&
 		slices.Equal(existing.CustomRules, request.CustomRules)
+}
+
+func normalizeSecurityConfig(cfg *store.SecurityConfig) *store.SecurityConfig {
+	if cfg == nil {
+		return nil
+	}
+	copied := *cfg
+	copied.WAFMode = normalizeWAFMode(copied.WAFMode)
+	return &copied
+}
+
+func normalizeDeploymentSecurity(d store.Deployment) store.Deployment {
+	d.Security = normalizeSecurityConfig(d.Security)
+	return d
+}
+
+func normalizeWAFMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case wafModeEnforce:
+		return wafModeEnforce
+	default:
+		return wafModeDetection
+	}
 }
 
 func updateRequestMatchesExisting(existing store.Deployment, body deploymentRequest, basicAuth *store.BasicAuthConfig) bool {

--- a/api/internal/api/handler_create_deployment.go
+++ b/api/internal/api/handler_create_deployment.go
@@ -45,6 +45,7 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 	if body.Volumes == nil {
 		body.Volumes = []string{}
 	}
+	body.Security = normalizeSecurityConfig(body.Security)
 
 	allDeployments, err := h.store.List()
 	if err != nil {
@@ -86,5 +87,5 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 		Status:       string(store.StatusDeploying),
 	})
 
-	writeJSON(w, http.StatusCreated, created)
+	writeJSON(w, http.StatusCreated, normalizeDeploymentSecurity(created))
 }

--- a/api/internal/api/handler_get_deployment.go
+++ b/api/internal/api/handler_get_deployment.go
@@ -20,7 +20,7 @@ func (h *Handler) getDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := deploymentResponse{Deployment: d}
+	response := deploymentResponse{Deployment: normalizeDeploymentSecurity(d)}
 	if h.containerStats != nil {
 		if stats, ok := h.containerStats.Get(d.ID); ok {
 			statsCopy := stats

--- a/api/internal/api/handler_list_deployments.go
+++ b/api/internal/api/handler_list_deployments.go
@@ -23,7 +23,7 @@ func (h *Handler) listDeployments(w http.ResponseWriter, _ *http.Request) {
 
 	responses := make([]deploymentResponse, 0, len(deployments))
 	for _, deployment := range deployments {
-		response := deploymentResponse{Deployment: deployment}
+		response := deploymentResponse{Deployment: normalizeDeploymentSecurity(deployment)}
 		if h.containerStats != nil {
 			if stats, ok := h.containerStats.Get(deployment.ID); ok {
 				statsCopy := stats

--- a/api/internal/api/handler_patch_deployment.go
+++ b/api/internal/api/handler_patch_deployment.go
@@ -22,6 +22,7 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "domain is reserved for dashboard", http.StatusConflict)
 		return
 	}
+	body.Security = normalizeSecurityConfig(body.Security)
 
 	basicAuth, err := sanitizeAndHashBasicAuth(body.BasicAuth)
 	if err != nil {
@@ -79,5 +80,5 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	writeJSON(w, http.StatusAccepted, updated)
+	writeJSON(w, http.StatusAccepted, normalizeDeploymentSecurity(updated))
 }

--- a/api/internal/api/handler_proxy_observability.go
+++ b/api/internal/api/handler_proxy_observability.go
@@ -25,8 +25,6 @@ type SecurityConfig struct {
 	SuspiciousWindowSeconds   int64    `json:"suspiciousWindowSeconds"`
 	SuspiciousThreshold       int      `json:"suspiciousThreshold"`
 	SuspiciousBlockForSeconds int64    `json:"suspiciousBlockForSeconds"`
-	WAFEnabled                bool     `json:"wafEnabled"`
-	WAFMode                   string   `json:"wafMode,omitempty"`
 	GlobalIPDenylist          []string `json:"globalIpDenylist,omitempty"`
 	GlobalIPAllowlist         []string `json:"globalIpAllowlist,omitempty"`
 }

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -2729,6 +2729,9 @@ func TestCreateDeployment_PersistsSecurityConfig(t *testing.T) {
 	if created.Security == nil || !created.Security.WAFEnabled {
 		t.Fatalf("want security config persisted, got %#v", created.Security)
 	}
+	if created.Security.WAFMode != "detection" {
+		t.Fatalf("want default waf mode detection, got %q", created.Security.WAFMode)
+	}
 	if len(created.Security.IPAllowlist) != 1 || created.Security.IPAllowlist[0] != "203.0.113.0/24" {
 		t.Fatalf("want ip allowlist persisted, got %#v", created.Security)
 	}
@@ -2773,5 +2776,8 @@ func TestPatchDeployment_UpdatesSecurityConfig(t *testing.T) {
 	}
 	if updated.Security == nil || !updated.Security.WAFEnabled {
 		t.Fatalf("want security config updated, got %#v", updated.Security)
+	}
+	if updated.Security.WAFMode != "detection" {
+		t.Fatalf("want default waf mode detection on patch, got %q", updated.Security.WAFMode)
 	}
 }

--- a/api/internal/api/handler_update_deployment.go
+++ b/api/internal/api/handler_update_deployment.go
@@ -40,6 +40,7 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 	if body.Volumes == nil {
 		body.Volumes = []string{}
 	}
+	body.Security = normalizeSecurityConfig(body.Security)
 
 	existing, err := h.store.Get(id)
 	if err != nil {
@@ -65,7 +66,7 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 	body.Ports = assignedPorts
 
 	if updateRequestMatchesExisting(existing, body, basicAuth) {
-		writeJSON(w, http.StatusOK, existing)
+		writeJSON(w, http.StatusOK, normalizeDeploymentSecurity(existing))
 		return
 	}
 
@@ -100,5 +101,5 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	writeJSON(w, http.StatusOK, updated)
+	writeJSON(w, http.StatusOK, normalizeDeploymentSecurity(updated))
 }

--- a/dashboard/src/deployments/DeploymentSecurityPanel.test.tsx
+++ b/dashboard/src/deployments/DeploymentSecurityPanel.test.tsx
@@ -6,7 +6,6 @@ import { DeploymentSecurityPanel } from './DeploymentSecurityPanel'
 import * as api from '../lib/api'
 
 vi.mock('../lib/api', () => ({
-  getSecurityConfig: vi.fn(),
   patchDeployment: vi.fn(),
 }))
 
@@ -32,16 +31,6 @@ const deployment: api.Deployment = {
 describe('DeploymentSecurityPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(api.getSecurityConfig).mockResolvedValue({
-      profile: 'standard',
-      suspiciousWindowSeconds: 30,
-      suspiciousThreshold: 10,
-      suspiciousBlockForSeconds: 120,
-      wafEnabled: true,
-      wafMode: 'detection',
-      globalIpDenylist: [],
-      globalIpAllowlist: [],
-    })
   })
 
   it('rejects invalid CIDR entries client-side', async () => {
@@ -60,6 +49,7 @@ describe('DeploymentSecurityPanel', () => {
       ...deployment,
       security: {
         waf_enabled: false,
+        waf_mode: 'detection',
         ip_denylist: ['10.0.0.0/8'],
         ip_allowlist: ['203.0.113.0/24'],
         custom_rules: ['SecRule REQUEST_URI "@contains blocked" "id:10001,phase:1,deny,status:403"'],
@@ -81,6 +71,7 @@ describe('DeploymentSecurityPanel', () => {
       expect(vi.mocked(api.patchDeployment)).toHaveBeenCalledWith('dep-1', {
         security: {
           waf_enabled: false,
+          waf_mode: 'detection',
           ip_denylist: ['10.0.0.0/8'],
           ip_allowlist: ['203.0.113.0/24'],
           custom_rules: ['SecRule REQUEST_URI "@contains blocked" "id:10001,phase:1,deny,status:403"'],

--- a/dashboard/src/deployments/DeploymentSecurityPanel.tsx
+++ b/dashboard/src/deployments/DeploymentSecurityPanel.tsx
@@ -1,10 +1,10 @@
 import { type FormEvent } from 'react'
-import { useQuery } from '@tanstack/react-query'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Label } from '../components/ui/label'
-import { getSecurityConfig, type Deployment } from '../lib/api'
+import { type Deployment } from '../lib/api'
 import { SecurityCIDRListField } from './SecurityCIDRListField'
+import { splitRules } from './securityConfig'
 import { useDeploymentSecurityForm } from './useDeploymentSecurityForm'
 
 type Props = {
@@ -12,13 +12,8 @@ type Props = {
 }
 
 export function DeploymentSecurityPanel({ deployment }: Props) {
-  const securityQuery = useQuery({
-    queryKey: ['security-config'],
-    queryFn: getSecurityConfig,
-  })
-  const globalWAFEnabled = securityQuery.data?.wafEnabled ?? true
-
-  const form = useDeploymentSecurityForm(deployment, globalWAFEnabled)
+  const form = useDeploymentSecurityForm(deployment)
+  const customRuleCount = splitRules(form.customRulesText).length
 
   function handleSubmit(event: FormEvent) {
     event.preventDefault()
@@ -32,18 +27,10 @@ export function DeploymentSecurityPanel({ deployment }: Props) {
           <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/60">Security</p>
           <p className="mt-1 text-xs text-muted-foreground">Configure per-deployment WAF, IP filtering, and custom rules.</p>
         </div>
-        {securityQuery.data?.wafMode ? (
-          <Badge variant="info" className="capitalize">
-            Global mode: {securityQuery.data.wafMode}
-          </Badge>
-        ) : null}
+        <Badge variant={form.config.waf_mode === 'enforcement' ? 'destructive' : 'warning'} className="capitalize">
+          Mode: {form.config.waf_mode}
+        </Badge>
       </div>
-
-      {!securityQuery.isLoading && securityQuery.data?.wafEnabled === false ? (
-        <p className="mt-3 rounded-md border border-amber-300/50 bg-amber-50 px-3 py-2 text-xs text-amber-900">
-          Global WAF is disabled. Enabling WAF here will not take effect until global WAF is enabled.
-        </p>
-      ) : null}
 
       <form onSubmit={handleSubmit} className="mt-4 space-y-4">
         <label className="flex items-center gap-2 text-sm text-foreground">
@@ -54,6 +41,19 @@ export function DeploymentSecurityPanel({ deployment }: Props) {
           />
           Enable WAF for this deployment
         </label>
+
+        <div className="space-y-2">
+          <Label htmlFor={`security-waf-mode-${deployment.id}`}>WAF mode</Label>
+          <select
+            id={`security-waf-mode-${deployment.id}`}
+            value={form.config.waf_mode}
+            onChange={event => form.setWAFMode(event.target.value as 'detection' | 'enforcement')}
+            className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm text-foreground shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+          >
+            <option value="detection">Detection (log only)</option>
+            <option value="enforcement">Enforcement (block requests)</option>
+          </select>
+        </div>
 
         <SecurityCIDRListField
           id={`security-denylist-${deployment.id}`}
@@ -89,6 +89,24 @@ export function DeploymentSecurityPanel({ deployment }: Props) {
             className="min-h-28 w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs text-foreground shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
           />
           <p className="text-xs text-muted-foreground">Use one ModSecurity SecRule per line.</p>
+        </div>
+
+        <div className="space-y-2 rounded-md border border-border/60 bg-background/60 p-3">
+          <p className="text-xs font-medium text-foreground">Effective rules for this deployment</p>
+          <ul className="space-y-1 text-xs text-muted-foreground">
+            <li>Custom deployment rules: {customRuleCount}</li>
+            <li>
+              Rule syntax guide:{' '}
+              <a
+                href="https://coraza.io/docs/seclang/directives/"
+                target="_blank"
+                rel="noreferrer"
+                className="text-sky-700 underline decoration-sky-300 underline-offset-2 transition-colors hover:text-sky-800"
+              >
+                Coraza SecLang directives
+              </a>
+            </li>
+          </ul>
         </div>
 
         {form.inputError ? <p className="text-xs text-destructive">{form.inputError}</p> : null}

--- a/dashboard/src/deployments/securityConfig.ts
+++ b/dashboard/src/deployments/securityConfig.ts
@@ -45,9 +45,10 @@ export function isValidCIDROrIP(input: string) {
   return false
 }
 
-export function toSecurityConfig(security: Deployment['security'], defaultWAFEnabled: boolean): SecurityConfig {
+export function toSecurityConfig(security: Deployment['security']): SecurityConfig {
   return {
-    waf_enabled: security?.waf_enabled ?? defaultWAFEnabled,
+    waf_enabled: security?.waf_enabled ?? true,
+    waf_mode: security?.waf_mode ?? 'detection',
     ip_denylist: security?.ip_denylist ?? [],
     ip_allowlist: security?.ip_allowlist ?? [],
     custom_rules: security?.custom_rules ?? [],
@@ -65,10 +66,11 @@ export function splitRules(value: string) {
     .filter(Boolean)
 }
 
-export function hasSecurityChanges(config: SecurityConfig, existing: Deployment['security'], globalWAFEnabled: boolean) {
+export function hasSecurityChanges(config: SecurityConfig, existing: Deployment['security']) {
   if (!existing) {
     return (
-      config.waf_enabled !== globalWAFEnabled ||
+      config.waf_enabled !== true ||
+      config.waf_mode !== 'detection' ||
       config.ip_denylist.length > 0 ||
       config.ip_allowlist.length > 0 ||
       config.custom_rules.length > 0

--- a/dashboard/src/deployments/useDeploymentSecurityForm.ts
+++ b/dashboard/src/deployments/useDeploymentSecurityForm.ts
@@ -7,9 +7,9 @@ type ListKey = 'ip_denylist' | 'ip_allowlist'
 
 const invalidEntryError = 'IP filters must be valid CIDR ranges or IP addresses.'
 
-export function useDeploymentSecurityForm(deployment: Deployment, globalWAFEnabled: boolean) {
+export function useDeploymentSecurityForm(deployment: Deployment) {
   const queryClient = useQueryClient()
-  const [config, setConfig] = useState<SecurityConfig>(() => toSecurityConfig(deployment.security, globalWAFEnabled))
+  const [config, setConfig] = useState<SecurityConfig>(() => toSecurityConfig(deployment.security))
   const [customRulesText, setCustomRulesText] = useState(() => joinRules(deployment.security?.custom_rules ?? []))
   const [denyInput, setDenyInput] = useState('')
   const [allowInput, setAllowInput] = useState('')
@@ -18,14 +18,14 @@ export function useDeploymentSecurityForm(deployment: Deployment, globalWAFEnabl
   const [isDirty, setIsDirty] = useState(false)
 
   useEffect(() => {
-    setConfig(toSecurityConfig(deployment.security, globalWAFEnabled))
+    setConfig(toSecurityConfig(deployment.security))
     setCustomRulesText(joinRules(deployment.security?.custom_rules ?? []))
     setDenyInput('')
     setAllowInput('')
     setInputError(undefined)
     setFormError(undefined)
     setIsDirty(false)
-  }, [deployment.id, deployment.security, globalWAFEnabled])
+  }, [deployment.id, deployment.security])
 
   const mutation = useMutation({
     mutationFn: (security: SecurityConfig) => patchDeployment(deployment.id, { security }),
@@ -42,8 +42,8 @@ export function useDeploymentSecurityForm(deployment: Deployment, globalWAFEnabl
   })
 
   const hasChanges = useMemo(
-    () => hasSecurityChanges(config, deployment.security, globalWAFEnabled),
-    [config, deployment.security, globalWAFEnabled]
+    () => hasSecurityChanges(config, deployment.security),
+    [config, deployment.security]
   )
 
   function setWAFEnabled(enabled: boolean) {
@@ -53,6 +53,11 @@ export function useDeploymentSecurityForm(deployment: Deployment, globalWAFEnabl
 
   function setCustomRules(value: string) {
     setCustomRulesText(value)
+    setIsDirty(true)
+  }
+
+  function setWAFMode(mode: SecurityConfig['waf_mode']) {
+    setConfig(prev => ({ ...prev, waf_mode: mode }))
     setIsDirty(true)
   }
 
@@ -118,6 +123,7 @@ export function useDeploymentSecurityForm(deployment: Deployment, globalWAFEnabl
     setDenyInput,
     setAllowInput,
     setWAFEnabled,
+    setWAFMode,
     setCustomRules,
     addDenyEntry: (value: string) => addEntry('ip_denylist', value),
     addAllowEntry: (value: string) => addEntry('ip_allowlist', value),

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -11,6 +11,7 @@ export type BasicAuthConfig = {
 
 export type SecurityConfig = {
   waf_enabled: boolean
+  waf_mode: 'detection' | 'enforcement'
   ip_denylist: string[]
   ip_allowlist: string[]
   custom_rules: string[]
@@ -115,8 +116,6 @@ export type ProxySecurityConfig = {
   suspiciousWindowSeconds: number
   suspiciousThreshold: number
   suspiciousBlockForSeconds: number
-  wafEnabled: boolean
-  wafMode?: string
   globalIpDenylist?: string[]
   globalIpAllowlist?: string[]
 }

--- a/dashboard/src/pages/TrafficPage.tsx
+++ b/dashboard/src/pages/TrafficPage.tsx
@@ -97,18 +97,6 @@ export function TrafficPage() {
     return `Blocked until ${date.toLocaleTimeString()}`
   }
 
-  const wafMode = securityConfig.data?.wafMode ?? 'off'
-
-  const wafModeVariant = () => {
-    if (wafMode === 'enforcement') {
-      return 'destructive' as const
-    }
-    if (wafMode === 'detection') {
-      return 'warning' as const
-    }
-    return 'secondary' as const
-  }
-
   return (
     <div className="space-y-5">
       <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">
@@ -198,14 +186,9 @@ export function TrafficPage() {
           <div>
             <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Global security</p>
             <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">
-              Effective WAF and IP filtering mode
+              Global IP filtering posture
             </h2>
           </div>
-          {securityConfig.isLoading ? null : securityConfig.isError ? null : (
-            <Badge variant={wafModeVariant()} className="capitalize">
-              WAF mode: {wafMode}
-            </Badge>
-          )}
         </div>
 
         {securityConfig.isLoading ? (

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -63,12 +63,7 @@ func main() {
 		log.Fatalf("proxy: %v", err)
 	}
 	uaFilter := middleware.NewUAFilter(hardeningProfile == handler.HardeningStrict, parseCSVList(os.Getenv("DIRIGENT_UA_BLOCK_LIST")))
-	wafEnabled := strings.EqualFold(strings.TrimSpace(os.Getenv("DIRIGENT_WAF_ENABLED")), "true")
-	wafMode, err := wafModeFromEnv()
-	if err != nil {
-		log.Fatalf("proxy: %v", err)
-	}
-	waf, err := middleware.NewWAF(wafEnabled, wafMode)
+	waf, err := middleware.NewWAF()
 	if err != nil {
 		log.Fatalf("proxy: initialize waf: %v", err)
 	}
@@ -87,11 +82,7 @@ func main() {
 	}
 
 	log.Printf("proxy: hardening profile %s", hardeningProfile)
-	if wafEnabled {
-		log.Printf("proxy: waf enabled (mode=%s)", wafMode)
-	} else {
-		log.Printf("proxy: waf disabled")
-	}
+	log.Printf("proxy: waf initialized for per-deployment mode")
 
 	interval := 5 * time.Second
 	if v := os.Getenv("DIRIGENT_POLL_INTERVAL"); v != "" {
@@ -324,16 +315,6 @@ func accessLogConfigFromEnv() (handler.AccessLogConfig, error) {
 		Retention:       retention,
 		WhitelistedKeys: headers,
 	}, nil
-}
-
-func wafModeFromEnv() (middleware.WAFMode, error) {
-	raw := strings.ToLower(strings.TrimSpace(envOrDefault("DIRIGENT_WAF_MODE", string(middleware.WAFModeDetection))))
-	switch middleware.WAFMode(raw) {
-	case middleware.WAFModeDetection, middleware.WAFModeEnforcement:
-		return middleware.WAFMode(raw), nil
-	default:
-		return "", fmt.Errorf("DIRIGENT_WAF_MODE must be one of: detection, enforcement")
-	}
 }
 
 func parseCSVList(raw string) []string {

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -134,8 +134,6 @@ type HardeningSettings struct {
 	SuspiciousWindowSeconds   int64            `json:"suspiciousWindowSeconds"`
 	SuspiciousThreshold       int              `json:"suspiciousThreshold"`
 	SuspiciousBlockForSeconds int64            `json:"suspiciousBlockForSeconds"`
-	WAFEnabled                bool             `json:"wafEnabled"`
-	WAFMode                   string           `json:"wafMode,omitempty"`
 	GlobalIPDenylist          []string         `json:"globalIpDenylist,omitempty"`
 	GlobalIPAllowlist         []string         `json:"globalIpAllowlist,omitempty"`
 }
@@ -254,10 +252,12 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.waf != nil && applyWAF {
 		customRules := []string(nil)
+		mode := middleware.WAFModeDetection
 		if route.Security != nil {
 			customRules = route.Security.CustomRules
+			mode = middleware.WAFMode(route.Security.WAFMode)
 		}
-		result, err := h.waf.Evaluate(r, client, customRules)
+		result, err := h.waf.Evaluate(r, client, mode, customRules)
 		if err != nil {
 			log.Printf("proxy: waf evaluate: %v", err)
 		} else {
@@ -333,10 +333,6 @@ func (h *Handler) securityConfig(w http.ResponseWriter, _ *http.Request) {
 		cfg.SuspiciousWindowSeconds = int64(h.scanner.window.Seconds())
 		cfg.SuspiciousThreshold = h.scanner.threshold
 		cfg.SuspiciousBlockForSeconds = int64(h.scanner.blockFor.Seconds())
-	}
-	if h.waf != nil {
-		cfg.WAFEnabled = h.waf.Enabled()
-		cfg.WAFMode = string(h.waf.Mode())
 	}
 	if h.ipFilter != nil {
 		cfg.GlobalIPDenylist, cfg.GlobalIPAllowlist = h.ipFilter.GlobalConfig()

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -465,10 +465,11 @@ func TestProxy_DashboardDomainBypassesWAF(t *testing.T) {
 	tbl := newTestTable()
 	tbl.Set("dashboard.example.com", backend.Listener.Addr().String(), nil, &store.SecurityConfig{
 		WAFEnabled:  true,
+		WAFMode:     "enforcement",
 		CustomRules: []string{wafRule},
 	})
 
-	waf, err := middleware.NewWAF(true, middleware.WAFModeEnforcement)
+	waf, err := middleware.NewWAF()
 	if err != nil {
 		t.Fatalf("NewWAF enforcement: %v", err)
 	}
@@ -978,13 +979,13 @@ func TestProxy_WAFDetectionAndEnforcement(t *testing.T) {
 	wafRule := `SecRule REQUEST_URI "@contains waf-trigger" "id:10099,phase:1,deny,status:403,log,msg:'waf trigger'"`
 
 	newRoute := func() *store.SecurityConfig {
-		return &store.SecurityConfig{WAFEnabled: true, CustomRules: []string{wafRule}}
+		return &store.SecurityConfig{WAFEnabled: true, WAFMode: "detection", CustomRules: []string{wafRule}}
 	}
 
 	// detection mode should not block but should mark request as detected.
 	tblDetection := newTestTable()
 	tblDetection.Set("example.com", backend.Listener.Addr().String(), nil, newRoute())
-	wafDetection, err := middleware.NewWAF(true, middleware.WAFModeDetection)
+	wafDetection, err := middleware.NewWAF()
 	if err != nil {
 		t.Fatalf("NewWAF detection: %v", err)
 	}
@@ -1004,8 +1005,8 @@ func TestProxy_WAFDetectionAndEnforcement(t *testing.T) {
 
 	// enforcement mode should block and increment waf blocked counter.
 	tblEnforcement := newTestTable()
-	tblEnforcement.Set("example.com", backend.Listener.Addr().String(), nil, newRoute())
-	wafEnforcement, err := middleware.NewWAF(true, middleware.WAFModeEnforcement)
+	tblEnforcement.Set("example.com", backend.Listener.Addr().String(), nil, &store.SecurityConfig{WAFEnabled: true, WAFMode: "enforcement", CustomRules: []string{wafRule}})
+	wafEnforcement, err := middleware.NewWAF()
 	if err != nil {
 		t.Fatalf("NewWAF enforcement: %v", err)
 	}

--- a/proxy/internal/middleware/waf.go
+++ b/proxy/internal/middleware/waf.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	coreruleset "github.com/corazawaf/coraza-coreruleset"
 	"github.com/corazawaf/coraza/v3"
 )
 
@@ -28,45 +27,39 @@ type WAFResult struct {
 }
 
 type WAF struct {
-	enabled bool
-	mode    WAFMode
-	baseWAF coraza.WAF
+	baseWAFByMode map[WAFMode]coraza.WAF
 
 	mu    sync.RWMutex
 	cache map[string]coraza.WAF
 }
 
-func NewWAF(enabled bool, mode WAFMode) (*WAF, error) {
-	mode = normalizeWAFMode(mode)
-	w := &WAF{enabled: enabled, mode: mode, cache: make(map[string]coraza.WAF)}
-	if !enabled {
-		return w, nil
-	}
-	base, err := buildCorazaWAF(mode, nil)
+func NewWAF() (*WAF, error) {
+	baseDetection, err := buildCorazaWAF(WAFModeDetection, nil)
 	if err != nil {
 		return nil, err
 	}
-	w.baseWAF = base
+	baseEnforcement, err := buildCorazaWAF(WAFModeEnforcement, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &WAF{
+		baseWAFByMode: map[WAFMode]coraza.WAF{
+			WAFModeDetection:   baseDetection,
+			WAFModeEnforcement: baseEnforcement,
+		},
+		cache: make(map[string]coraza.WAF),
+	}
 	return w, nil
 }
 
-func (w *WAF) Enabled() bool {
-	return w != nil && w.enabled
-}
-
-func (w *WAF) Mode() WAFMode {
+func (w *WAF) Evaluate(r *http.Request, clientIP string, mode WAFMode, customRules []string) (WAFResult, error) {
 	if w == nil {
-		return WAFModeDetection
-	}
-	return normalizeWAFMode(w.mode)
-}
-
-func (w *WAF) Evaluate(r *http.Request, clientIP string, customRules []string) (WAFResult, error) {
-	if w == nil || !w.enabled || w.baseWAF == nil {
 		return WAFResult{}, nil
 	}
+	mode = normalizeWAFMode(mode)
 
-	wafInstance, err := w.wafForRules(customRules)
+	wafInstance, err := w.wafForRules(mode, customRules)
 	if err != nil {
 		return WAFResult{}, err
 	}
@@ -95,7 +88,7 @@ func (w *WAF) Evaluate(r *http.Request, clientIP string, customRules []string) (
 	}
 
 	if interruption := tx.ProcessRequestHeaders(); interruption != nil {
-		if w.mode == WAFModeEnforcement {
+		if mode == WAFModeEnforcement {
 			return WAFResult{Blocked: true, Status: interruptionStatus(interruption.Status)}, nil
 		}
 		return WAFResult{Detected: true}, nil
@@ -111,7 +104,7 @@ func (w *WAF) Evaluate(r *http.Request, clientIP string, customRules []string) (
 			if interruption, _, writeErr := tx.WriteRequestBody(body); writeErr != nil {
 				return WAFResult{}, writeErr
 			} else if interruption != nil {
-				if w.mode == WAFModeEnforcement {
+				if mode == WAFModeEnforcement {
 					return WAFResult{Blocked: true, Status: interruptionStatus(interruption.Status)}, nil
 				}
 				return WAFResult{Detected: true}, nil
@@ -122,26 +115,31 @@ func (w *WAF) Evaluate(r *http.Request, clientIP string, customRules []string) (
 	if interruption, err := tx.ProcessRequestBody(); err != nil {
 		return WAFResult{}, err
 	} else if interruption != nil {
-		if w.mode == WAFModeEnforcement {
+		if mode == WAFModeEnforcement {
 			return WAFResult{Blocked: true, Status: interruptionStatus(interruption.Status)}, nil
 		}
 		return WAFResult{Detected: true}, nil
 	}
 
-	if w.mode == WAFModeDetection && len(tx.MatchedRules()) > 0 {
+	if mode == WAFModeDetection && len(tx.MatchedRules()) > 0 {
 		return WAFResult{Detected: true}, nil
 	}
 
 	return WAFResult{}, nil
 }
 
-func (w *WAF) wafForRules(customRules []string) (coraza.WAF, error) {
-	rules := normalizeRules(customRules)
-	if len(rules) == 0 {
-		return w.baseWAF, nil
+func (w *WAF) wafForRules(mode WAFMode, customRules []string) (coraza.WAF, error) {
+	baseWAF := w.baseWAFByMode[mode]
+	if baseWAF == nil {
+		return nil, fmt.Errorf("waf base mode %q is unavailable", mode)
 	}
 
-	key := strings.Join(rules, "\n")
+	rules := normalizeRules(customRules)
+	if len(rules) == 0 {
+		return baseWAF, nil
+	}
+
+	key := string(mode) + "\n" + strings.Join(rules, "\n")
 	w.mu.RLock()
 	cached := w.cache[key]
 	w.mu.RUnlock()
@@ -149,7 +147,7 @@ func (w *WAF) wafForRules(customRules []string) (coraza.WAF, error) {
 		return cached, nil
 	}
 
-	built, err := buildCorazaWAF(w.mode, rules)
+	built, err := buildCorazaWAF(mode, rules)
 	if err != nil {
 		return nil, err
 	}
@@ -171,10 +169,7 @@ func buildCorazaWAF(mode WAFMode, customRules []string) (coraza.WAF, error) {
 	}
 
 	directives := strings.Builder{}
-	directives.WriteString("Include @coraza.conf-recommended\n")
-	directives.WriteString("Include @crs-setup.conf.example\n")
 	directives.WriteString(fmt.Sprintf("SecRuleEngine %s\n", ruleEngine))
-	directives.WriteString("Include @owasp_crs/*.conf\n")
 	for _, rule := range normalizeRules(customRules) {
 		directives.WriteString(rule)
 		directives.WriteString("\n")
@@ -182,7 +177,6 @@ func buildCorazaWAF(mode WAFMode, customRules []string) (coraza.WAF, error) {
 
 	return coraza.NewWAF(
 		coraza.NewWAFConfig().
-			WithRootFS(coreruleset.FS).
 			WithRequestBodyAccess().
 			WithDirectives(directives.String()),
 	)

--- a/proxy/internal/middleware/waf_test.go
+++ b/proxy/internal/middleware/waf_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestWAF_EnforcementBlocksCustomRuleMatch(t *testing.T) {
-	waf, err := middleware.NewWAF(true, middleware.WAFModeEnforcement)
+	waf, err := middleware.NewWAF()
 	if err != nil {
 		t.Fatalf("NewWAF: %v", err)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/waf-trigger", nil)
-	result, err := waf.Evaluate(req, "203.0.113.7", []string{
+	result, err := waf.Evaluate(req, "203.0.113.7", middleware.WAFModeEnforcement, []string{
 		`SecRule REQUEST_URI "@contains waf-trigger" "id:10000,phase:1,deny,status:403,log,msg:'waf trigger'"`,
 	})
 	if err != nil {
@@ -27,13 +27,13 @@ func TestWAF_EnforcementBlocksCustomRuleMatch(t *testing.T) {
 }
 
 func TestWAF_DetectionMarksMatchWithoutBlocking(t *testing.T) {
-	waf, err := middleware.NewWAF(true, middleware.WAFModeDetection)
+	waf, err := middleware.NewWAF()
 	if err != nil {
 		t.Fatalf("NewWAF: %v", err)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/waf-trigger", nil)
-	result, err := waf.Evaluate(req, "203.0.113.7", []string{
+	result, err := waf.Evaluate(req, "203.0.113.7", middleware.WAFModeDetection, []string{
 		`SecRule REQUEST_URI "@contains waf-trigger" "id:10001,phase:1,deny,status:403,log,msg:'waf trigger'"`,
 	})
 	if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -71,6 +71,7 @@ type BasicAuthUser struct {
 
 type SecurityConfig struct {
 	WAFEnabled  bool     `json:"waf_enabled"`
+	WAFMode     string   `json:"waf_mode,omitempty"`
 	IPDenylist  []string `json:"ip_denylist,omitempty"`
 	IPAllowlist []string `json:"ip_allowlist,omitempty"`
 	CustomRules []string `json:"custom_rules,omitempty"`

--- a/website/src/content/docs/deployment-configuration.md
+++ b/website/src/content/docs/deployment-configuration.md
@@ -13,6 +13,7 @@ A deployment is the central object in Dirigent. It describes a container you wan
 | envs    | object   | No       | Environment variables passed into the container as a key-value map. Values are stored in the Dirigent data file on disk. Example: `{"DATABASE_URL": "postgres://..."}`. |
 | domain  | string   | No       | A fully-qualified domain name to route to this container via the integrated reverse proxy. Point your DNS A record to the VPS IP, and Dirigent will forward HTTP traffic on port 80. Example: `api.example.com`. |
 | basic_auth | object | No       | Require HTTP Basic Auth on the proxy route for this deployment. Only applies when `domain` is set. Contains a `users` list of `{ username, password }` pairs. |
+| security | object | No | Per-deployment traffic security settings. Includes `waf_enabled`, `waf_mode` (`detection` or `enforcement`), `ip_denylist`, `ip_allowlist`, and `custom_rules`. |
 
 ## Ports
 
@@ -75,6 +76,62 @@ You can protect a domain-exposed deployment with HTTP Basic Auth. When configure
 Set credentials in the dashboard when creating or editing a deployment. Multiple users can be added — useful for granting access to teammates without sharing a single credential.
 
 > **Security note:** Basic Auth over plain HTTP transmits credentials in base64. Combine with HTTPS termination (via an upstream proxy or CDN) for production use.
+
+## WAF rules
+
+WAF behavior is configured per deployment in **Security** on the deployment details page.
+
+- `waf_enabled`: toggles WAF for this deployment only.
+- `waf_mode`: `detection` (log only) or `enforcement` (block matching requests).
+- `custom_rules`: one ModSecurity/Coraza rule per line.
+
+By default, `custom_rules` is empty. Add only the rules you want for each deployment.
+
+Coraza rule syntax reference:
+
+- [Coraza SecLang directives](https://coraza.io/docs/seclang/directives/)
+
+Example starter rules:
+
+```text
+# Block direct probes for common sensitive files.
+SecRule REQUEST_URI "@rx (?i)^/(\.env|\.git|\.svn|\.DS_Store)$" "id:110001,phase:1,deny,status:403,log,msg:'Sensitive file probe'"
+
+# Block obvious SQL injection patterns in query strings.
+SecRule ARGS "@rx (?i)(union\s+select|or\s+1=1|information_schema)" "id:110002,phase:2,deny,status:403,log,msg:'SQLi pattern in args'"
+
+# Block path traversal attempts.
+SecRule REQUEST_URI "@rx (\.\./|%2e%2e%2f|%252e%252e%252f)" "id:110003,phase:1,deny,status:403,log,msg:'Path traversal attempt'"
+```
+
+> **Rule ID note:** Keep rule IDs unique per deployment to avoid conflicts.
+
+### Copy-paste starter pack
+
+You can start with these additional rules and then tune based on your app behavior.
+
+```text
+# Block command injection separators in common input args.
+SecRule ARGS "@rx (?i)(;|\|\||&&|`|\$\()" "id:110004,phase:2,deny,status:403,log,msg:'Command injection pattern in args'"
+
+# Block requests with known scanner user agents.
+SecRule REQUEST_HEADERS:User-Agent "@rx (?i)(sqlmap|nikto|nmap|masscan|acunetix)" "id:110005,phase:1,deny,status:403,log,msg:'Scanner user-agent blocked'"
+
+# Block direct access to common admin/debug endpoints.
+SecRule REQUEST_URI "@rx (?i)^/(phpmyadmin|wp-admin|wp-login\.php|actuator|_debugbar)" "id:110006,phase:1,deny,status:403,log,msg:'Admin/debug endpoint probe'"
+
+# Restrict methods to common web/API verbs.
+SecRule REQUEST_METHOD "!@within GET POST PUT PATCH DELETE OPTIONS HEAD" "id:110007,phase:1,deny,status:405,log,msg:'Unexpected HTTP method'"
+
+# Block oversized query strings (basic abuse guard).
+SecRule QUERY_STRING "@gt 2048" "id:110008,phase:1,deny,status:414,log,msg:'Query string too long'"
+```
+
+Suggested rollout:
+
+1. Enable `waf_mode: detection` first and review access logs.
+2. Keep rules that catch bad traffic without false positives.
+3. Switch to `waf_mode: enforcement` after validation.
 
 ## Deployment lifecycle
 

--- a/website/src/content/docs/production-readiness.md
+++ b/website/src/content/docs/production-readiness.md
@@ -98,6 +98,7 @@ journalctl -u dirigent-orchestrator -n 100
 - API/dashboard default exposure is `:8080` unless dashboard domain exposure is configured.
 - Proxy enforces domain routing and optional Basic Auth for dashboard access.
 - Proxy hardening profiles (`standard` or `strict`) block common scanner and sensitive-path traffic.
+- WAF rules are opt-in per deployment via `custom_rules`; no default deployment WAF rule set is applied.
 
 ### Internet-facing hardening checklist
 


### PR DESCRIPTION
## Summary
- move WAF behavior fully to deployment-level config by adding `security.waf_mode` (defaulting to `detection`) and removing global WAF mode/enabled fields from proxy security config responses
- refactor proxy WAF evaluation to use per-deployment mode on each request, remove `DIRIGENT_WAF_ENABLED`/`DIRIGENT_WAF_MODE` startup controls, and load only deployment `custom_rules` by default
- update dashboard security UI to edit per-deployment mode, show effective rule transparency on deployment details, remove global WAF mode display from Traffic, and document custom-rule usage with starter examples in website docs

## Validation
- `go test ./...` (api)
- `go test ./...` (proxy)
- `bun x vitest run src/deployments/DeploymentSecurityPanel.test.tsx` (dashboard)
- `bun run build` (dashboard)