### PR TITLE
feat(dashboard): add logs view for core services and deployments

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -44,6 +44,7 @@ type EventBus interface {
 // container is currently running for the deployment.
 type DockerLogs interface {
 	StreamLogs(ctx context.Context, deploymentID string, tail int) (io.ReadCloser, error)
+	RecentLogs(ctx context.Context, deploymentID string, tail int) ([]string, error)
 }
 
 type VersionInfoProvider interface {
@@ -188,6 +189,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/deployments", h.listDeployments)
 	mux.HandleFunc("GET /api/system-status", h.systemStatus)
 	mux.HandleFunc("GET /api/system-status/events", h.systemStatusEvents)
+	mux.HandleFunc("GET /api/core-services/logs", h.coreServiceLogs)
 	mux.HandleFunc("GET /api/load-balancer/access-logs", h.loadBalancerAccessLogs)
 	mux.HandleFunc("POST /api/system-status/orchestrator-heartbeat", h.recordOrchestratorHeartbeat)
 	mux.HandleFunc("GET /api/version", h.getVersion)
@@ -199,6 +201,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/deployments", h.createDeployment)
 	mux.HandleFunc("GET /api/deployments/events", h.deploymentEvents)
 	mux.HandleFunc("GET /api/deployments/{id}/logs", h.deploymentLogs)
+	mux.HandleFunc("GET /api/deployments/{id}/logs/recent", h.deploymentRecentLogs)
 	mux.HandleFunc("GET /api/deployments/{id}", h.getDeployment)
 	mux.HandleFunc("PUT /api/deployments/{id}", h.updateDeployment)
 	mux.HandleFunc("POST /api/deployments/{id}/restart", h.restartDeployment)

--- a/api/internal/api/handler_core_service_logs.go
+++ b/api/internal/api/handler_core_service_logs.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultCoreServiceLogTail = 200
+	maxCoreServiceLogTail     = 1000
+)
+
+var coreServiceUnits = map[string]string{
+	"api":          "dirigent-api",
+	"orchestrator": "dirigent-orchestrator",
+	"proxy":        "dirigent-proxy",
+}
+
+type coreServiceLogsResponse struct {
+	Service string   `json:"service"`
+	Lines   []string `json:"lines"`
+}
+
+func (h *Handler) coreServiceLogs(w http.ResponseWriter, r *http.Request) {
+	service := strings.TrimSpace(r.URL.Query().Get("service"))
+	unit, ok := coreServiceUnits[service]
+	if !ok {
+		http.Error(w, "service must be one of: api, orchestrator, proxy", http.StatusBadRequest)
+		return
+	}
+
+	tail, err := parseCoreServiceLogTail(r.URL.Query().Get("tail"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	lines, err := readJournalctlUnitLogs(r.Context(), unit, tail)
+	if err != nil {
+		log.Printf("coreServiceLogs: read %s logs: %v", service, err)
+		http.Error(w, "failed to read service logs", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, coreServiceLogsResponse{Service: service, Lines: lines})
+}
+
+func parseCoreServiceLogTail(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultCoreServiceLogTail, nil
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("tail must be a positive integer")
+	}
+	if n > maxCoreServiceLogTail {
+		n = maxCoreServiceLogTail
+	}
+
+	return n, nil
+}
+
+func readJournalctlUnitLogs(ctx context.Context, unit string, tail int) ([]string, error) {
+	if strings.TrimSpace(unit) == "" {
+		return nil, errors.New("unit is required")
+	}
+
+	cmd := exec.CommandContext(
+		ctx,
+		"journalctl",
+		"--no-pager",
+		"--output=short-iso",
+		"-u",
+		unit,
+		"-n",
+		strconv.Itoa(tail),
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil, context.Canceled
+		}
+		return nil, fmt.Errorf("journalctl: %w (%s)", err, strings.TrimSpace(string(output)))
+	}
+
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return []string{}, nil
+	}
+
+	return strings.Split(trimmed, "\n"), nil
+}

--- a/api/internal/api/handler_deployment_recent_logs.go
+++ b/api/internal/api/handler_deployment_recent_logs.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/ercadev/dirigent/store"
+)
+
+const (
+	defaultRecentDeploymentLogTail = 300
+	maxRecentDeploymentLogTail     = 1000
+)
+
+type deploymentRecentLogsResponse struct {
+	DeploymentID string   `json:"deploymentId"`
+	Lines        []string `json:"lines"`
+}
+
+func (h *Handler) deploymentRecentLogs(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if _, err := h.store.Get(id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(w, "deployment not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to get deployment", http.StatusInternalServerError)
+		return
+	}
+
+	tail, err := parseRecentDeploymentLogTail(r.URL.Query().Get("tail"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	lines, err := h.dockerLogs.RecentLogs(r.Context(), id, tail)
+	if err != nil {
+		http.Error(w, "failed to read deployment logs", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, deploymentRecentLogsResponse{DeploymentID: id, Lines: lines})
+}
+
+func parseRecentDeploymentLogTail(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultRecentDeploymentLogTail, nil
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("tail must be a positive integer")
+	}
+	if n > maxRecentDeploymentLogTail {
+		n = maxRecentDeploymentLogTail
+	}
+
+	return n, nil
+}

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -147,14 +147,30 @@ func (noopDockerLogs) StreamLogs(_ context.Context, _ string, _ int) (io.ReadClo
 	return nil, nil
 }
 
+func (noopDockerLogs) RecentLogs(_ context.Context, _ string, _ int) ([]string, error) {
+	return []string{}, nil
+}
+
 // stubDockerLogs satisfies api.DockerLogs and returns the configured reader or error.
 type stubDockerLogs struct {
-	rc  io.ReadCloser
-	err error
+	rc         io.ReadCloser
+	err        error
+	recentLogs []string
+	recentErr  error
 }
 
 func (s *stubDockerLogs) StreamLogs(_ context.Context, _ string, _ int) (io.ReadCloser, error) {
 	return s.rc, s.err
+}
+
+func (s *stubDockerLogs) RecentLogs(_ context.Context, _ string, _ int) ([]string, error) {
+	if s.recentErr != nil {
+		return nil, s.recentErr
+	}
+	if s.recentLogs == nil {
+		return []string{}, nil
+	}
+	return s.recentLogs, nil
 }
 
 func newTestServer(s api.Store) *httptest.Server {
@@ -2254,6 +2270,101 @@ func TestRestartDeployment_StoreError(t *testing.T) {
 	}
 }
 
+func TestCoreServiceLogs_OK(t *testing.T) {
+	setFakeJournalctl(t, "printf 'line one\nline two\n'")
+
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/core-services/logs?service=api&tail=2")
+	if err != nil {
+		t.Fatalf("GET /api/core-services/logs: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Service string   `json:"service"`
+		Lines   []string `json:"lines"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body.Service != "api" {
+		t.Fatalf("want service api, got %q", body.Service)
+	}
+	if len(body.Lines) != 2 {
+		t.Fatalf("want 2 log lines, got %d", len(body.Lines))
+	}
+	if body.Lines[0] != "line one" || body.Lines[1] != "line two" {
+		t.Fatalf("unexpected log lines: %#v", body.Lines)
+	}
+}
+
+func TestCoreServiceLogs_InvalidService(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/core-services/logs?service=unknown")
+	if err != nil {
+		t.Fatalf("GET /api/core-services/logs: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestCoreServiceLogs_JournalctlError(t *testing.T) {
+	setFakeJournalctl(t, "echo 'boom' >&2; exit 1")
+
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/core-services/logs?service=proxy")
+	if err != nil {
+		t.Fatalf("GET /api/core-services/logs: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestCoreServiceLogs_InvalidTail(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/core-services/logs?service=api&tail=abc")
+	if err != nil {
+		t.Fatalf("GET /api/core-services/logs: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func setFakeJournalctl(t *testing.T, body string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "journalctl")
+	script := "#!/usr/bin/env bash\nset -euo pipefail\n" + body + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake journalctl: %v", err)
+	}
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 // readLogLines connects to a log SSE endpoint and sends parsed log line strings
 // to the returned channel until ctx is cancelled or the connection drops.
 func readLogLines(ctx context.Context, t *testing.T, url string) <-chan string {
@@ -2422,6 +2533,89 @@ func TestDeploymentLogs_DockerError(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout: channel did not close on docker error")
+	}
+}
+
+func TestDeploymentRecentLogs_NotFound(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/deployments/nonexistent/logs/recent")
+	if err != nil {
+		t.Fatalf("GET /api/deployments/nonexistent/logs/recent: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestDeploymentRecentLogs_OK(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Status: store.StatusHealthy}
+
+	srv := newTestServerWithDockerLogs(s, &stubDockerLogs{recentLogs: []string{"booting", "ready"}})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/deployments/d1/logs/recent?tail=2")
+	if err != nil {
+		t.Fatalf("GET /api/deployments/d1/logs/recent: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		DeploymentID string   `json:"deploymentId"`
+		Lines        []string `json:"lines"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.DeploymentID != "d1" {
+		t.Fatalf("want deploymentId d1, got %q", body.DeploymentID)
+	}
+	if len(body.Lines) != 2 || body.Lines[0] != "booting" || body.Lines[1] != "ready" {
+		t.Fatalf("unexpected lines: %#v", body.Lines)
+	}
+}
+
+func TestDeploymentRecentLogs_InvalidTail(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Status: store.StatusHealthy}
+
+	srv := newTestServerWithDockerLogs(s, &stubDockerLogs{})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/deployments/d1/logs/recent?tail=abc")
+	if err != nil {
+		t.Fatalf("GET /api/deployments/d1/logs/recent: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestDeploymentRecentLogs_DockerError(t *testing.T) {
+	s := newMemStore()
+	s.deployments["d1"] = store.Deployment{ID: "d1", Name: "web", Status: store.StatusHealthy}
+
+	srv := newTestServerWithDockerLogs(s, &stubDockerLogs{recentErr: errors.New("docker unavailable")})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/deployments/d1/logs/recent")
+	if err != nil {
+		t.Fatalf("GET /api/deployments/d1/logs/recent: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", resp.StatusCode)
 	}
 }
 

--- a/api/internal/docker/logs.go
+++ b/api/internal/docker/logs.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -34,23 +35,12 @@ func New(client Client) *LogStreamer {
 //
 // Returns (nil, nil) when no managed container exists for the deployment.
 func (s *LogStreamer) StreamLogs(ctx context.Context, deploymentID string, tail int) (io.ReadCloser, error) {
-	f := filters.NewArgs(
-		filters.Arg("label", "dirigent.managed=true"),
-		filters.Arg("label", "dirigent.id="+deploymentID),
-	)
-	containers, err := s.client.ContainerList(ctx, container.ListOptions{All: true, Filters: f})
+	latest, err := s.latestContainer(ctx, deploymentID)
 	if err != nil {
-		return nil, fmt.Errorf("docker: list containers for deployment %s: %w", deploymentID, err)
+		return nil, err
 	}
-	if len(containers) == 0 {
+	if latest == nil {
 		return nil, nil
-	}
-
-	latest := containers[0]
-	for _, c := range containers[1:] {
-		if c.Created > latest.Created {
-			latest = c
-		}
 	}
 
 	raw, err := s.client.ContainerLogs(ctx, latest.ID, container.LogsOptions{
@@ -72,4 +62,67 @@ func (s *LogStreamer) StreamLogs(ctx context.Context, deploymentID string, tail 
 		stdcopy.StdCopy(pw, pw, raw) //nolint:errcheck
 	}()
 	return pr, nil
+}
+
+// RecentLogs returns the latest log lines for the newest container associated
+// with deploymentID without holding an active follow stream.
+func (s *LogStreamer) RecentLogs(ctx context.Context, deploymentID string, tail int) ([]string, error) {
+	latest, err := s.latestContainer(ctx, deploymentID)
+	if err != nil {
+		return nil, err
+	}
+	if latest == nil {
+		return []string{}, nil
+	}
+
+	raw, err := s.client.ContainerLogs(ctx, latest.ID, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     false,
+		Tail:       fmt.Sprintf("%d", tail),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("docker: logs for container %s: %w", latest.ID, err)
+	}
+	defer raw.Close()
+
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		stdcopy.StdCopy(pw, pw, raw) //nolint:errcheck
+	}()
+
+	scanner := bufio.NewScanner(pr)
+	lines := make([]string, 0, tail)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("docker: scan logs for deployment %s: %w", deploymentID, err)
+	}
+
+	return lines, nil
+}
+
+func (s *LogStreamer) latestContainer(ctx context.Context, deploymentID string) (*dockertypes.Container, error) {
+	f := filters.NewArgs(
+		filters.Arg("label", "dirigent.managed=true"),
+		filters.Arg("label", "dirigent.id="+deploymentID),
+	)
+	containers, err := s.client.ContainerList(ctx, container.ListOptions{All: true, Filters: f})
+	if err != nil {
+		return nil, fmt.Errorf("docker: list containers for deployment %s: %w", deploymentID, err)
+	}
+	if len(containers) == 0 {
+		return nil, nil
+	}
+
+	latest := containers[0]
+	for _, c := range containers[1:] {
+		if c.Created > latest.Created {
+			latest = c
+		}
+	}
+
+	return &latest, nil
 }

--- a/api/internal/docker/logs_test.go
+++ b/api/internal/docker/logs_test.go
@@ -84,3 +84,31 @@ func TestStreamLogs_NoContainers(t *testing.T) {
 		t.Fatal("did not expect ContainerLogs call")
 	}
 }
+
+func TestRecentLogs_UsesNewestContainerWithoutFollow(t *testing.T) {
+	m := &mockClient{
+		containers: []dockertypes.Container{
+			{ID: "old", Created: 100},
+			{ID: "new", Created: 200},
+		},
+	}
+
+	streamer := New(m)
+	lines, err := streamer.RecentLogs(context.Background(), "dep-1", 150)
+	if err != nil {
+		t.Fatalf("RecentLogs: %v", err)
+	}
+	if len(lines) != 0 {
+		t.Fatalf("want no lines from empty mock output, got %d", len(lines))
+	}
+
+	if m.logsContainer != "new" {
+		t.Fatalf("want logs from newest container 'new', got %q", m.logsContainer)
+	}
+	if m.logsOptions.Follow {
+		t.Fatal("want Follow=false")
+	}
+	if m.logsOptions.Tail != "150" {
+		t.Fatalf("want Tail=150, got %q", m.logsOptions.Tail)
+	}
+}

--- a/dashboard/src/deployments/useDeploymentLogsSSE.ts
+++ b/dashboard/src/deployments/useDeploymentLogsSSE.ts
@@ -1,11 +1,17 @@
 import { useEffect, useState } from 'react'
 import type { DeploymentLogEvent } from '../lib/api'
 
-export function useDeploymentLogsSSE(deploymentId: string) {
+export function useDeploymentLogsSSE(deploymentId: string, reconnectToken = 0) {
   const [lines, setLines] = useState<string[]>([])
   const [connected, setConnected] = useState(false)
 
   useEffect(() => {
+    if (!deploymentId) {
+      setLines([])
+      setConnected(false)
+      return
+    }
+
     setLines([])
     setConnected(false)
 
@@ -24,7 +30,7 @@ export function useDeploymentLogsSSE(deploymentId: string) {
     }
 
     return () => es.close()
-  }, [deploymentId])
+  }, [deploymentId, reconnectToken])
 
   return { lines, connected }
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -175,6 +175,18 @@ export type LoadBalancerAccessLogFilters = {
   ip?: string
 }
 
+export type CoreService = 'api' | 'orchestrator' | 'proxy'
+
+export type CoreServiceLogsResponse = {
+  service: CoreService
+  lines: string[]
+}
+
+export type DeploymentRecentLogsResponse = {
+  deploymentId: string
+  lines: string[]
+}
+
 export async function getDeployments(): Promise<Deployment[]> {
   const res = await fetch('/api/deployments')
   if (!res.ok) throw new Error('Failed to fetch deployments')
@@ -283,6 +295,20 @@ export async function getLoadBalancerAccessLogs(
 
   const res = await fetch(`/api/load-balancer/access-logs?${params.toString()}`)
   if (!res.ok) throw new Error('Failed to fetch load balancer access logs')
+  return res.json()
+}
+
+export async function getCoreServiceLogs(service: CoreService, tail = 200): Promise<CoreServiceLogsResponse> {
+  const params = new URLSearchParams({ service, tail: String(tail) })
+  const res = await fetch(`/api/core-services/logs?${params.toString()}`)
+  if (!res.ok) throw new Error('Failed to fetch core service logs')
+  return res.json()
+}
+
+export async function getDeploymentRecentLogs(deploymentId: string, tail = 300): Promise<DeploymentRecentLogsResponse> {
+  const params = new URLSearchParams({ tail: String(tail) })
+  const res = await fetch(`/api/deployments/${deploymentId}/logs/recent?${params.toString()}`)
+  if (!res.ok) throw new Error('Failed to fetch deployment recent logs')
   return res.json()
 }
 

--- a/dashboard/src/pages/LogsPage.tsx
+++ b/dashboard/src/pages/LogsPage.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Button } from '../components/ui/button'
+import { useDeploymentLogsSSE } from '../deployments/useDeploymentLogsSSE'
+import { type CoreService, getCoreServiceLogs, getDeploymentRecentLogs, getDeployments } from '../lib/api'
+
+const CORE_SERVICES: Array<{ value: CoreService; label: string }> = [
+  { value: 'api', label: 'API service' },
+  { value: 'orchestrator', label: 'Orchestrator service' },
+  { value: 'proxy', label: 'Proxy service' },
+]
+
+const TAIL_OPTIONS = [100, 200, 400, 800]
+const DEPLOYMENT_RECENT_TAIL_OPTIONS = [100, 300, 500, 800]
+
+export function LogsPage() {
+  const [coreService, setCoreService] = useState<CoreService>('api')
+  const [tail, setTail] = useState(200)
+  const [autoRefreshCore, setAutoRefreshCore] = useState(true)
+  const [selectedDeploymentID, setSelectedDeploymentID] = useState('')
+  const [deploymentLogMode, setDeploymentLogMode] = useState<'live' | 'recent'>('live')
+  const [deploymentRecentTail, setDeploymentRecentTail] = useState(300)
+  const [reconnectToken, setReconnectToken] = useState(0)
+
+  const coreLogs = useQuery({
+    queryKey: ['core-service-logs', coreService, tail],
+    queryFn: () => getCoreServiceLogs(coreService, tail),
+    refetchInterval: autoRefreshCore ? 5000 : false,
+    retry: false,
+  })
+
+  const deployments = useQuery({
+    queryKey: ['deployments'],
+    queryFn: getDeployments,
+    refetchInterval: 30_000,
+  })
+
+  const sortedDeployments = useMemo(
+    () => [...(deployments.data ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+    [deployments.data]
+  )
+
+  useEffect(() => {
+    if (sortedDeployments.length === 0) {
+      setSelectedDeploymentID('')
+      return
+    }
+
+    const selectedStillExists = sortedDeployments.some(deployment => deployment.id === selectedDeploymentID)
+    if (!selectedStillExists) {
+      setSelectedDeploymentID(sortedDeployments[0].id)
+    }
+  }, [selectedDeploymentID, sortedDeployments])
+
+  const selectedDeployment = sortedDeployments.find(deployment => deployment.id === selectedDeploymentID)
+  const deploymentLogs = useDeploymentLogsSSE(selectedDeploymentID, reconnectToken)
+  const deploymentRecentLogs = useQuery({
+    queryKey: ['deployment-recent-logs', selectedDeploymentID, deploymentRecentTail],
+    queryFn: () => getDeploymentRecentLogs(selectedDeploymentID, deploymentRecentTail),
+    enabled: deploymentLogMode === 'recent' && !!selectedDeploymentID,
+    retry: false,
+  })
+  const deploymentLogContainerRef = useRef<HTMLPreElement | null>(null)
+
+  useEffect(() => {
+    if (!deploymentLogContainerRef.current) {
+      return
+    }
+    deploymentLogContainerRef.current.scrollTop = deploymentLogContainerRef.current.scrollHeight
+  }, [deploymentLogMode, deploymentLogs.lines, deploymentRecentLogs.data])
+
+  return (
+    <div className="space-y-5">
+      <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Core services</p>
+            <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">API, orchestrator, and proxy logs</h2>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="button" size="sm" variant="outline" onClick={() => coreLogs.refetch()} disabled={coreLogs.isFetching}>
+              {coreLogs.isFetching ? 'Refreshing...' : 'Refresh'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-3">
+          <label className="space-y-1">
+            <span className="text-xs text-muted-foreground">Service</span>
+            <select
+              value={coreService}
+              onChange={event => setCoreService(event.target.value as CoreService)}
+              className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm text-foreground shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+            >
+              {CORE_SERVICES.map(service => (
+                <option key={service.value} value={service.value}>
+                  {service.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="space-y-1">
+            <span className="text-xs text-muted-foreground">History window</span>
+            <select
+              value={tail}
+              onChange={event => setTail(Number(event.target.value))}
+              className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm text-foreground shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+            >
+              {TAIL_OPTIONS.map(option => (
+                <option key={option} value={option}>
+                  Last {option} lines
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex items-center gap-2 pt-6 text-sm text-foreground">
+            <input type="checkbox" checked={autoRefreshCore} onChange={event => setAutoRefreshCore(event.target.checked)} />
+            Auto refresh every 5s
+          </label>
+        </div>
+
+        <div className="mt-4 rounded-lg border border-border/60 bg-background/70 p-4">
+          {coreLogs.isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading service logs...</p>
+          ) : coreLogs.isError ? (
+            <p className="text-sm text-destructive">Unable to load service logs.</p>
+          ) : coreLogs.data && coreLogs.data.lines.length > 0 ? (
+            <pre className="h-[420px] overflow-y-auto font-mono text-xs leading-5 text-foreground/90 whitespace-pre-wrap break-all">{coreLogs.data.lines.join('\n')}</pre>
+          ) : (
+            <p className="text-sm text-muted-foreground">No log output was found for this service yet.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Deployments</p>
+            <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">Deployment run log stream</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Select a deployment to follow its live container output.</p>
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <label className="space-y-1">
+            <span className="text-xs text-muted-foreground">Deployment</span>
+            <select
+              value={selectedDeploymentID}
+              onChange={event => setSelectedDeploymentID(event.target.value)}
+              disabled={deployments.isLoading || deployments.isError || sortedDeployments.length === 0}
+              className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm text-foreground shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {sortedDeployments.map(deployment => (
+                <option key={deployment.id} value={deployment.id}>
+                  {deployment.name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="space-y-1">
+            <span className="text-xs text-muted-foreground">View mode</span>
+            <div className="flex h-9 items-center rounded-md border border-border/60 bg-background/70 p-1">
+              <button
+                type="button"
+                className={`h-full flex-1 rounded px-2 text-xs font-medium transition-colors ${
+                  deploymentLogMode === 'live' ? 'bg-card text-foreground' : 'text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => setDeploymentLogMode('live')}
+              >
+                Live stream
+              </button>
+              <button
+                type="button"
+                className={`h-full flex-1 rounded px-2 text-xs font-medium transition-colors ${
+                  deploymentLogMode === 'recent' ? 'bg-card text-foreground' : 'text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => setDeploymentLogMode('recent')}
+              >
+                Recent snapshot
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {deploymentLogMode === 'live' ? (
+            <>
+              <div className="flex h-8 items-center rounded-md border border-border/60 bg-background/70 px-3">
+                <span className={`mr-2 h-1.5 w-1.5 rounded-full ${deploymentLogs.connected ? 'animate-pulse bg-emerald-500' : 'bg-muted-foreground/30'}`} />
+                <span className="text-xs text-muted-foreground">
+                  {selectedDeployment ? (deploymentLogs.connected ? 'Connected' : 'Connecting...') : 'No deployment selected'}
+                </span>
+              </div>
+              <Button type="button" size="sm" variant="outline" onClick={() => setReconnectToken(prev => prev + 1)} disabled={!selectedDeploymentID}>
+                Reconnect stream
+              </Button>
+            </>
+          ) : (
+            <>
+              <select
+                value={deploymentRecentTail}
+                onChange={event => setDeploymentRecentTail(Number(event.target.value))}
+                className="h-8 rounded-md border border-input bg-transparent px-2.5 text-xs text-foreground shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+              >
+                {DEPLOYMENT_RECENT_TAIL_OPTIONS.map(option => (
+                  <option key={option} value={option}>
+                    Last {option} lines
+                  </option>
+                ))}
+              </select>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => deploymentRecentLogs.refetch()}
+                disabled={!selectedDeploymentID || deploymentRecentLogs.isFetching}
+              >
+                {deploymentRecentLogs.isFetching ? 'Refreshing...' : 'Refresh snapshot'}
+              </Button>
+            </>
+          )}
+        </div>
+
+        <div className="mt-4 rounded-lg border border-border/60 bg-background/70 p-4">
+          {deployments.isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading deployments...</p>
+          ) : deployments.isError ? (
+            <p className="text-sm text-destructive">Unable to load deployments.</p>
+          ) : !selectedDeployment ? (
+            <p className="text-sm text-muted-foreground">No deployments available yet.</p>
+          ) : deploymentLogMode === 'live' && deploymentLogs.lines.length > 0 ? (
+            <pre ref={deploymentLogContainerRef} className="h-[420px] overflow-y-auto font-mono text-xs leading-5 text-foreground/90 whitespace-pre-wrap break-all">
+              {deploymentLogs.lines.join('\n')}
+            </pre>
+          ) : deploymentLogMode === 'recent' && deploymentRecentLogs.isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading recent deployment logs...</p>
+          ) : deploymentLogMode === 'recent' && deploymentRecentLogs.isError ? (
+            <p className="text-sm text-destructive">Unable to load recent deployment logs.</p>
+          ) : deploymentLogMode === 'recent' && (deploymentRecentLogs.data?.lines.length ?? 0) > 0 ? (
+            <pre ref={deploymentLogContainerRef} className="h-[420px] overflow-y-auto font-mono text-xs leading-5 text-foreground/90 whitespace-pre-wrap break-all">
+              {deploymentRecentLogs.data?.lines.join('\n')}
+            </pre>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {deploymentLogMode === 'live' ? 'Waiting for deployment log output...' : 'No recent logs captured for this deployment.'}
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/dashboard/src/router.tsx
+++ b/dashboard/src/router.tsx
@@ -7,7 +7,7 @@ import {
   redirect,
   useRouterState,
 } from '@tanstack/react-router'
-import { Activity, Boxes, Moon, Rocket, Server, Settings, Sun } from 'lucide-react'
+import { Activity, Boxes, FileText, Moon, Rocket, Server, Settings, Sun } from 'lucide-react'
 import { Button } from './components/ui/button'
 import {
   Sidebar,
@@ -23,6 +23,7 @@ import {
 } from './components/ui/sidebar'
 import DeploymentList from './pages/DeploymentList'
 import { DeploymentDetailPage } from './pages/DeploymentDetailPage'
+import { LogsPage } from './pages/LogsPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { SystemStatusPage } from './pages/SystemStatusPage'
 import { TrafficPage } from './pages/TrafficPage'
@@ -36,12 +37,15 @@ function DashboardLayout() {
   const isSystemStatusPage = pathname === '/system-status'
   const isSettingsPage = pathname === '/settings'
   const isTrafficPage = pathname === '/traffic'
+  const isLogsPage = pathname === '/logs'
   const isDeploymentPage = pathname.startsWith('/deployments')
   const isDeploymentDetailPage = isDeploymentPage && pathname !== '/deployments'
   const pageTitle = isSystemStatusPage
     ? 'System status'
     : isTrafficPage
       ? 'Traffic & security'
+      : isLogsPage
+      ? 'Logs'
       : isSettingsPage
       ? 'Settings'
       : isDeploymentDetailPage
@@ -51,6 +55,8 @@ function DashboardLayout() {
     ? 'Observe API health and freshness.'
     : isTrafficPage
       ? 'Inspect recent proxy traffic and effective protection settings.'
+      : isLogsPage
+      ? 'Inspect core service output and deployment log streams without SSH.'
       : isSettingsPage
       ? 'Manage product version and in-dashboard upgrades.'
       : isDeploymentDetailPage
@@ -105,6 +111,14 @@ function DashboardLayout() {
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
+                    <SidebarMenuButton asChild isActive={pathname === '/logs'} size="lg" className="rounded-lg">
+                      <Link to="/logs">
+                        <FileText className="h-4 w-4 shrink-0" />
+                        <span>Logs</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                  <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname === '/settings'} size="lg" className="rounded-lg">
                       <Link to="/settings">
                         <Settings className="h-4 w-4 shrink-0" />
@@ -121,7 +135,7 @@ function DashboardLayout() {
       </Sidebar>
 
       <SidebarInset>
-        <p className="mb-4 text-sm text-muted-foreground">{isSystemStatusPage || isTrafficPage ? 'Observability' : isSettingsPage ? 'Configuration' : 'Deployments'}</p>
+        <p className="mb-4 text-sm text-muted-foreground">{isSystemStatusPage || isTrafficPage || isLogsPage ? 'Observability' : isSettingsPage ? 'Configuration' : 'Deployments'}</p>
         <div className="mx-auto w-full max-w-5xl space-y-4">
           <div>
             <h1 className="font-[family-name:var(--font-display)] text-2xl font-semibold tracking-tight">{pageTitle}</h1>
@@ -176,13 +190,27 @@ const trafficRoute = createRoute({
   component: TrafficPage,
 })
 
+const logsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/logs',
+  component: LogsPage,
+})
+
 const settingsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/settings',
   component: SettingsPage,
 })
 
-const routeTree = rootRoute.addChildren([indexRoute, deploymentsRoute, deploymentDetailRoute, systemStatusRoute, trafficRoute, settingsRoute])
+const routeTree = rootRoute.addChildren([
+  indexRoute,
+  deploymentsRoute,
+  deploymentDetailRoute,
+  systemStatusRoute,
+  trafficRoute,
+  logsRoute,
+  settingsRoute,
+])
 
 export const router = createRouter({ routeTree })
 


### PR DESCRIPTION
## Summary
- add a dedicated `/logs` dashboard page and sidebar entry for observability, with clear loading/empty/error states and monospace scrollable output
- add API support for core service logs (`api`, `orchestrator`, `proxy`) via `GET /api/core-services/logs` and deployment snapshot logs via `GET /api/deployments/{id}/logs/recent`
- extend deployment log UX with both live stream mode and refreshable recent snapshot mode so users can inspect logs without SSH

## Testing
- `go test ./api/internal/api ./api/internal/docker`
- `bun run build` (dashboard)