### PR TITLE
feat(host): add host profile metadata and rework host controls

### DIFF
--- a/api/cmd/lotsen/main.go
+++ b/api/cmd/lotsen/main.go
@@ -60,6 +60,11 @@ func main() {
 
 	h := internalapi.NewWithVersion(s, broker, logStreamer, version)
 	h.SetAuth(userStore, jwtSecret)
+	hostProfileStore, err := internalapi.NewFileHostProfileStore(hostProfilePath(dataPath()))
+	if err != nil {
+		log.Fatalf("lotsen: open host profile store: %v", err)
+	}
+	h.SetHostProfileStore(hostProfileStore)
 
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
@@ -69,6 +74,10 @@ func main() {
 	if err := http.ListenAndServe(addr, handler); err != nil {
 		log.Fatalf("lotsen: %v", err)
 	}
+}
+
+func hostProfilePath(storePath string) string {
+	return filepath.Join(filepath.Dir(storePath), "host_profile.json")
 }
 
 func authFromEnv(storePath string) (*auth.UserStore, []byte, error) {

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -68,6 +68,11 @@ type AuthUserStore interface {
 	DeleteUser(username string) error
 }
 
+type HostProfileStore interface {
+	Get() (HostProfile, error)
+	UpdateDisplayName(displayName string) (HostProfile, error)
+}
+
 type basicAuthUserRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
@@ -120,6 +125,8 @@ type Handler struct {
 	containerStats *ContainerStatsCache
 	authStore      AuthUserStore
 	jwtSecret      []byte
+	hostProfiles   HostProfileStore
+	hostMetadata   HostMetadataIngestor
 }
 
 const defaultOrchestratorStaleAfter = 30 * time.Second
@@ -166,6 +173,7 @@ func NewWithDependencies(s Store, eb EventBus, dl DockerLogs, statusSource Syste
 	loadBalancerIngestor, _ := statusSource.(LoadBalancerHealthIngestor)
 	cpuIngestor, _ := statusSource.(CPUUtilizationIngestor)
 	ramIngestor, _ := statusSource.(RAMUtilizationIngestor)
+	hostMetadataIngestor, _ := statusSource.(HostMetadataIngestor)
 
 	return &Handler{
 		store:          s,
@@ -184,6 +192,7 @@ func NewWithDependencies(s Store, eb EventBus, dl DockerLogs, statusSource Syste
 		versions:       versions,
 		upgrade:        upgrader,
 		containerStats: NewContainerStatsCache(),
+		hostMetadata:   hostMetadataIngestor,
 	}
 }
 
@@ -192,6 +201,10 @@ func NewWithDependencies(s Store, eb EventBus, dl DockerLogs, statusSource Syste
 func (h *Handler) SetAuth(userStore AuthUserStore, jwtSecret []byte) {
 	h.authStore = userStore
 	h.jwtSecret = jwtSecret
+}
+
+func (h *Handler) SetHostProfileStore(store HostProfileStore) {
+	h.hostProfiles = store
 }
 
 func buildAPIStoreChecker(s Store) func(context.Context) bool {
@@ -228,6 +241,8 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/load-balancer/access-logs", protect(http.HandlerFunc(h.loadBalancerAccessLogs)))
 	mux.Handle("GET /api/version", protect(http.HandlerFunc(h.getVersion)))
 	mux.Handle("GET /api/version/releases", protect(http.HandlerFunc(h.getVersionReleases)))
+	mux.Handle("GET /api/host", protect(http.HandlerFunc(h.getHost)))
+	mux.Handle("PUT /api/host", protect(http.HandlerFunc(h.updateHost)))
 	mux.Handle("GET /api/users", protect(http.HandlerFunc(h.listUsers)))
 	mux.Handle("POST /api/users", protect(http.HandlerFunc(h.createUser)))
 	mux.Handle("PUT /api/users/{username}/password", protect(http.HandlerFunc(h.updateUserPassword)))

--- a/api/internal/api/handler_host.go
+++ b/api/internal/api/handler_host.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const maxHostDisplayNameLength = 64
+
+type HostProfile struct {
+	DisplayName string `json:"displayName"`
+}
+
+type hostResponse struct {
+	DisplayName string                    `json:"displayName"`
+	Metadata    *HostMetadataSystemStatus `json:"metadata,omitempty"`
+}
+
+func (h *Handler) getHost(w http.ResponseWriter, r *http.Request) {
+	profile := HostProfile{}
+	if h.hostProfiles != nil {
+		stored, err := h.hostProfiles.Get()
+		if err != nil {
+			http.Error(w, "failed to load host profile", http.StatusInternalServerError)
+			return
+		}
+		profile = stored
+	}
+
+	snapshot := h.currentSystemStatusSnapshot(r)
+	writeJSON(w, http.StatusOK, hostResponse{DisplayName: profile.DisplayName, Metadata: snapshot.Host.Metadata})
+}
+
+func (h *Handler) updateHost(w http.ResponseWriter, r *http.Request) {
+	if h.hostProfiles == nil {
+		http.Error(w, "host profile unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+
+	var body struct {
+		DisplayName *string `json:"displayName"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if body.DisplayName == nil {
+		http.Error(w, "displayName is required", http.StatusBadRequest)
+		return
+	}
+
+	displayName := strings.TrimSpace(*body.DisplayName)
+	if len(displayName) > maxHostDisplayNameLength {
+		http.Error(w, "displayName too long", http.StatusBadRequest)
+		return
+	}
+
+	updated, err := h.hostProfiles.UpdateDisplayName(displayName)
+	if err != nil {
+		http.Error(w, "failed to update host profile", http.StatusInternalServerError)
+		return
+	}
+
+	snapshot := h.currentSystemStatusSnapshot(r)
+	writeJSON(w, http.StatusOK, hostResponse{DisplayName: updated.DisplayName, Metadata: snapshot.Host.Metadata})
+}

--- a/api/internal/api/handler_host_test.go
+++ b/api/internal/api/handler_host_test.go
@@ -1,0 +1,152 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/ercadev/dirigent/internal/api"
+	"github.com/ercadev/dirigent/internal/events"
+)
+
+func newTestServerWithHostProfileStore(t *testing.T, storePath string) *httptest.Server {
+	t.Helper()
+
+	hostProfiles, err := api.NewFileHostProfileStore(storePath)
+	if err != nil {
+		t.Fatalf("NewFileHostProfileStore: %v", err)
+	}
+
+	h := api.New(newMemStore(), events.NewBroker(), noopDockerLogs{})
+	h.SetHostProfileStore(hostProfiles)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return httptest.NewServer(mux)
+}
+
+func TestHost_GetAndUpdateDisplayName(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServerWithHostProfileStore(t, filepath.Join(t.TempDir(), "host_profile.json"))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/host")
+	if err != nil {
+		t.Fatalf("GET /api/host: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var initial struct {
+		DisplayName string `json:"displayName"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&initial); err != nil {
+		t.Fatalf("decode host response: %v", err)
+	}
+	if initial.DisplayName != "" {
+		t.Fatalf("want empty initial display name, got %q", initial.DisplayName)
+	}
+
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/host", bytes.NewBufferString(`{"displayName":"prod-eu"}`))
+	if err != nil {
+		t.Fatalf("build PUT /api/host request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	updateResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/host: %v", err)
+	}
+	defer updateResp.Body.Close()
+
+	if updateResp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", updateResp.StatusCode)
+	}
+
+	var updated struct {
+		DisplayName string `json:"displayName"`
+	}
+	if err := json.NewDecoder(updateResp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode updated host response: %v", err)
+	}
+	if updated.DisplayName != "prod-eu" {
+		t.Fatalf("want updated display name prod-eu, got %q", updated.DisplayName)
+	}
+
+	verifyResp, err := http.Get(srv.URL + "/api/host")
+	if err != nil {
+		t.Fatalf("GET /api/host after update: %v", err)
+	}
+	defer verifyResp.Body.Close()
+
+	var persisted struct {
+		DisplayName string `json:"displayName"`
+	}
+	if err := json.NewDecoder(verifyResp.Body).Decode(&persisted); err != nil {
+		t.Fatalf("decode persisted host response: %v", err)
+	}
+	if persisted.DisplayName != "prod-eu" {
+		t.Fatalf("want persisted display name prod-eu, got %q", persisted.DisplayName)
+	}
+}
+
+func TestHost_MetadataFromHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServerWithHostProfileStore(t, filepath.Join(t.TempDir(), "host_profile.json"))
+	defer srv.Close()
+
+	body := `{"host":{"metadata":{"ipAddress":"10.0.0.5","osName":"Ubuntu","osVersion":"24.04","specs":{"cpuCores":4,"memoryBytes":8589934592,"diskBytes":68719476736}}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/system-status/orchestrator-heartbeat", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("build heartbeat request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	heartbeatResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST orchestrator heartbeat: %v", err)
+	}
+	heartbeatResp.Body.Close()
+	if heartbeatResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("want 204 from heartbeat endpoint, got %d", heartbeatResp.StatusCode)
+	}
+
+	resp, err := http.Get(srv.URL + "/api/host")
+	if err != nil {
+		t.Fatalf("GET /api/host: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		Metadata *struct {
+			IPAddress string `json:"ipAddress"`
+			OSName    string `json:"osName"`
+			OSVersion string `json:"osVersion"`
+			Specs     struct {
+				CPUCores    int    `json:"cpuCores"`
+				MemoryBytes uint64 `json:"memoryBytes"`
+				DiskBytes   uint64 `json:"diskBytes"`
+			} `json:"specs"`
+		} `json:"metadata"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode host payload: %v", err)
+	}
+
+	if payload.Metadata == nil {
+		t.Fatal("want metadata in host payload")
+	}
+	if payload.Metadata.IPAddress != "10.0.0.5" {
+		t.Fatalf("want ip 10.0.0.5, got %q", payload.Metadata.IPAddress)
+	}
+	if payload.Metadata.Specs.CPUCores != 4 {
+		t.Fatalf("want cpu cores 4, got %d", payload.Metadata.Specs.CPUCores)
+	}
+}

--- a/api/internal/api/handler_record_orchestrator_heartbeat.go
+++ b/api/internal/api/handler_record_orchestrator_heartbeat.go
@@ -50,6 +50,16 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 				UsagePercent *float64   `json:"usagePercent"`
 				CheckedAt    *time.Time `json:"checkedAt"`
 			} `json:"ram"`
+			Metadata *struct {
+				IPAddress string `json:"ipAddress"`
+				OSName    string `json:"osName"`
+				OSVersion string `json:"osVersion"`
+				Specs     *struct {
+					CPUCores    *int    `json:"cpuCores"`
+					MemoryBytes *uint64 `json:"memoryBytes"`
+					DiskBytes   *uint64 `json:"diskBytes"`
+				} `json:"specs"`
+			} `json:"metadata"`
 		} `json:"host"`
 		ContainerStats *map[string]struct {
 			CPUPercent       *float64 `json:"cpuPercent"`
@@ -116,6 +126,35 @@ func (h *Handler) recordOrchestratorHeartbeat(w http.ResponseWriter, r *http.Req
 	}
 
 	if body.Host != nil {
+		if body.Host.Metadata != nil {
+			if h.hostMetadata == nil {
+				http.Error(w, "system status unavailable", http.StatusServiceUnavailable)
+				return
+			}
+
+			hostMetadata := HostMetadataSystemStatus{
+				IPAddress: body.Host.Metadata.IPAddress,
+				OSName:    body.Host.Metadata.OSName,
+				OSVersion: body.Host.Metadata.OSVersion,
+			}
+			if body.Host.Metadata.Specs != nil {
+				if body.Host.Metadata.Specs.CPUCores != nil {
+					hostMetadata.Specs.CPUCores = *body.Host.Metadata.Specs.CPUCores
+				}
+				if body.Host.Metadata.Specs.MemoryBytes != nil {
+					hostMetadata.Specs.MemoryBytes = *body.Host.Metadata.Specs.MemoryBytes
+				}
+				if body.Host.Metadata.Specs.DiskBytes != nil {
+					hostMetadata.Specs.DiskBytes = *body.Host.Metadata.Specs.DiskBytes
+				}
+			}
+
+			if err := h.hostMetadata.RecordHostMetadata(r.Context(), hostMetadata); err != nil {
+				http.Error(w, "failed to record host metadata", http.StatusInternalServerError)
+				return
+			}
+		}
+
 		if body.Host.CPU != nil && body.Host.CPU.UsagePercent != nil {
 			if h.cpu == nil {
 				http.Error(w, "system status unavailable", http.StatusServiceUnavailable)

--- a/api/internal/api/host_profile_store.go
+++ b/api/internal/api/host_profile_store.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+)
+
+type FileHostProfileStore struct {
+	mu   sync.RWMutex
+	path string
+}
+
+func NewFileHostProfileStore(path string) (*FileHostProfileStore, error) {
+	if path == "" {
+		return nil, fmt.Errorf("host profile store: path must be non-empty")
+	}
+	if !filepath.IsAbs(path) {
+		return nil, fmt.Errorf("host profile store: path must be absolute: %s", path)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("host profile store: create data dir: %w", err)
+	}
+
+	return &FileHostProfileStore{path: path}, nil
+}
+
+func (s *FileHostProfileStore) Get() (HostProfile, error) {
+	var result HostProfile
+	err := s.withRLock(func() error {
+		profile, err := s.read()
+		if err != nil {
+			return err
+		}
+		result = profile
+		return nil
+	})
+	if err != nil {
+		return HostProfile{}, err
+	}
+
+	return result, nil
+}
+
+func (s *FileHostProfileStore) UpdateDisplayName(displayName string) (HostProfile, error) {
+	updated := HostProfile{}
+	err := s.withLock(func() error {
+		profile, err := s.read()
+		if err != nil {
+			return err
+		}
+		profile.DisplayName = displayName
+		if err := s.persist(profile); err != nil {
+			return err
+		}
+		updated = profile
+		return nil
+	})
+	if err != nil {
+		return HostProfile{}, err
+	}
+
+	return updated, nil
+}
+
+func (s *FileHostProfileStore) withLock(fn func() error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	lf, err := os.OpenFile(s.path+".lock", os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("host profile store: open lock file: %w", err)
+	}
+	defer lf.Close()
+
+	if err := syscall.Flock(int(lf.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("host profile store: acquire lock: %w", err)
+	}
+	defer syscall.Flock(int(lf.Fd()), syscall.LOCK_UN) //nolint:errcheck
+
+	return fn()
+}
+
+func (s *FileHostProfileStore) withRLock(fn func() error) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	lf, err := os.OpenFile(s.path+".lock", os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("host profile store: open lock file: %w", err)
+	}
+	defer lf.Close()
+
+	if err := syscall.Flock(int(lf.Fd()), syscall.LOCK_SH); err != nil {
+		return fmt.Errorf("host profile store: acquire shared lock: %w", err)
+	}
+	defer syscall.Flock(int(lf.Fd()), syscall.LOCK_UN) //nolint:errcheck
+
+	return fn()
+}
+
+func (s *FileHostProfileStore) read() (HostProfile, error) {
+	f, err := os.Open(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return HostProfile{}, nil
+	}
+	if err != nil {
+		return HostProfile{}, fmt.Errorf("host profile store: open %s: %w", s.path, err)
+	}
+	defer f.Close()
+
+	var profile HostProfile
+	if err := json.NewDecoder(f).Decode(&profile); err != nil {
+		return HostProfile{}, fmt.Errorf("host profile store: decode %s: %w", s.path, err)
+	}
+
+	return profile, nil
+}
+
+func (s *FileHostProfileStore) persist(profile HostProfile) error {
+	tmp := s.path + ".tmp"
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("host profile store: create temp file: %w", err)
+	}
+
+	if err := json.NewEncoder(f).Encode(profile); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("host profile store: encode: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("host profile store: sync temp file: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("host profile store: close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmp, s.path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("host profile store: rename: %w", err)
+	}
+
+	return nil
+}

--- a/api/internal/api/system_status.go
+++ b/api/internal/api/system_status.go
@@ -87,10 +87,24 @@ type HostMetricSystemStatus struct {
 	LastUpdated  *time.Time        `json:"lastUpdated,omitempty"`
 }
 
+type HostMetadataSpecsSystemStatus struct {
+	CPUCores    int    `json:"cpuCores,omitempty"`
+	MemoryBytes uint64 `json:"memoryBytes,omitempty"`
+	DiskBytes   uint64 `json:"diskBytes,omitempty"`
+}
+
+type HostMetadataSystemStatus struct {
+	IPAddress string                        `json:"ipAddress,omitempty"`
+	OSName    string                        `json:"osName,omitempty"`
+	OSVersion string                        `json:"osVersion,omitempty"`
+	Specs     HostMetadataSpecsSystemStatus `json:"specs,omitempty"`
+}
+
 // HostSystemStatus carries host-level runtime utilization signals.
 type HostSystemStatus struct {
-	CPU HostMetricSystemStatus `json:"cpu"`
-	RAM HostMetricSystemStatus `json:"ram"`
+	CPU      HostMetricSystemStatus    `json:"cpu"`
+	RAM      HostMetricSystemStatus    `json:"ram"`
+	Metadata *HostMetadataSystemStatus `json:"metadata,omitempty"`
 }
 
 // SystemStatusSnapshot is the typed dashboard-facing system-status contract.
@@ -132,6 +146,10 @@ type RAMUtilizationIngestor interface {
 	RecordRAMUtilization(ctx context.Context, usagePercent float64, at time.Time) error
 }
 
+type HostMetadataIngestor interface {
+	RecordHostMetadata(ctx context.Context, metadata HostMetadataSystemStatus) error
+}
+
 type defaultSystemStatusProvider struct {
 	now                func() time.Time
 	staleAfter         time.Duration
@@ -145,6 +163,7 @@ type defaultSystemStatusProvider struct {
 	hostSignalMu       sync.RWMutex
 	cpuSignal          hostMetricSignal
 	ramSignal          hostMetricSignal
+	hostMetadata       hostMetadataSignal
 }
 
 type orchestratorHeartbeatSignal struct {
@@ -170,6 +189,11 @@ type hostMetricSignal struct {
 	lastCheckedUTC time.Time
 	usagePercent   float64
 	hasSignal      bool
+}
+
+type hostMetadataSignal struct {
+	metadata  HostMetadataSystemStatus
+	hasSignal bool
 }
 
 func newDefaultSystemStatusProvider(now func() time.Time, staleAfter time.Duration, apiStoreCheck func(context.Context) bool) SystemStatusProvider {
@@ -202,8 +226,9 @@ func (p *defaultSystemStatusProvider) Snapshot(ctx context.Context) (SystemStatu
 		LoadBalancer: p.loadBalancerStatus(),
 		Docker:       p.dockerStatus(),
 		Host: HostSystemStatus{
-			CPU: p.cpuStatus(),
-			RAM: p.ramStatus(),
+			CPU:      p.cpuStatus(),
+			RAM:      p.ramStatus(),
+			Metadata: p.hostMetadataStatus(),
 		},
 	}, nil
 }
@@ -404,6 +429,17 @@ func (p *defaultSystemStatusProvider) RecordRAMUtilization(_ context.Context, us
 	return nil
 }
 
+func (p *defaultSystemStatusProvider) RecordHostMetadata(_ context.Context, metadata HostMetadataSystemStatus) error {
+	p.hostSignalMu.Lock()
+	p.hostMetadata = hostMetadataSignal{
+		metadata:  cloneHostMetadata(metadata),
+		hasSignal: true,
+	}
+	p.hostSignalMu.Unlock()
+
+	return nil
+}
+
 func (p *defaultSystemStatusProvider) cpuStatus() HostMetricSystemStatus {
 	p.hostSignalMu.RLock()
 	signal := p.cpuSignal
@@ -443,6 +479,32 @@ func (p *defaultSystemStatusProvider) ramStatus() HostMetricSystemStatus {
 		State:        state,
 		UsagePercent: signal.usagePercent,
 		LastUpdated:  &ramCheckedAt,
+	}
+}
+
+func (p *defaultSystemStatusProvider) hostMetadataStatus() *HostMetadataSystemStatus {
+	p.hostSignalMu.RLock()
+	signal := p.hostMetadata
+	p.hostSignalMu.RUnlock()
+
+	if !signal.hasSignal {
+		return nil
+	}
+
+	metadata := cloneHostMetadata(signal.metadata)
+	return &metadata
+}
+
+func cloneHostMetadata(in HostMetadataSystemStatus) HostMetadataSystemStatus {
+	return HostMetadataSystemStatus{
+		IPAddress: in.IPAddress,
+		OSName:    in.OSName,
+		OSVersion: in.OSVersion,
+		Specs: HostMetadataSpecsSystemStatus{
+			CPUCores:    in.Specs.CPUCores,
+			MemoryBytes: in.Specs.MemoryBytes,
+			DiskBytes:   in.Specs.DiskBytes,
+		},
 	}
 }
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -214,9 +214,28 @@ export type HostMetricSystemStatus = {
   lastUpdated?: string
 }
 
+export type HostSpecs = {
+  cpuCores?: number
+  memoryBytes?: number
+  diskBytes?: number
+}
+
+export type HostMetadata = {
+  ipAddress?: string
+  osName?: string
+  osVersion?: string
+  specs?: HostSpecs
+}
+
 export type HostSystemStatus = {
   cpu: HostMetricSystemStatus
   ram: HostMetricSystemStatus
+  metadata?: HostMetadata
+}
+
+export type HostProfile = {
+  displayName: string
+  metadata?: HostMetadata
 }
 
 export type SystemStatusSnapshot = {
@@ -351,6 +370,22 @@ export async function restartDeployment(id: string): Promise<Deployment> {
 export async function getSystemStatus(): Promise<SystemStatusSnapshot> {
   const res = await apiFetch('/api/system-status')
   if (!res.ok) throw new Error('Failed to fetch system status')
+  return res.json()
+}
+
+export async function getHostProfile(): Promise<HostProfile> {
+  const res = await apiFetch('/api/host')
+  if (!res.ok) throw new Error('Failed to fetch host profile')
+  return res.json()
+}
+
+export async function updateHostProfile(displayName: string): Promise<HostProfile> {
+  const res = await apiFetch('/api/host', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ displayName }),
+  })
+  if (!res.ok) throw new Error('Failed to update host profile')
   return res.json()
 }
 

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -6,7 +6,8 @@ import remarkGfm from 'remark-gfm'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog'
-import { getVersionInfo, getVersionReleases, triggerUpgrade, type VersionRelease } from '../lib/api'
+import { Input } from '../components/ui/input'
+import { getHostProfile, getVersionInfo, getVersionReleases, triggerUpgrade, updateHostProfile, type VersionRelease } from '../lib/api'
 import { UpgradeLogPanel } from '../settings/UpgradeLogPanel'
 import { useUpgradeLogsSSE } from '../settings/useUpgradeLogsSSE'
 import { useVersionCheck } from '../settings/useVersionCheck'
@@ -46,6 +47,21 @@ function formatDate(value?: string) {
   return parsed.toLocaleString()
 }
 
+function formatBytes(value?: number) {
+  if (!value || value <= 0) return 'Unavailable'
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let size = value
+  let unitIndex = 0
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex += 1
+  }
+
+  const precision = unitIndex < 2 ? 0 : 1
+  return `${size.toFixed(precision)} ${units[unitIndex]}`
+}
+
 function parseSemver(raw?: string): [number, number, number] | null {
   if (!raw) return null
   const match = raw.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/)
@@ -82,6 +98,27 @@ function getUpgradePath(currentVersion: string, latestVersion: string | undefine
     .sort((a, b) => compareSemver(b.version, a.version))
 }
 
+function FieldTile({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <article className="rounded-lg border border-border/55 bg-background/70 px-3 py-2.5">
+      <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <p className={mono ? 'mt-1 font-mono text-sm text-foreground' : 'mt-1 text-sm text-foreground'}>{value}</p>
+    </article>
+  )
+}
+
+function RunwayStat({ label, value, status }: { label: string; value: string; status?: ReactNode }) {
+  return (
+    <article className="rounded-lg border border-border/55 bg-background/70 p-3">
+      <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <div className="mt-1.5 flex items-center gap-2">
+        <p className="font-mono text-sm text-foreground">{value}</p>
+        {status}
+      </div>
+    </article>
+  )
+}
+
 export function SettingsPage() {
   const queryClient = useQueryClient()
   const [confirmOpen, setConfirmOpen] = useState(false)
@@ -92,9 +129,24 @@ export function SettingsPage() {
   const [reconnectReady, setReconnectReady] = useState(false)
   const [targetVersion, setTargetVersion] = useState<string | null>(null)
   const [upgradeError, setUpgradeError] = useState<string | null>(null)
+  const [hostNameDraft, setHostNameDraft] = useState('')
+  const [hostUpdateError, setHostUpdateError] = useState<string | null>(null)
   const [attemptId, setAttemptId] = useState(0)
 
   const { currentVersion, latestVersion, publishedAt, releaseNotes, upgradeAvailable, cachedAt, isLoading, isError } = useVersionCheck()
+  const hostProfileQuery = useQuery({
+    queryKey: ['hostProfile'],
+    queryFn: getHostProfile,
+  })
+  const hostMetadata = hostProfileQuery.data?.metadata
+  const hasHostMetadata = Boolean(
+    hostMetadata?.ipAddress ||
+      hostMetadata?.osName ||
+      hostMetadata?.osVersion ||
+      hostMetadata?.specs?.cpuCores ||
+      hostMetadata?.specs?.memoryBytes ||
+      hostMetadata?.specs?.diskBytes
+  )
   const { data: releases = [], isLoading: releasesLoading } = useQuery({
     queryKey: ['version-releases'],
     queryFn: () => getVersionReleases(30),
@@ -192,17 +244,32 @@ export function SettingsPage() {
     },
   })
 
+  useEffect(() => {
+    setHostNameDraft(hostProfileQuery.data?.displayName ?? '')
+  }, [hostProfileQuery.data?.displayName])
+
+  const hostNameUpdate = useMutation({
+    mutationFn: updateHostProfile,
+    onSuccess: profile => {
+      queryClient.setQueryData(['hostProfile'], profile)
+      setHostUpdateError(null)
+    },
+    onError: error => {
+      setHostUpdateError(error instanceof Error ? error.message : 'Failed to update host name')
+    },
+  })
+
   const activeTarget = selectedUpgradeTarget ?? (upgradeAvailable ? latestVersion ?? null : null)
   const canStartUpgrade = upgradeAvailable && Boolean(activeTarget) && !isUpgradeRunning && !startUpgrade.isPending
 
   return (
-    <section className="space-y-5">
+    <section className="space-y-4">
       {isLoading && <p className="text-sm text-muted-foreground">Checking version information...</p>}
 
       {isError && <p className="text-sm text-destructive">Unable to fetch version information right now.</p>}
 
       {reconnectReady && (
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[#2a7a64]/30 bg-[#2a7a64]/10 px-4 py-3 text-sm text-[#1f5f4f] dark:border-[#2a7a64]/40 dark:bg-[#2a7a64]/20 dark:text-[#93d0bc]">
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[#2a7a64]/30 bg-[#2a7a64]/10 px-4 py-3 text-sm text-[#1f5f4f] dark:border-[#2a7a64]/40 dark:bg-[#2a7a64]/20 dark:text-[#93d0bc]">
           <p>Upgrade complete - reload to connect to the updated runtime.</p>
           <Button type="button" size="sm" onClick={() => window.location.reload()}>
             <RefreshCw className="h-4 w-4" />
@@ -212,7 +279,7 @@ export function SettingsPage() {
       )}
 
       {upgradeError && (
-        <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-destructive">
+        <div className="rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-destructive">
           <div className="flex items-start gap-2">
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
             <p className="text-sm font-medium">Upgrade failed</p>
@@ -222,39 +289,70 @@ export function SettingsPage() {
       )}
 
       <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Running now</p>
-        <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">Installed release details</h2>
-        <p className="mt-1 text-sm text-muted-foreground">Current runtime identity and local cache timing.</p>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Host dossier</p>
+            <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">Identity and runtime facts</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Set the host label and confirm machine facts before making runtime changes.</p>
+          </div>
+          <Badge variant="outline" className="rounded-md border-border/70 bg-background/70 px-2.5 py-1 font-mono text-[11px]">
+            {hostProfileQuery.data?.displayName?.trim() || 'Unnamed host'}
+          </Badge>
+        </div>
 
-        <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-          <article className="rounded-lg border border-border/60 bg-background/70 p-3">
-            <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Installed version</p>
-            <p className="mt-1 font-mono text-sm text-foreground">{currentVersion}</p>
-          </article>
-          <article className="rounded-lg border border-border/60 bg-background/70 p-3">
-            <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Latest discovered</p>
-            <div className="mt-1 flex items-center gap-2">
-              <p className="font-mono text-sm text-foreground">{latestVersion ?? 'Unavailable'}</p>
-              {upgradeAvailable ? <Badge variant="info">behind</Badge> : <Badge variant="secondary">current</Badge>}
-            </div>
-          </article>
-          <article className="rounded-lg border border-border/60 bg-background/70 p-3">
-            <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Latest published</p>
-            <p className="mt-1 text-sm text-foreground">{formatDate(publishedAt)}</p>
-          </article>
-          <article className="rounded-lg border border-border/60 bg-background/70 p-3">
-            <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Version cache refreshed</p>
-            <p className="mt-1 text-sm text-foreground">{formatDate(cachedAt)}</p>
-          </article>
+        <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)]">
+          <section className="rounded-lg border border-border/55 bg-background/70 p-4">
+            <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Host identity</p>
+            <p className="mt-1 text-sm text-muted-foreground">Name shown in navigation and logs.</p>
+
+            <form
+              className="mt-3 flex flex-col gap-2 sm:flex-row"
+              onSubmit={event => {
+                event.preventDefault()
+                hostNameUpdate.mutate(hostNameDraft)
+              }}
+            >
+              <Input
+                value={hostNameDraft}
+                onChange={event => setHostNameDraft(event.target.value)}
+                placeholder="e.g. prod-eu-1"
+                maxLength={64}
+                className="sm:max-w-sm"
+                aria-label="Host display name"
+              />
+              <Button type="submit" disabled={hostNameUpdate.isPending || hostProfileQuery.isLoading}>
+                Save host name
+              </Button>
+            </form>
+
+            {hostUpdateError && <p className="mt-2 text-sm text-destructive">{hostUpdateError}</p>}
+          </section>
+
+          <section className="rounded-lg border border-border/55 bg-background/70 p-4">
+            <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Machine runtime facts</p>
+            <p className="mt-1 text-sm text-muted-foreground">Snapshot from the active host process.</p>
+
+            {hasHostMetadata ? (
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                <FieldTile label="IP address" value={hostMetadata?.ipAddress || 'Unavailable'} mono />
+                <FieldTile label="Operating system" value={[hostMetadata?.osName, hostMetadata?.osVersion].filter(Boolean).join(' ') || 'Unavailable'} />
+                <FieldTile label="CPU" value={hostMetadata?.specs?.cpuCores ? `${hostMetadata.specs.cpuCores} cores` : 'Unavailable'} />
+                <FieldTile label="Memory" value={formatBytes(hostMetadata?.specs?.memoryBytes)} mono />
+                <FieldTile label="Disk" value={formatBytes(hostMetadata?.specs?.diskBytes)} mono />
+              </div>
+            ) : (
+              <p className="mt-3 text-sm text-muted-foreground">Metadata unavailable.</p>
+            )}
+          </section>
         </div>
       </section>
 
       <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Upgrade path</p>
-            <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">Available versions</h2>
-            <p className="mt-1 text-sm text-muted-foreground">All releases between installed and latest with direct upgrade actions.</p>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Release runway</p>
+            <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">Installed and discovered versions</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Check runtime state and jump directly to the newest valid target.</p>
           </div>
           {latestVersion && upgradeAvailable && upgradePath.length > 0 && (
             <Button
@@ -268,6 +366,30 @@ export function SettingsPage() {
               {startUpgrade.isPending || isUpgradeRunning ? 'Upgrading...' : `Upgrade to ${latestVersion}`}
             </Button>
           )}
+        </div>
+
+        <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+          <RunwayStat label="Installed version" value={currentVersion} />
+          <RunwayStat
+            label="Latest discovered"
+            value={latestVersion ?? 'Unavailable'}
+            status={upgradeAvailable ? <Badge variant="info">behind</Badge> : <Badge variant="secondary">current</Badge>}
+          />
+          <RunwayStat label="Latest published" value={formatDate(publishedAt)} />
+          <RunwayStat label="Cache refreshed" value={formatDate(cachedAt)} />
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Upgrade sequence</p>
+            <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">Available versions</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Runway ledger of releases between installed and latest.</p>
+          </div>
+          <Badge variant="outline" className="rounded-md border-border/70 bg-background/70 px-2.5 py-1 font-mono text-[11px]">
+            {upgradePath.length} hop{upgradePath.length === 1 ? '' : 's'}
+          </Badge>
         </div>
 
         {releasesLoading ? (
@@ -284,39 +406,47 @@ export function SettingsPage() {
               const canUpgradeToRelease = upgradeAvailable && !isCurrent && !isUpgradeRunning && !startUpgrade.isPending
 
               return (
-                <article key={release.version} className="rounded-lg border border-border/60 bg-background/70 p-3">
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <p className="font-mono text-sm font-medium text-foreground">{release.version}</p>
-                      {isCurrent && <Badge variant="secondary">installed</Badge>}
-                      {isLatest && <Badge variant="info">latest</Badge>}
-                      <span className="text-xs text-muted-foreground">Published {formatDate(release.publishedAt)}</span>
+                <article key={release.version} className="rounded-lg border border-border/55 bg-background/70 p-3">
+                  <div className="flex gap-3">
+                    <div className="mt-1 flex shrink-0 flex-col items-center">
+                      <span className="h-2.5 w-2.5 rounded-full bg-border" />
+                      {!isLatest && <span className="mt-1 h-full w-px bg-border/70" />}
                     </div>
-                    <Button
-                      type="button"
-                      size="sm"
-                      disabled={!canUpgradeToRelease}
-                      onClick={() => {
-                        setSelectedUpgradeTarget(release.version)
-                        setConfirmOpen(true)
-                      }}
-                    >
-                      Upgrade to {release.version}
-                    </Button>
-                  </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="font-mono text-sm font-medium text-foreground">{release.version}</p>
+                          {isCurrent && <Badge variant="secondary">installed</Badge>}
+                          {isLatest && <Badge variant="info">latest</Badge>}
+                          <span className="text-xs text-muted-foreground">Published {formatDate(release.publishedAt)}</span>
+                        </div>
+                        <Button
+                          type="button"
+                          size="sm"
+                          disabled={!canUpgradeToRelease}
+                          onClick={() => {
+                            setSelectedUpgradeTarget(release.version)
+                            setConfirmOpen(true)
+                          }}
+                        >
+                          Upgrade to {release.version}
+                        </Button>
+                      </div>
 
-                  <details className="mt-3 rounded-md border border-border/60 bg-background p-3">
-                    <summary className="cursor-pointer text-xs font-medium uppercase tracking-[0.13em] text-muted-foreground">Release notes</summary>
-                    <div className="mt-3 text-sm text-foreground">
-                      {release.releaseNotes?.trim() ? (
-                        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-                          {release.releaseNotes}
-                        </ReactMarkdown>
-                      ) : (
-                        <p className="text-sm text-muted-foreground">No release notes available.</p>
-                      )}
+                      <details className="mt-3 rounded-md border border-border/60 bg-background p-3">
+                        <summary className="cursor-pointer text-xs font-medium uppercase tracking-[0.13em] text-muted-foreground">Release notes</summary>
+                        <div className="mt-3 text-sm text-foreground">
+                          {release.releaseNotes?.trim() ? (
+                            <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                              {release.releaseNotes}
+                            </ReactMarkdown>
+                          ) : (
+                            <p className="text-sm text-muted-foreground">No release notes available.</p>
+                          )}
+                        </div>
+                      </details>
                     </div>
-                  </details>
+                  </div>
                 </article>
               )
             })}

--- a/dashboard/src/router.tsx
+++ b/dashboard/src/router.tsx
@@ -8,7 +8,8 @@ import {
   useNavigate,
   useRouterState,
 } from '@tanstack/react-router'
-import { Activity, Boxes, FileText, LogOut, Moon, Rocket, Server, Settings, Sun, Users } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { Gauge, HardDrive, LogOut, Moon, PackageSearch, Radar, Rocket, ScrollText, Sun, UserRound, UserRoundCog } from 'lucide-react'
 import { useEffect } from 'react'
 import { Button } from './components/ui/button'
 import {
@@ -32,6 +33,7 @@ import { SystemStatusPage } from './pages/SystemStatusPage'
 import { TrafficPage } from './pages/TrafficPage'
 import { UsersPage } from './pages/UsersPage'
 import { useAuth, useLogout } from './auth/useAuth'
+import { getHostProfile } from './lib/api'
 import { useVersionCheck } from './settings/useVersionCheck'
 import { useTheme } from './theme'
 
@@ -42,6 +44,11 @@ function DashboardLayout() {
   const { isAuthenticated, isAuthDisabled, isLoading, username } = useAuth()
   const navigate = useNavigate()
   const logoutMutation = useLogout()
+  const hostProfileQuery = useQuery({
+    queryKey: ['hostProfile'],
+    queryFn: getHostProfile,
+    refetchInterval: 60_000,
+  })
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated && !isAuthDisabled) {
@@ -54,20 +61,21 @@ function DashboardLayout() {
   }
 
   const isSystemStatusPage = pathname === '/system-status'
-  const isSettingsPage = pathname === '/settings'
+  const isHostPage = pathname === '/host' || pathname === '/settings'
   const isUsersPage = pathname === '/users'
   const isTrafficPage = pathname === '/traffic'
   const isLogsPage = pathname === '/logs'
   const isDeploymentPage = pathname.startsWith('/deployments')
   const isDeploymentDetailPage = isDeploymentPage && pathname !== '/deployments'
+  const hostName = hostProfileQuery.data?.displayName?.trim() || 'Unnamed host'
   const pageTitle = isSystemStatusPage
     ? 'System status'
     : isTrafficPage
       ? 'Traffic & security'
       : isLogsPage
       ? 'Logs'
-      : isSettingsPage
-      ? 'Settings'
+      : isHostPage
+      ? 'Host'
       : isUsersPage
       ? 'Users'
       : isDeploymentDetailPage
@@ -79,8 +87,8 @@ function DashboardLayout() {
       ? 'Inspect recent proxy traffic and effective protection settings.'
       : isLogsPage
       ? 'Inspect core service output and deployment log streams without SSH.'
-      : isSettingsPage
-      ? 'Manage product version and in-dashboard upgrades.'
+      : isHostPage
+      ? 'Manage host naming, metadata, and runtime upgrades.'
       : isUsersPage
       ? 'Create users, rotate passwords, and revoke dashboard access.'
       : isDeploymentDetailPage
@@ -120,16 +128,21 @@ function DashboardLayout() {
               )}
             </div>
           </div>
+          <div className="rounded-xl border border-border/70 bg-muted/45 p-3">
+            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/85">Current host</p>
+            <p className="mt-1 truncate text-sm font-semibold text-foreground">{hostName}</p>
+          </div>
         </SidebarHeader>
         <SidebarContent className="px-4 pb-4 pt-1">
           <nav aria-label="Dashboard sections" className="p-1">
             <SidebarGroup className="p-0">
+              <p className="px-2 pb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">Operate</p>
               <SidebarGroupContent>
                 <SidebarMenu>
                   <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname.startsWith('/deployments')} size="lg" className="rounded-lg">
                       <Link to="/deployments">
-                        <Boxes className="h-4 w-4 shrink-0" />
+                        <PackageSearch className="h-4 w-4 shrink-0" />
                         <span>Deployments</span>
                       </Link>
                     </SidebarMenuButton>
@@ -137,7 +150,7 @@ function DashboardLayout() {
                   <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname === '/system-status'} size="lg" className="rounded-lg">
                       <Link to="/system-status">
-                        <Server className="h-4 w-4 shrink-0" />
+                        <Gauge className="h-4 w-4 shrink-0" />
                         <span>System status</span>
                       </Link>
                     </SidebarMenuButton>
@@ -145,7 +158,7 @@ function DashboardLayout() {
                   <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname === '/traffic'} size="lg" className="rounded-lg">
                       <Link to="/traffic">
-                        <Activity className="h-4 w-4 shrink-0" />
+                        <Radar className="h-4 w-4 shrink-0" />
                         <span>Traffic</span>
                       </Link>
                     </SidebarMenuButton>
@@ -153,24 +166,32 @@ function DashboardLayout() {
                   <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname === '/logs'} size="lg" className="rounded-lg">
                       <Link to="/logs">
-                        <FileText className="h-4 w-4 shrink-0" />
+                        <ScrollText className="h-4 w-4 shrink-0" />
                         <span>Logs</span>
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+
+            <SidebarGroup className="mt-4 p-0">
+              <p className="px-2 pb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">Configure</p>
+              <SidebarGroupContent>
+                <SidebarMenu>
                   <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname === '/users'} size="lg" className="rounded-lg">
                       <Link to="/users">
-                        <Users className="h-4 w-4 shrink-0" />
+                        <UserRoundCog className="h-4 w-4 shrink-0" />
                         <span>Users</span>
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
-                    <SidebarMenuButton asChild isActive={pathname === '/settings'} size="lg" className="rounded-lg">
-                      <Link to="/settings">
-                        <Settings className="h-4 w-4 shrink-0" />
-                        <span>Settings</span>
+                    <SidebarMenuButton asChild isActive={pathname === '/host' || pathname === '/settings'} size="lg" className="rounded-lg">
+                      <Link to="/host">
+                        <HardDrive className="h-4 w-4 shrink-0" />
+                        <span>Host</span>
                         {upgradeAvailable && <span aria-label="Upgrade available" className="ml-auto h-2 w-2 rounded-full bg-primary" />}
                       </Link>
                     </SidebarMenuButton>
@@ -179,15 +200,27 @@ function DashboardLayout() {
               </SidebarGroupContent>
             </SidebarGroup>
           </nav>
+
+          <div className="mt-auto px-2 pt-4">
+            <div className="flex items-center gap-2 border-t border-border/70 pt-3">
+              <span className="grid h-6 w-6 place-items-center rounded-md border border-border/70 bg-background/80 text-muted-foreground">
+                <UserRound className="h-3.5 w-3.5" />
+              </span>
+              <div className="min-w-0">
+                <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground/80">Signed in</p>
+                <p className="truncate text-xs font-medium text-foreground">{isAuthDisabled ? 'Auth disabled' : username || 'Authenticated user'}</p>
+              </div>
+            </div>
+          </div>
         </SidebarContent>
       </Sidebar>
 
       <SidebarInset>
         <div className="mx-auto w-full max-w-6xl">
           <section className="rounded-2xl border border-border/70 bg-card/92 p-4 shadow-sm backdrop-blur sm:p-5 lg:p-6">
-            <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-              {isSystemStatusPage || isTrafficPage || isLogsPage ? 'Observability' : isSettingsPage || isUsersPage ? 'Configuration' : 'Deployments'}
-            </p>
+              <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+              {isSystemStatusPage || isTrafficPage || isLogsPage ? 'Observability' : isHostPage || isUsersPage ? 'Configuration' : 'Deployments'}
+              </p>
             <div className="mb-4">
               <h1 className="font-[family-name:var(--font-display)] text-2xl font-semibold tracking-tight text-foreground">{pageTitle}</h1>
               <p className="mt-1 text-sm text-muted-foreground">{pageDescription}</p>
@@ -263,10 +296,18 @@ const logsRoute = createRoute({
   component: LogsPage,
 })
 
+const hostRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/host',
+  component: SettingsPage,
+})
+
 const settingsRoute = createRoute({
   getParentRoute: () => appRoute,
   path: '/settings',
-  component: SettingsPage,
+  beforeLoad: () => {
+    throw redirect({ to: '/host' })
+  },
 })
 
 const usersRoute = createRoute({
@@ -285,6 +326,7 @@ const routeTree = rootRoute.addChildren([
     trafficRoute,
     logsRoute,
     usersRoute,
+    hostRoute,
     settingsRoute,
   ]),
 ])

--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ercadev/dirigent/orchestrator/internal/apiclient"
 	"github.com/ercadev/dirigent/orchestrator/internal/docker"
+	"github.com/ercadev/dirigent/orchestrator/internal/hostinfo"
 	"github.com/ercadev/dirigent/orchestrator/internal/hostmetrics"
 	"github.com/ercadev/dirigent/orchestrator/internal/reconciler"
 	"github.com/ercadev/dirigent/store"
@@ -86,10 +87,21 @@ func main() {
 		select {
 		case <-ticker.C:
 			now := time.Now().UTC()
+			hostInfo := hostinfo.Collect()
 			dockerReachable := true
 			containerStats := map[string]apiclient.HeartbeatContainerStats{}
 			loadBalancerResponding := false
 			var loadBalancerTraffic *apiclient.HeartbeatLoadBalancerTraffic
+			hostMetadata := &apiclient.HeartbeatHostMetadata{
+				IPAddress: hostInfo.IPAddress,
+				OSName:    hostInfo.OSName,
+				OSVersion: hostInfo.OSVersion,
+				Specs: apiclient.HeartbeatHostSpecs{
+					CPUCores:    hostInfo.CPUCores,
+					MemoryBytes: hostInfo.MemoryBytes,
+					DiskBytes:   hostInfo.DiskBytes,
+				},
+			}
 			storeAccessible := true
 			var cpuUsagePercent *float64
 			var ramUsagePercent *float64
@@ -148,7 +160,7 @@ func main() {
 			}
 
 			// Heartbeat is always sent, regardless of Docker state.
-			if err := notifier.NotifyHeartbeat(dockerReachable, loadBalancerResponding, loadBalancerTraffic, storeAccessible, now, cpuUsagePercent, ramUsagePercent, containerStats); err != nil {
+			if err := notifier.NotifyHeartbeat(dockerReachable, loadBalancerResponding, loadBalancerTraffic, storeAccessible, now, cpuUsagePercent, ramUsagePercent, hostMetadata, containerStats); err != nil {
 				log.Printf("orchestrator: notify heartbeat: %v", err)
 			}
 

--- a/orchestrator/internal/apiclient/client.go
+++ b/orchestrator/internal/apiclient/client.go
@@ -56,13 +56,27 @@ type HeartbeatLoadBalancerBlockedIPState struct {
 }
 
 type heartbeatHostState struct {
-	CPU *heartbeatHostMetric `json:"cpu,omitempty"`
-	RAM *heartbeatHostMetric `json:"ram,omitempty"`
+	CPU      *heartbeatHostMetric   `json:"cpu,omitempty"`
+	RAM      *heartbeatHostMetric   `json:"ram,omitempty"`
+	Metadata *HeartbeatHostMetadata `json:"metadata,omitempty"`
 }
 
 type heartbeatHostMetric struct {
 	UsagePercent float64   `json:"usagePercent"`
 	CheckedAt    time.Time `json:"checkedAt"`
+}
+
+type HeartbeatHostSpecs struct {
+	CPUCores    int    `json:"cpuCores,omitempty"`
+	MemoryBytes uint64 `json:"memoryBytes,omitempty"`
+	DiskBytes   uint64 `json:"diskBytes,omitempty"`
+}
+
+type HeartbeatHostMetadata struct {
+	IPAddress string             `json:"ipAddress,omitempty"`
+	OSName    string             `json:"osName,omitempty"`
+	OSVersion string             `json:"osVersion,omitempty"`
+	Specs     HeartbeatHostSpecs `json:"specs,omitempty"`
 }
 
 type HeartbeatContainerStats struct {
@@ -114,14 +128,14 @@ func (c *Client) NotifyStatus(id string, status store.Status, reason store.Statu
 
 // NotifyHeartbeat calls POST /api/system-status/orchestrator-heartbeat so the
 // API can update orchestrator liveness, Docker connectivity, and host metrics.
-func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bool, loadBalancerTraffic *HeartbeatLoadBalancerTraffic, storeAccessible bool, checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64, containerStats map[string]HeartbeatContainerStats) error {
+func (c *Client) NotifyHeartbeat(dockerReachable bool, loadBalancerResponding bool, loadBalancerTraffic *HeartbeatLoadBalancerTraffic, storeAccessible bool, checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64, hostMetadata *HeartbeatHostMetadata, containerStats map[string]HeartbeatContainerStats) error {
 	if checkedAt.IsZero() {
 		checkedAt = time.Now().UTC()
 	} else {
 		checkedAt = checkedAt.UTC()
 	}
 
-	host := buildHeartbeatHostState(checkedAt, cpuUsagePercent, ramUsagePercent)
+	host := buildHeartbeatHostState(checkedAt, cpuUsagePercent, ramUsagePercent, hostMetadata)
 
 	body, err := json.Marshal(heartbeatRequest{
 		At: checkedAt,
@@ -190,7 +204,7 @@ func cloneHeartbeatLoadBalancerTraffic(in *HeartbeatLoadBalancerTraffic) *Heartb
 	return &out
 }
 
-func buildHeartbeatHostState(checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64) *heartbeatHostState {
+func buildHeartbeatHostState(checkedAt time.Time, cpuUsagePercent *float64, ramUsagePercent *float64, metadata *HeartbeatHostMetadata) *heartbeatHostState {
 	host := &heartbeatHostState{}
 
 	if cpuUsagePercent != nil {
@@ -199,10 +213,28 @@ func buildHeartbeatHostState(checkedAt time.Time, cpuUsagePercent *float64, ramU
 	if ramUsagePercent != nil {
 		host.RAM = &heartbeatHostMetric{UsagePercent: *ramUsagePercent, CheckedAt: checkedAt}
 	}
+	if metadata != nil {
+		host.Metadata = cloneHeartbeatHostMetadata(metadata)
+	}
 
-	if host.CPU == nil && host.RAM == nil {
+	if host.CPU == nil && host.RAM == nil && host.Metadata == nil {
 		return nil
 	}
 
 	return host
+}
+
+func cloneHeartbeatHostMetadata(in *HeartbeatHostMetadata) *HeartbeatHostMetadata {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+	out.Specs = HeartbeatHostSpecs{
+		CPUCores:    in.Specs.CPUCores,
+		MemoryBytes: in.Specs.MemoryBytes,
+		DiskBytes:   in.Specs.DiskBytes,
+	}
+
+	return &out
 }

--- a/orchestrator/internal/apiclient/client_test.go
+++ b/orchestrator/internal/apiclient/client_test.go
@@ -29,6 +29,16 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 			MemoryPercent:    50,
 		},
 	}
+	hostMetadata := &HeartbeatHostMetadata{
+		IPAddress: "10.0.0.5",
+		OSName:    "Ubuntu",
+		OSVersion: "24.04",
+		Specs: HeartbeatHostSpecs{
+			CPUCores:    4,
+			MemoryBytes: 8589934592,
+			DiskBytes:   68719476736,
+		},
+	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -70,6 +80,16 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 					UsagePercent float64   `json:"usagePercent"`
 					CheckedAt    time.Time `json:"checkedAt"`
 				} `json:"ram"`
+				Metadata *struct {
+					IPAddress string `json:"ipAddress"`
+					OSName    string `json:"osName"`
+					OSVersion string `json:"osVersion"`
+					Specs     struct {
+						CPUCores    int    `json:"cpuCores"`
+						MemoryBytes uint64 `json:"memoryBytes"`
+						DiskBytes   uint64 `json:"diskBytes"`
+					} `json:"specs"`
+				} `json:"metadata"`
 			} `json:"host"`
 			ContainerStats map[string]struct {
 				CPUPercent       float64 `json:"cpuPercent"`
@@ -109,8 +129,8 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 		if len(body.LoadBalancer.Traffic.BlockedIPs) != 1 || body.LoadBalancer.Traffic.BlockedIPs[0].IP != "203.0.113.7" {
 			t.Fatal("want blocked ip payload")
 		}
-		if body.Host == nil || body.Host.CPU == nil || body.Host.RAM == nil {
-			t.Fatal("want host cpu and ram metrics in heartbeat")
+		if body.Host == nil || body.Host.CPU == nil || body.Host.RAM == nil || body.Host.Metadata == nil {
+			t.Fatal("want host metrics and metadata in heartbeat")
 		}
 		if body.Host.CPU.UsagePercent != cpu {
 			t.Fatalf("want cpu usage %v, got %v", cpu, body.Host.CPU.UsagePercent)
@@ -124,6 +144,12 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 		if !body.Host.RAM.CheckedAt.Equal(checkedAt) {
 			t.Fatalf("want ram checkedAt %s, got %s", checkedAt, body.Host.RAM.CheckedAt)
 		}
+		if body.Host.Metadata.IPAddress != hostMetadata.IPAddress {
+			t.Fatalf("want ip %q, got %q", hostMetadata.IPAddress, body.Host.Metadata.IPAddress)
+		}
+		if body.Host.Metadata.Specs.CPUCores != hostMetadata.Specs.CPUCores {
+			t.Fatalf("want cpu cores %d, got %d", hostMetadata.Specs.CPUCores, body.Host.Metadata.Specs.CPUCores)
+		}
 		if len(body.ContainerStats) != 1 {
 			t.Fatalf("want 1 container stats entry, got %d", len(body.ContainerStats))
 		}
@@ -136,7 +162,7 @@ func TestClient_NotifyHeartbeat(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(false, false, traffic, false, checkedAt, &cpu, &ram, containerStats); err != nil {
+	if err := client.NotifyHeartbeat(false, false, traffic, false, checkedAt, &cpu, &ram, hostMetadata, containerStats); err != nil {
 		t.Fatalf("NotifyHeartbeat: %v", err)
 	}
 }
@@ -164,7 +190,7 @@ func TestClient_NotifyHeartbeat_WithoutHostMetrics(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(false, true, nil, true, checkedAt, nil, nil, nil); err != nil {
+	if err := client.NotifyHeartbeat(false, true, nil, true, checkedAt, nil, nil, nil, nil); err != nil {
 		t.Fatalf("NotifyHeartbeat: %v", err)
 	}
 }
@@ -176,7 +202,7 @@ func TestClient_NotifyHeartbeat_UnexpectedResponse(t *testing.T) {
 	defer srv.Close()
 
 	client := New(srv.URL)
-	if err := client.NotifyHeartbeat(true, true, nil, true, time.Time{}, nil, nil, nil); err == nil {
+	if err := client.NotifyHeartbeat(true, true, nil, true, time.Time{}, nil, nil, nil, nil); err == nil {
 		t.Fatal("want error for non-204 heartbeat response")
 	}
 }

--- a/orchestrator/internal/hostinfo/hostinfo.go
+++ b/orchestrator/internal/hostinfo/hostinfo.go
@@ -1,0 +1,138 @@
+package hostinfo
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const osReleasePath = "/etc/os-release"
+
+type Metadata struct {
+	IPAddress   string
+	OSName      string
+	OSVersion   string
+	CPUCores    int
+	MemoryBytes uint64
+	DiskBytes   uint64
+}
+
+func Collect() Metadata {
+	metadata := Metadata{CPUCores: runtime.NumCPU()}
+
+	if ip := primaryIPv4(); ip != "" {
+		metadata.IPAddress = ip
+	}
+
+	if name, version := osIdentity(); name != "" || version != "" {
+		metadata.OSName = name
+		metadata.OSVersion = version
+	}
+
+	if memoryBytes, ok := totalMemoryBytes(); ok {
+		metadata.MemoryBytes = memoryBytes
+	}
+
+	if diskBytes, ok := totalDiskBytes("/"); ok {
+		metadata.DiskBytes = diskBytes
+	}
+
+	return metadata
+}
+
+func primaryIPv4() string {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || addr.IP == nil {
+		return ""
+	}
+
+	ip := addr.IP.To4()
+	if ip == nil {
+		return ""
+	}
+
+	return ip.String()
+}
+
+func osIdentity() (string, string) {
+	f, err := os.Open(osReleasePath)
+	if err != nil {
+		return "", ""
+	}
+	defer f.Close()
+
+	name := ""
+	version := ""
+	prettyName := ""
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := parts[0]
+		value := strings.Trim(parts[1], "\"")
+
+		switch key {
+		case "PRETTY_NAME":
+			prettyName = value
+		case "NAME":
+			name = value
+		case "VERSION_ID":
+			version = value
+		}
+	}
+
+	if prettyName != "" {
+		return prettyName, version
+	}
+
+	return name, version
+}
+
+func totalMemoryBytes() (uint64, bool) {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0, false
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "MemTotal:" {
+			continue
+		}
+
+		kib, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0, false
+		}
+
+		return kib * 1024, true
+	}
+
+	return 0, false
+}
+
+func totalDiskBytes(path string) (uint64, bool) {
+	var stats syscall.Statfs_t
+	if err := syscall.Statfs(path, &stats); err != nil {
+		return 0, false
+	}
+
+	return stats.Blocks * uint64(stats.Bsize), true
+}


### PR DESCRIPTION
## Summary
- add a host profile API/store and orchestrator heartbeat metadata ingestion so host identity and machine facts are persisted and exposed to the dashboard
- rework the Host page into a clearer control flow with host dossier, release runway, and upgrade sequence sections while keeping existing upgrade behavior
- refresh sidebar information architecture with more descriptive navigation icons, separate operate/configure groups, and a compact signed-in user footer

## Testing
- bun run build (dashboard)