### PR TITLE
feat(auth): prompt initial login and make env bootstrap-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Then `dirigent setup` will:
 - Create the `/var/lib/dirigent/` data directory and the `dirigent` Docker network
 - Offer security profiles in guided mode (`strict` is recommended)
 - Configure proxy hardening profiles (`standard` by default, `strict` recommended for internet-facing hosts)
+- Prompt for initial dashboard `/login` credentials in interactive setup (blank password auto-generates one)
 
 Re-running the installer performs an in-place upgrade.
 
@@ -60,6 +61,8 @@ sudo DIRIGENT_PROXY_HARDENING_PROFILE=strict dirigent setup
 | `dirigent-proxy`      | `:80`  | Reverse proxy — routes traffic to containers   |
 
 The dashboard is served by `dirigent-api` on `:8080` by default. If you set `DIRIGENT_DASHBOARD_DOMAIN` during setup, the proxy exposes it on `:80/:443` with optional Basic Auth.
+
+`DIRIGENT_AUTH_USER`/`DIRIGENT_AUTH_PASSWORD` (`LOTSEN_` aliases also supported) are bootstrap-only: they seed the first dashboard user when `users.db` is empty and are ignored after users already exist.
 
 ## Features
 

--- a/api/cmd/lotsen/main.go
+++ b/api/cmd/lotsen/main.go
@@ -84,22 +84,27 @@ func authFromEnv(storePath string) (*auth.UserStore, []byte, error) {
 	}
 
 	// Bootstrap credentials from env on startup.
+	hasUsers, err := userStore.HasUsers()
+	if err != nil {
+		userStore.Close()
+		return nil, nil, fmt.Errorf("check users: %w", err)
+	}
+
 	user := strings.TrimSpace(os.Getenv("LOTSEN_AUTH_USER"))
 	password := strings.TrimSpace(os.Getenv("LOTSEN_AUTH_PASSWORD"))
-	if user != "" && password != "" {
+	if hasUsers {
+		if user != "" || password != "" {
+			log.Printf("lotsen: auth users already exist; ignoring LOTSEN_AUTH_USER/LOTSEN_AUTH_PASSWORD bootstrap env")
+		}
+	} else if user != "" && password != "" {
 		if err := userStore.SetPassword(user, password); err != nil {
 			userStore.Close()
 			return nil, nil, fmt.Errorf("set initial credentials: %w", err)
 		}
+	} else if user != "" || password != "" {
+		log.Printf("lotsen: WARNING: LOTSEN_AUTH_USER and LOTSEN_AUTH_PASSWORD must both be set to bootstrap first login user")
 	} else {
-		has, err := userStore.HasUsers()
-		if err != nil {
-			userStore.Close()
-			return nil, nil, fmt.Errorf("check users: %w", err)
-		}
-		if !has {
-			log.Printf("lotsen: WARNING: no users in store and LOTSEN_AUTH_USER/LOTSEN_AUTH_PASSWORD not set; login will not work")
-		}
+		log.Printf("lotsen: WARNING: no users in store and LOTSEN_AUTH_USER/LOTSEN_AUTH_PASSWORD not set; login will not work")
 	}
 
 	return userStore, []byte(secret), nil

--- a/api/cmd/lotsen/main_test.go
+++ b/api/cmd/lotsen/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/ercadev/dirigent/auth"
+)
+
+func TestAuthFromEnvBootstrapsFirstUser(t *testing.T) {
+	t.Setenv("LOTSEN_JWT_SECRET", "test-secret")
+	t.Setenv("LOTSEN_AUTH_USER", "admin")
+	t.Setenv("LOTSEN_AUTH_PASSWORD", "bootstrap-pass")
+
+	storePath := filepath.Join(t.TempDir(), "deployments.json")
+	userStore, secret, err := authFromEnv(storePath)
+	if err != nil {
+		t.Fatalf("authFromEnv() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = userStore.Close()
+	})
+
+	if string(secret) != "test-secret" {
+		t.Fatalf("secret = %q, want %q", string(secret), "test-secret")
+	}
+
+	if err := userStore.Authenticate("admin", "bootstrap-pass"); err != nil {
+		t.Fatalf("Authenticate() error = %v, want nil", err)
+	}
+}
+
+func TestAuthFromEnvIgnoresBootstrapEnvWhenUsersExist(t *testing.T) {
+	storeDir := t.TempDir()
+	storePath := filepath.Join(storeDir, "deployments.json")
+
+	seedStore, err := auth.NewUserStore(filepath.Join(storeDir, "users.db"))
+	if err != nil {
+		t.Fatalf("NewUserStore() error = %v", err)
+	}
+	if err := seedStore.SetPassword("admin", "existing-pass"); err != nil {
+		t.Fatalf("SetPassword() error = %v", err)
+	}
+	if err := seedStore.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	t.Setenv("LOTSEN_JWT_SECRET", "test-secret")
+	t.Setenv("LOTSEN_AUTH_USER", "admin")
+	t.Setenv("LOTSEN_AUTH_PASSWORD", "new-bootstrap-pass")
+
+	userStore, _, err := authFromEnv(storePath)
+	if err != nil {
+		t.Fatalf("authFromEnv() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = userStore.Close()
+	})
+
+	if err := userStore.Authenticate("admin", "existing-pass"); err != nil {
+		t.Fatalf("Authenticate(existing) error = %v, want nil", err)
+	}
+
+	err = userStore.Authenticate("admin", "new-bootstrap-pass")
+	if !errors.Is(err, auth.ErrInvalidCredentials) {
+		t.Fatalf("Authenticate(new bootstrap pass) error = %v, want %v", err, auth.ErrInvalidCredentials)
+	}
+}

--- a/setup.sh
+++ b/setup.sh
@@ -426,6 +426,12 @@ AUTH_PASSWORD="${DIRIGENT_AUTH_PASSWORD:-${LOTSEN_AUTH_PASSWORD:-}}"
 JWT_SECRET="${DIRIGENT_JWT_SECRET:-${LOTSEN_JWT_SECRET:-}}"
 GENERATED_AUTH_PASSWORD=0
 GENERATED_JWT_SECRET=0
+EXISTING_DASHBOARD_DOMAIN=""
+EXISTING_DASHBOARD_USER=""
+EXISTING_DASHBOARD_PASSWORD=""
+EXISTING_AUTH_USER=""
+EXISTING_AUTH_PASSWORD=""
+EXISTING_JWT_SECRET=""
 
 if [ -f "${ENV_FILE}" ]; then
     EXISTING_DASHBOARD_DOMAIN=$(read_env_value "DIRIGENT_DASHBOARD_DOMAIN")
@@ -476,13 +482,45 @@ fi
 if [ -z "${AUTH_USER}" ]; then
     AUTH_USER="admin"
 fi
-if [ -z "${AUTH_PASSWORD}" ]; then
-    AUTH_PASSWORD=$(generate_hex_secret 16)
-    GENERATED_AUTH_PASSWORD=1
-fi
 if [ -z "${JWT_SECRET}" ]; then
     JWT_SECRET=$(generate_hex_secret 32)
     GENERATED_JWT_SECRET=1
+fi
+
+if [ -t 0 ] && [ "${DIRIGENT_NON_INTERACTIVE:-0}" != "1" ] && [ "${DIRIGENT_UPGRADE:-0}" != "1" ] && [ -z "${AUTH_PASSWORD}" ]; then
+    echo ""
+    echo "Dashboard /login bootstrap credentials"
+    echo "  These credentials are used for the first dashboard login user."
+
+    read -r -p "Dashboard login username [${AUTH_USER}]: " INPUT_AUTH_USER
+    if [ -n "${INPUT_AUTH_USER}" ]; then
+        AUTH_USER="${INPUT_AUTH_USER}"
+    fi
+
+    while true; do
+        read -r -s -p "Dashboard login password (leave blank to auto-generate): " INPUT_AUTH_PASSWORD
+        echo ""
+        if [ -z "${INPUT_AUTH_PASSWORD}" ]; then
+            AUTH_PASSWORD=$(generate_hex_secret 16)
+            GENERATED_AUTH_PASSWORD=1
+            break
+        fi
+
+        read -r -s -p "Confirm dashboard login password: " INPUT_AUTH_PASSWORD_CONFIRM
+        echo ""
+        if [ "${INPUT_AUTH_PASSWORD}" != "${INPUT_AUTH_PASSWORD_CONFIRM}" ]; then
+            echo "Passwords do not match. Try again."
+            continue
+        fi
+
+        AUTH_PASSWORD="${INPUT_AUTH_PASSWORD}"
+        break
+    done
+fi
+
+if [ -z "${AUTH_PASSWORD}" ]; then
+    AUTH_PASSWORD=$(generate_hex_secret 16)
+    GENERATED_AUTH_PASSWORD=1
 fi
 
 if [ -t 0 ] && [ "${DIRIGENT_NON_INTERACTIVE:-0}" != "1" ] && [ "${DIRIGENT_UPGRADE:-0}" != "1" ]; then

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -24,6 +24,7 @@ The installer will:
 - Download and install the three Lotsen binaries.
 - Create a Docker bridge network named `lotsen`.
 - Write and enable three systemd units: `lotsen-api`, `lotsen-orchestrator`, and `lotsen-proxy`.
+- Prompt for initial dashboard `/login` credentials in interactive setup.
 - Prompt for optional dashboard domain + Basic Auth setup (works in normal SSH sessions, including piped install commands).
 
 > **Tip:** To pin a specific version, prefix the command with `LOTSEN_VERSION=v0.0.2` before the curl.
@@ -53,6 +54,15 @@ http://<your-vps-ip>:8080
 ```
 
 The orchestrator has no public inbound port.
+
+### First dashboard login user
+
+In interactive mode, `lotsen setup` prompts for the initial dashboard `/login` username and password.
+
+- Leave the password blank to auto-generate a strong password.
+- The generated password is printed once at the end of setup.
+
+`LOTSEN_AUTH_USER` and `LOTSEN_AUTH_PASSWORD` are bootstrap-only values. They are used to create the first user when the user database is empty, and ignored on later starts once users exist.
 
 ### Expose dashboard publicly (HTTPS + Basic Auth)
 


### PR DESCRIPTION
## Summary
- prompt for initial dashboard `/login` credentials in interactive `lotsen setup`, with blank password generating a strong one
- treat `LOTSEN_AUTH_USER`/`LOTSEN_AUTH_PASSWORD` as bootstrap-only by ignoring them when `users.db` already contains users
- add tests for first-user bootstrap and existing-user ignore behavior, and document first-user/bootstrap-only semantics

## Validation
- `go test ./api/cmd/lotsen`

Closes #193