### PR TITLE
feat(dashboard): add clear public/private deployment controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ setup:
 # concurrently in a single terminal. Ctrl+C shuts down both processes cleanly.
 dev:
 	@trap 'kill 0' SIGINT; \
-	(cd api && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_PROXY_ACCESS_LOG_DIR=/tmp/lotsen-proxy-logs $(AIR)) & \
+	(cd api && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_PROXY_ACCESS_LOG_DIR=/tmp/lotsen-proxy-logs LOTSEN_JWT_SECRET= LOTSEN_AUTH_USER= LOTSEN_AUTH_PASSWORD= $(AIR)) & \
 	(cd orchestrator && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_PROXY_HEALTH_URL=http://localhost:8090/internal/health LOTSEN_PROXY_TRAFFIC_URL=http://localhost:8090/internal/traffic $(AIR)) & \
-	(cd proxy && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_PROXY_ADDR=:8090 LOTSEN_PROXY_HTTPS_ADDR=:8443 LOTSEN_CERT_CACHE_DIR=/tmp/lotsen-certs LOTSEN_PROXY_ACCESS_LOG_DIR=/tmp/lotsen-proxy-logs $(AIR)) & \
+	(cd proxy && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_PROXY_ADDR=:8090 LOTSEN_PROXY_HTTPS_ADDR=:8443 LOTSEN_CERT_CACHE_DIR=/tmp/lotsen-certs LOTSEN_PROXY_ACCESS_LOG_DIR=/tmp/lotsen-proxy-logs LOTSEN_JWT_SECRET= LOTSEN_AUTH_USER= LOTSEN_AUTH_PASSWORD= $(AIR)) & \
 	(cd dashboard && bun run dev) & \
 	wait
 

--- a/dashboard/src/deployments/CreateDeploymentForm.test.tsx
+++ b/dashboard/src/deployments/CreateDeploymentForm.test.tsx
@@ -62,6 +62,40 @@ describe('CreateDeploymentForm', () => {
         ports: [],
         volumes: [],
         domain: '',
+        public: false,
+      })
+    )
+  })
+
+  it('submits public=true when public access is enabled', async () => {
+    const mockCreate = vi.mocked(api.createDeployment).mockResolvedValue({
+      id: 'public-1',
+      name: 'public-app',
+      image: 'nginx:latest',
+      status: 'idle',
+      envs: {},
+      ports: [],
+      volumes: [],
+      domain: '',
+      public: true,
+    })
+    const user = userEvent.setup()
+    renderWithQuery(<CreateDeploymentForm />)
+
+    await user.type(screen.getByLabelText(/name \*/i), 'public-app')
+    await user.type(screen.getByLabelText(/image \*/i), 'nginx:latest')
+    await user.click(screen.getByRole('switch', { name: /public deployment/i }))
+    await user.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() =>
+      expect(mockCreate.mock.calls[0][0]).toEqual({
+        name: 'public-app',
+        image: 'nginx:latest',
+        envs: {},
+        ports: [],
+        volumes: [],
+        domain: '',
+        public: true,
       })
     )
   })
@@ -153,6 +187,7 @@ describe('CreateDeploymentForm', () => {
         ports: ['80'],
         volumes: ['/data:/app/data'],
         domain: 'example.com',
+        public: false,
       })
     )
   })

--- a/dashboard/src/deployments/CreateDeploymentForm.tsx
+++ b/dashboard/src/deployments/CreateDeploymentForm.tsx
@@ -19,6 +19,7 @@ type Props = {
 export default function CreateDeploymentForm({ onSuccess, className, hideHeader = false }: Props) {
   const {
     name, setName, image, setImage, domain, setDomain,
+    isPublic, setIsPublic,
     envRows, portRows, volumeRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
     errors, handleSubmit, isPending,
   } = useCreateDeploymentForm({ onSuccess })
@@ -94,6 +95,39 @@ export default function CreateDeploymentForm({ onSuccess, className, hideHeader 
                 value={domain}
                 onChange={e => setDomain(e.target.value)}
               />
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border/60 bg-background/70 p-3">
+              <div>
+                <p className="text-sm font-medium text-foreground">Publicly accessible</p>
+                <p className="text-xs text-muted-foreground">When enabled, requests go directly to your app without Lotsen login.</p>
+              </div>
+              <label className="inline-flex cursor-pointer items-center gap-2">
+                <input
+                  type="checkbox"
+                  role="switch"
+                  aria-label="Public deployment"
+                  checked={isPublic}
+                  onChange={e => setIsPublic(e.target.checked)}
+                  className="peer sr-only"
+                />
+                <span
+                  className={cn(
+                    'relative h-6 w-11 rounded-full border transition-colors',
+                    isPublic
+                      ? 'border-primary/40 bg-primary/20'
+                      : 'border-border bg-background'
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-foreground transition-transform',
+                      isPublic ? 'translate-x-5' : 'translate-x-0'
+                    )}
+                  />
+                </span>
+                <span className="text-xs font-medium text-foreground">{isPublic ? 'Public' : 'Private'}</span>
+              </label>
             </div>
           </section>
 

--- a/dashboard/src/deployments/DeploymentRow.tsx
+++ b/dashboard/src/deployments/DeploymentRow.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, ExternalLink, Globe, Pencil, Trash2 } from 'lucide-react'
+import { ArrowUpRight, ExternalLink, Globe, Lock, Trash2, Unlock } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
@@ -9,10 +9,9 @@ type Props = {
   deployment: Deployment
   onDelete: (deployment: Deployment) => void
   isDeleting: boolean
-  onEdit: (deployment: Deployment) => void
 }
 
-export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: Props) {
+export function DeploymentRow({ deployment: d, onDelete, isDeleting }: Props) {
   const detailsLabel = d.status === 'failed' ? 'Investigate' : 'Details'
   const hasDomain = Boolean(d.domain)
   const hasPorts = d.ports.length > 0
@@ -66,6 +65,10 @@ export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: P
             <Badge variant="secondary" className="px-2 py-0.5 text-[11px]">
               {Object.keys(d.envs).length} env var{Object.keys(d.envs).length === 1 ? '' : 's'}
             </Badge>
+            <Badge variant={d.public ? 'success' : 'warning'} className="px-2 py-0.5 text-[11px]">
+              {d.public ? <Unlock size={12} /> : <Lock size={12} />}
+              {d.public ? 'Public' : 'Private'}
+            </Badge>
             {stats && (
               <>
                 <Badge variant="outline" className="px-2 py-0.5 font-mono text-[11px]">
@@ -85,16 +88,6 @@ export function DeploymentRow({ deployment: d, onDelete, isDeleting, onEdit }: P
               {detailsLabel}
               <ExternalLink size={13} />
             </Link>
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => onEdit(d)}
-            aria-label={`Edit ${d.name}`}
-            className="h-8 w-8 text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            <Pencil size={15} />
           </Button>
           <Button
             type="button"

--- a/dashboard/src/deployments/DeploymentTable.tsx
+++ b/dashboard/src/deployments/DeploymentTable.tsx
@@ -12,7 +12,6 @@ type Props = {
   isError: boolean
   isDeleting: boolean
   onDelete: (deployment: Deployment) => void
-  onEdit: (deployment: Deployment) => void
   onCreate: () => void
   onClearFilters: () => void
   onRetry: () => void
@@ -26,7 +25,6 @@ export function DeploymentTable({
   isError,
   isDeleting,
   onDelete,
-  onEdit,
   onCreate,
   onClearFilters,
   onRetry,
@@ -100,7 +98,6 @@ export function DeploymentTable({
           deployment={d}
           onDelete={onDelete}
           isDeleting={isDeleting}
-          onEdit={onEdit}
         />
       ))}
     </div>

--- a/dashboard/src/deployments/EditDeploymentForm.test.tsx
+++ b/dashboard/src/deployments/EditDeploymentForm.test.tsx
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import EditDeploymentForm from './EditDeploymentForm'
+import * as api from '../lib/api'
+
+vi.mock('../lib/api', () => ({
+  updateDeployment: vi.fn(),
+}))
+
+function renderWithQuery(ui: React.ReactElement) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+const deployment: api.Deployment = {
+  id: 'dep-1',
+  name: 'my-app',
+  image: 'nginx:latest',
+  envs: {},
+  ports: ['32768:80'],
+  volumes: [],
+  domain: 'app.example.com',
+  public: false,
+  status: 'healthy',
+}
+
+describe('EditDeploymentForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('submits public=true when public access is enabled', async () => {
+    const onClose = vi.fn()
+    const mockUpdate = vi.mocked(api.updateDeployment).mockResolvedValue({
+      ...deployment,
+      public: true,
+    })
+    const user = userEvent.setup()
+
+    renderWithQuery(<EditDeploymentForm deployment={deployment} onClose={onClose} />)
+
+    await user.click(screen.getByRole('switch', { name: /public deployment/i }))
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('dep-1', {
+        name: 'my-app',
+        image: 'nginx:latest',
+        envs: {},
+        ports: ['80'],
+        volumes: [],
+        domain: 'app.example.com',
+        public: true,
+        basic_auth: undefined,
+        security: undefined,
+      })
+    })
+  })
+})

--- a/dashboard/src/deployments/EditDeploymentForm.tsx
+++ b/dashboard/src/deployments/EditDeploymentForm.tsx
@@ -20,6 +20,7 @@ type Props = {
 export default function EditDeploymentForm({ deployment, onClose, className, hideHeader = false }: Props) {
   const {
     name, setName, image, setImage, domain, setDomain,
+    isPublic, setIsPublic,
     envRows, portRows, volumeRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
     errors, handleSubmit, isDirty, isPending,
   } = useEditDeploymentForm(deployment, onClose)
@@ -56,6 +57,39 @@ export default function EditDeploymentForm({ deployment, onClose, className, hid
           <Label htmlFor="edit-dep-domain">Domain (optional)</Label>
           <Input id="edit-dep-domain" type="text" placeholder="app.example.com" value={domain}
             onChange={e => setDomain(e.target.value)} />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border/60 bg-background/70 p-3">
+          <div>
+            <p className="text-sm font-medium text-foreground">Publicly accessible</p>
+            <p className="text-xs text-muted-foreground">When enabled, requests go directly to your app without Lotsen login.</p>
+          </div>
+          <label className="inline-flex cursor-pointer items-center gap-2">
+            <input
+              type="checkbox"
+              role="switch"
+              aria-label="Public deployment"
+              checked={isPublic}
+              onChange={e => setIsPublic(e.target.checked)}
+              className="peer sr-only"
+            />
+            <span
+              className={cn(
+                'relative h-6 w-11 rounded-full border transition-colors',
+                isPublic
+                  ? 'border-primary/40 bg-primary/20'
+                  : 'border-border bg-background'
+              )}
+            >
+              <span
+                className={cn(
+                  'absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-foreground transition-transform',
+                  isPublic ? 'translate-x-5' : 'translate-x-0'
+                )}
+              />
+            </span>
+            <span className="text-xs font-medium text-foreground">{isPublic ? 'Public' : 'Private'}</span>
+          </label>
         </div>
 
         <DynamicSection<EnvRow>

--- a/dashboard/src/deployments/useCreateDeploymentForm.ts
+++ b/dashboard/src/deployments/useCreateDeploymentForm.ts
@@ -31,6 +31,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
   const [name, setName] = useState('')
   const [image, setImage] = useState('')
   const [domain, setDomain] = useState('')
+  const [isPublic, setIsPublic] = useState(false)
   const [basicAuthEnabled, setBasicAuthEnabled] = useState(false)
   const [errors, setErrors] = useState<FormErrors>(EMPTY_ERRORS)
 
@@ -46,6 +47,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
       setName('')
       setImage('')
       setDomain('')
+      setIsPublic(false)
       setBasicAuthEnabled(false)
       envRows.reset()
       portRows.reset()
@@ -112,6 +114,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
       ports: portRows.rows.map(r => r.port.trim()),
       volumes: volumeRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
       domain: domain.trim(),
+      public: isPublic,
       basic_auth: basicAuth,
     })
   }
@@ -120,6 +123,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
     name, setName,
     image, setImage,
     domain, setDomain,
+    isPublic, setIsPublic,
     basicAuthEnabled, setBasicAuthEnabled,
     envRows,
     portRows,

--- a/dashboard/src/deployments/useEditDeploymentForm.ts
+++ b/dashboard/src/deployments/useEditDeploymentForm.ts
@@ -49,6 +49,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
   const [name, setName] = useState(deployment.name)
   const [image, setImage] = useState(deployment.image)
   const [domain, setDomain] = useState(deployment.domain)
+  const [isPublic, setIsPublic] = useState(deployment.public)
   const [basicAuthEnabled, setBasicAuthEnabled] = useState(Boolean(deployment.basic_auth && deployment.basic_auth.users.length > 0))
   const [errors, setErrors] = useState<FormErrors>(EMPTY_ERRORS)
 
@@ -70,6 +71,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
       ports: portRows.rows.map(r => r.port.trim()),
       volumes: volumeRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
       domain: domain.trim(),
+      public: isPublic,
       basic_auth: basicAuthEnabled
         ? {
             users: basicAuthRows.rows.map(row => ({
@@ -80,7 +82,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
         : undefined,
       security: deployment.security,
     }
-  }, [name, image, domain, envRows.rows, portRows.rows, volumeRows.rows, basicAuthEnabled, basicAuthRows.rows, deployment.security])
+  }, [name, image, domain, isPublic, envRows.rows, portRows.rows, volumeRows.rows, basicAuthEnabled, basicAuthRows.rows, deployment.security])
 
   const isDirty = useMemo(() => {
     const initial: UpdateDeploymentInput = {
@@ -93,13 +95,15 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
       }),
       volumes: deployment.volumes,
       domain: deployment.domain,
+      public: deployment.public,
       basic_auth: deployment.basic_auth,
       security: deployment.security,
     }
 
     if (initial.name !== normalizedInput.name ||
       initial.image !== normalizedInput.image ||
-      initial.domain !== normalizedInput.domain) {
+      initial.domain !== normalizedInput.domain ||
+      initial.public !== normalizedInput.public) {
       return true
     }
 
@@ -200,6 +204,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
     name, setName,
     image, setImage,
     domain, setDomain,
+    isPublic, setIsPublic,
     basicAuthEnabled, setBasicAuthEnabled,
     envRows,
     portRows,

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -243,6 +243,7 @@ export type CreateDeploymentInput = {
   ports: string[]
   volumes: string[]
   domain: string
+  public: boolean
   basic_auth?: BasicAuthConfig
 }
 
@@ -263,6 +264,7 @@ export type UpdateDeploymentInput = {
   ports: string[]
   volumes: string[]
   domain: string
+  public: boolean
   basic_auth?: BasicAuthConfig
   security?: SecurityConfig
 }
@@ -283,6 +285,7 @@ export type PatchDeploymentInput = {
   ports?: string[]
   volumes?: string[]
   domain?: string
+  public?: boolean
   basic_auth?: BasicAuthConfig
   security?: SecurityConfig
 }

--- a/dashboard/src/pages/DeploymentDetailPage.tsx
+++ b/dashboard/src/pages/DeploymentDetailPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, useParams } from '@tanstack/react-router'
-import { AlertTriangle, ArrowLeft, ChevronDown, ExternalLink, Globe, Hash, Package, Pencil, RotateCcw } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, ChevronDown, ExternalLink, Globe, Hash, Lock, Package, Pencil, RotateCcw, Unlock } from 'lucide-react'
+import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../components/ui/dialog'
 import EditDeploymentForm from '../deployments/EditDeploymentForm'
@@ -124,6 +125,21 @@ export function DeploymentDetailPage() {
             {restartMutation.isError ? (
               <p className="text-xs text-destructive">Failed to restart deployment.</p>
             ) : null}
+            <div className="flex flex-wrap items-center gap-2">
+              {deployment.public ? (
+                <Unlock className="h-3 w-3 shrink-0 text-emerald-600" />
+              ) : (
+                <Lock className="h-3 w-3 shrink-0 text-amber-700" />
+              )}
+              <Badge variant={deployment.public ? 'success' : 'warning'}>
+                {deployment.public ? 'Public' : 'Private'}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
+                {deployment.public
+                  ? 'Traffic goes directly to your app.'
+                  : 'Protected by Lotsen login before app access.'}
+              </span>
+            </div>
             {deployment.domain && (
               <div className="flex items-center gap-1.5">
                 <Globe className="h-3 w-3 shrink-0 text-muted-foreground/50" />

--- a/dashboard/src/pages/DeploymentList.tsx
+++ b/dashboard/src/pages/DeploymentList.tsx
@@ -6,7 +6,6 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import CreateDeploymentForm from '../deployments/CreateDeploymentForm'
-import EditDeploymentForm from '../deployments/EditDeploymentForm'
 import { DeploymentTable } from '../deployments/DeploymentTable'
 import { useDeleteDeploymentDialog } from '../deployments/useDeleteDeploymentDialog'
 import { useDeploymentDialogs } from '../deployments/useDeploymentDialogs'
@@ -31,9 +30,6 @@ export default function DeploymentList() {
     openCreateDialog,
     closeCreateDialog,
     setCreateDialogOpen,
-    editingDeployment,
-    openEditDialog,
-    closeEditDialog,
   } = useDeploymentDialogs()
 
   const statusCounts = useMemo(() => {
@@ -184,26 +180,6 @@ export default function DeploymentList() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={editingDeployment !== null} onOpenChange={open => !open && closeEditDialog()}>
-        <DialogContent className="max-h-[90vh] overflow-y-auto border-border/60 sm:max-w-4xl">
-          <DialogHeader>
-            <DialogTitle>Edit deployment</DialogTitle>
-            <DialogDescription>
-              Update runtime settings for <span className="font-medium text-foreground">{editingDeployment?.name}</span>.
-            </DialogDescription>
-          </DialogHeader>
-          {editingDeployment && (
-            <EditDeploymentForm
-              key={editingDeployment.id}
-              deployment={editingDeployment}
-              onClose={closeEditDialog}
-              className="mb-0 border-0 shadow-none"
-              hideHeader
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
       <Dialog open={deploymentToDelete !== null} onOpenChange={open => !open && closeDeleteDialog()}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
@@ -252,7 +228,6 @@ export default function DeploymentList() {
         isError={isError}
         isDeleting={deleteMutation.isPending}
         onDelete={openDeleteDialog}
-        onEdit={openEditDialog}
         onCreate={openCreateDialog}
         onClearFilters={() => {
           setSearch('')

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -1,14 +1,23 @@
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { Rocket } from 'lucide-react'
+import { useEffect } from 'react'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
+import { useAuth } from '../auth/useAuth'
 import { useLoginForm } from '../auth/useLoginForm'
 import { UnauthorizedError } from '../lib/api'
 
 export function LoginPage() {
   const { redirect } = useSearch({ strict: false }) as { redirect?: string }
   const navigate = useNavigate()
+  const { isLoading, isAuthenticated, isAuthDisabled } = useAuth()
+
+  useEffect(() => {
+    if (!isLoading && (isAuthenticated || isAuthDisabled)) {
+      navigate({ to: (redirect as never) ?? '/deployments' })
+    }
+  }, [isLoading, isAuthenticated, isAuthDisabled, redirect, navigate])
 
   const { username, setUsername, password, setPassword, mutation } = useLoginForm(() => {
     navigate({ to: (redirect as never) ?? '/deployments' })

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': 'http://localhost:8080',
+      '/auth': 'http://localhost:8080',
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- add explicit public/private switches to deployment create and edit flows, wiring the `public` field through dashboard API payloads
- surface deployment exposure status in the UI with clear Public/Private indicators in both list rows and deployment detail view
- fix local dev auth behavior by proxying `/auth` through Vite and ensuring `make dev` starts with auth env vars cleared; remove list-view edit action to keep editing on the detail page

## Testing
- bun x vitest run src/deployments/CreateDeploymentForm.test.tsx src/deployments/EditDeploymentForm.test.tsx
- bun x tsc --noEmit