### PR TITLE
feat(registries): add private registry credential management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ setup:
 # concurrently in a single terminal. Ctrl+C shuts down both processes cleanly.
 dev:
 	@trap 'kill 0' SIGINT; \
-	(cd api && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_PROXY_ACCESS_LOG_DIR=/tmp/lotsen-proxy-logs LOTSEN_JWT_SECRET=dev-secret LOTSEN_AUTH_USER=admin LOTSEN_AUTH_PASSWORD=admin LOTSEN_AUTH_ENSURE_BOOTSTRAP=1 $(AIR)) & \
-	(cd orchestrator && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_PROXY_HEALTH_URL=http://localhost:8090/internal/health LOTSEN_PROXY_TRAFFIC_URL=http://localhost:8090/internal/traffic $(AIR)) & \
+	(cd api && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_PROXY_ACCESS_LOG_DIR=/tmp/lotsen-proxy-logs LOTSEN_JWT_SECRET=dev-secret LOTSEN_REGISTRY_SECRET=dev-secret LOTSEN_AUTH_USER=admin LOTSEN_AUTH_PASSWORD=admin LOTSEN_AUTH_ENSURE_BOOTSTRAP=1 $(AIR)) & \
+	(cd orchestrator && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_REGISTRY_SECRET=dev-secret LOTSEN_PROXY_HEALTH_URL=http://localhost:8090/internal/health LOTSEN_PROXY_TRAFFIC_URL=http://localhost:8090/internal/traffic $(AIR)) & \
 	(cd proxy && LOTSEN_DATA=/tmp/lotsen.json LOTSEN_PROXY_ADDR=:8090 LOTSEN_PROXY_HTTPS_ADDR=:8443 LOTSEN_CERT_CACHE_DIR=/tmp/lotsen-certs LOTSEN_PROXY_ACCESS_LOG_DIR=/tmp/lotsen-proxy-logs LOTSEN_JWT_SECRET=dev-secret LOTSEN_AUTH_USER=admin LOTSEN_AUTH_PASSWORD=admin $(AIR)) & \
 	(cd dashboard && bun run dev) & \
 	wait

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -31,6 +31,10 @@ type Store interface {
 	Update(d store.Deployment) (store.Deployment, error)
 	Patch(id string, patch store.Deployment) (store.Deployment, error)
 	Delete(id string) error
+	ListRegistries() ([]store.RegistryEntry, error)
+	CreateRegistry(id, prefix, username, password string) (store.RegistryEntry, error)
+	UpdateRegistry(id, prefix, username, password string) (store.RegistryEntry, error)
+	DeleteRegistry(id string) error
 }
 
 // EventBus is the pub/sub interface required by the API handlers.
@@ -247,6 +251,10 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("POST /api/users", protect(http.HandlerFunc(h.createUser)))
 	mux.Handle("PUT /api/users/{username}/password", protect(http.HandlerFunc(h.updateUserPassword)))
 	mux.Handle("DELETE /api/users/{username}", protect(http.HandlerFunc(h.deleteUser)))
+	mux.Handle("GET /api/registries", protect(http.HandlerFunc(h.listRegistries)))
+	mux.Handle("POST /api/registries", protect(http.HandlerFunc(h.createRegistry)))
+	mux.Handle("PUT /api/registries/{id}", protect(http.HandlerFunc(h.updateRegistry)))
+	mux.Handle("DELETE /api/registries/{id}", protect(http.HandlerFunc(h.deleteRegistry)))
 	mux.Handle("GET /api/access-logs", protect(http.HandlerFunc(h.accessLogs)))
 	mux.Handle("GET /api/security-config", protect(http.HandlerFunc(h.securityConfig)))
 	mux.Handle("POST /api/upgrade", protect(http.HandlerFunc(h.startUpgrade)))

--- a/api/internal/api/handler_registries.go
+++ b/api/internal/api/handler_registries.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/ercadev/dirigent/store"
+)
+
+type registryRequest struct {
+	Prefix   string `json:"prefix"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func (h *Handler) listRegistries(w http.ResponseWriter, _ *http.Request) {
+	registries, err := h.store.ListRegistries()
+	if err != nil {
+		http.Error(w, "failed to list registries", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"registries": registries})
+}
+
+func (h *Handler) createRegistry(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+
+	var body registryRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	prefix := strings.TrimSpace(body.Prefix)
+	username := strings.TrimSpace(body.Username)
+	password := strings.TrimSpace(body.Password)
+	if prefix == "" || username == "" || password == "" {
+		http.Error(w, "prefix, username and password are required", http.StatusBadRequest)
+		return
+	}
+
+	id, err := newID()
+	if err != nil {
+		http.Error(w, "failed to generate id", http.StatusInternalServerError)
+		return
+	}
+
+	created, err := h.store.CreateRegistry(id, prefix, username, password)
+	if err != nil {
+		if errors.Is(err, store.ErrDuplicateRegistryPrefix) {
+			http.Error(w, "registry prefix already in use", http.StatusConflict)
+			return
+		}
+		http.Error(w, "failed to create registry", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (h *Handler) updateRegistry(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		http.Error(w, "registry id is required", http.StatusBadRequest)
+		return
+	}
+
+	var body registryRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	prefix := strings.TrimSpace(body.Prefix)
+	username := strings.TrimSpace(body.Username)
+	if prefix == "" || username == "" {
+		http.Error(w, "prefix and username are required", http.StatusBadRequest)
+		return
+	}
+
+	updated, err := h.store.UpdateRegistry(id, prefix, username, strings.TrimSpace(body.Password))
+	if err != nil {
+		switch {
+		case errors.Is(err, store.ErrRegistryNotFound):
+			http.Error(w, "registry not found", http.StatusNotFound)
+		case errors.Is(err, store.ErrDuplicateRegistryPrefix):
+			http.Error(w, "registry prefix already in use", http.StatusConflict)
+		default:
+			http.Error(w, "failed to update registry", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (h *Handler) deleteRegistry(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		http.Error(w, "registry id is required", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.store.DeleteRegistry(id); err != nil {
+		if errors.Is(err, store.ErrRegistryNotFound) {
+			http.Error(w, "registry not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to delete registry", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -26,10 +26,11 @@ import (
 type memStore struct {
 	mu          sync.RWMutex
 	deployments map[string]store.Deployment
+	registries  map[string]store.RegistryEntry
 }
 
 func newMemStore() *memStore {
-	return &memStore{deployments: make(map[string]store.Deployment)}
+	return &memStore{deployments: make(map[string]store.Deployment), registries: make(map[string]store.RegistryEntry)}
 }
 
 func (m *memStore) List() ([]store.Deployment, error) {
@@ -120,6 +121,55 @@ func (m *memStore) Patch(id string, patch store.Deployment) (store.Deployment, e
 	}
 	m.deployments[id] = d
 	return d, nil
+}
+
+func (m *memStore) ListRegistries() ([]store.RegistryEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]store.RegistryEntry, 0, len(m.registries))
+	for _, r := range m.registries {
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+func (m *memStore) CreateRegistry(id, prefix, username, _ string) (store.RegistryEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, existing := range m.registries {
+		if existing.Prefix == prefix {
+			return store.RegistryEntry{}, store.ErrDuplicateRegistryPrefix
+		}
+	}
+	entry := store.RegistryEntry{ID: id, Prefix: prefix, Username: username}
+	m.registries[id] = entry
+	return entry, nil
+}
+
+func (m *memStore) UpdateRegistry(id, prefix, username, _ string) (store.RegistryEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.registries[id]; !ok {
+		return store.RegistryEntry{}, store.ErrRegistryNotFound
+	}
+	for rid, existing := range m.registries {
+		if rid != id && existing.Prefix == prefix {
+			return store.RegistryEntry{}, store.ErrDuplicateRegistryPrefix
+		}
+	}
+	entry := store.RegistryEntry{ID: id, Prefix: prefix, Username: username}
+	m.registries[id] = entry
+	return entry, nil
+}
+
+func (m *memStore) DeleteRegistry(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.registries[id]; !ok {
+		return store.ErrRegistryNotFound
+	}
+	delete(m.registries, id)
+	return nil
 }
 
 // failUpdateStore wraps memStore but always fails on Update.
@@ -1251,6 +1301,16 @@ func (e *errStore) Patch(_ string, _ store.Deployment) (store.Deployment, error)
 	return store.Deployment{}, errors.New("disk full")
 }
 func (e *errStore) Delete(_ string) error { return errors.New("disk full") }
+func (e *errStore) ListRegistries() ([]store.RegistryEntry, error) {
+	return nil, errors.New("disk full")
+}
+func (e *errStore) CreateRegistry(_, _, _, _ string) (store.RegistryEntry, error) {
+	return store.RegistryEntry{}, errors.New("disk full")
+}
+func (e *errStore) UpdateRegistry(_, _, _, _ string) (store.RegistryEntry, error) {
+	return store.RegistryEntry{}, errors.New("disk full")
+}
+func (e *errStore) DeleteRegistry(_ string) error { return errors.New("disk full") }
 
 func TestDeleteDeployment_StoreError(t *testing.T) {
 	srv := newTestServer(&errStore{})
@@ -3026,5 +3086,91 @@ func TestPatchDeployment_UpdatesSecurityConfig(t *testing.T) {
 	}
 	if updated.Security.WAFMode != "detection" {
 		t.Fatalf("want default waf mode detection on patch, got %q", updated.Security.WAFMode)
+	}
+}
+
+func TestRegistries_CRUD(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	body := []byte(`{"prefix":"ghcr.io/myorg","username":"alice","password":"secret-token"}`)
+	createReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/registries", bytes.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("POST /api/registries: %v", err)
+	}
+	defer createResp.Body.Close()
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("want 201, got %d", createResp.StatusCode)
+	}
+
+	var created store.RegistryEntry
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("want created id")
+	}
+
+	listResp, err := http.Get(srv.URL + "/api/registries")
+	if err != nil {
+		t.Fatalf("GET /api/registries: %v", err)
+	}
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", listResp.StatusCode)
+	}
+	var listed struct {
+		Registries []store.RegistryEntry `json:"registries"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed.Registries) != 1 {
+		t.Fatalf("want 1 registry, got %d", len(listed.Registries))
+	}
+
+	updateBody := []byte(`{"prefix":"ghcr.io/myorg/platform","username":"bob"}`)
+	updateReq, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/registries/"+created.ID, bytes.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateResp, err := http.DefaultClient.Do(updateReq)
+	if err != nil {
+		t.Fatalf("PUT /api/registries/{id}: %v", err)
+	}
+	defer updateResp.Body.Close()
+	if updateResp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", updateResp.StatusCode)
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/registries/"+created.ID, nil)
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("DELETE /api/registries/{id}: %v", err)
+	}
+	defer deleteResp.Body.Close()
+	if deleteResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", deleteResp.StatusCode)
+	}
+}
+
+func TestCreateRegistry_DuplicatePrefixReturnsConflict(t *testing.T) {
+	s := newMemStore()
+	_, _ = s.CreateRegistry("r1", "ghcr.io/myorg", "alice", "secret")
+
+	srv := newTestServer(s)
+	defer srv.Close()
+
+	body := []byte(`{"prefix":"ghcr.io/myorg","username":"bob","password":"another"}`)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/registries", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/registries: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("want 409, got %d", resp.StatusCode)
 	}
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -44,6 +44,12 @@ export type DashboardUser = {
   username: string
 }
 
+export type RegistryCredential = {
+  id: string
+  prefix: string
+  username: string
+}
+
 export async function getUsers(): Promise<DashboardUser[]> {
   const res = await apiFetch('/api/users')
   if (!res.ok) throw new Error('Failed to fetch users')
@@ -75,6 +81,47 @@ export async function deleteUser(username: string): Promise<void> {
   const res = await apiFetch(`/api/users/${encodeURIComponent(username)}`, { method: 'DELETE' })
   if (res.status === 404) throw new Error('User not found')
   if (!res.ok) throw new Error('Failed to delete user')
+}
+
+export async function getRegistries(): Promise<RegistryCredential[]> {
+  const res = await apiFetch('/api/registries')
+  if (!res.ok) throw new Error('Failed to fetch registries')
+  const body = await res.json() as { registries?: RegistryCredential[] }
+  return body.registries ?? []
+}
+
+export async function createRegistry(prefix: string, username: string, password: string): Promise<RegistryCredential> {
+  const res = await apiFetch('/api/registries', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prefix, username, password }),
+  })
+  if (res.status === 409) throw new Error('Registry prefix already exists')
+  if (!res.ok) throw new Error('Failed to create registry')
+  return res.json()
+}
+
+export async function updateRegistry(id: string, prefix: string, username: string, password?: string): Promise<RegistryCredential> {
+  const payload: { prefix: string; username: string; password?: string } = { prefix, username }
+  if (password) {
+    payload.password = password
+  }
+
+  const res = await apiFetch(`/api/registries/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (res.status === 404) throw new Error('Registry not found')
+  if (res.status === 409) throw new Error('Registry prefix already exists')
+  if (!res.ok) throw new Error('Failed to update registry')
+  return res.json()
+}
+
+export async function deleteRegistry(id: string): Promise<void> {
+  const res = await apiFetch(`/api/registries/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  if (res.status === 404) throw new Error('Registry not found')
+  if (!res.ok) throw new Error('Failed to delete registry')
 }
 
 export type DeploymentStatus = 'idle' | 'deploying' | 'healthy' | 'failed'

--- a/dashboard/src/pages/RegistriesPage.tsx
+++ b/dashboard/src/pages/RegistriesPage.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Badge } from '../components/ui/badge'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { createRegistry, deleteRegistry, getRegistries, updateRegistry, type RegistryCredential } from '../lib/api'
+
+export function RegistriesPage() {
+  const queryClient = useQueryClient()
+  const [registryPrefix, setRegistryPrefix] = useState('')
+  const [registryUsername, setRegistryUsername] = useState('')
+  const [registryPassword, setRegistryPassword] = useState('')
+  const [registryError, setRegistryError] = useState<string | null>(null)
+  const [editingRegistryId, setEditingRegistryId] = useState<string | null>(null)
+
+  const registriesQuery = useQuery({
+    queryKey: ['registries'],
+    queryFn: getRegistries,
+  })
+
+  const resetRegistryForm = () => {
+    setRegistryPrefix('')
+    setRegistryUsername('')
+    setRegistryPassword('')
+    setEditingRegistryId(null)
+  }
+
+  const upsertRegistryMutation = useMutation({
+    mutationFn: async () => {
+      if (editingRegistryId) {
+        return updateRegistry(editingRegistryId, registryPrefix, registryUsername, registryPassword || undefined)
+      }
+      return createRegistry(registryPrefix, registryUsername, registryPassword)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['registries'] })
+      setRegistryError(null)
+      resetRegistryForm()
+    },
+    onError: error => {
+      setRegistryError(error instanceof Error ? error.message : 'Failed to save registry')
+    },
+  })
+
+  const deleteRegistryMutation = useMutation({
+    mutationFn: deleteRegistry,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['registries'] })
+      setRegistryError(null)
+      if (editingRegistryId) {
+        resetRegistryForm()
+      }
+    },
+    onError: error => {
+      setRegistryError(error instanceof Error ? error.message : 'Failed to delete registry')
+    },
+  })
+
+  const beginEditRegistry = (registry: RegistryCredential) => {
+    setEditingRegistryId(registry.id)
+    setRegistryPrefix(registry.prefix)
+    setRegistryUsername(registry.username)
+    setRegistryPassword('')
+    setRegistryError(null)
+  }
+
+  return (
+    <section className="rounded-xl border border-border/60 bg-card p-4 sm:p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Registry credentials</p>
+          <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">Private image access</h2>
+          <p className="mt-1 text-sm text-muted-foreground">Save registry prefixes once and Dirigent reuses credentials automatically for matching pulls.</p>
+        </div>
+        <Badge variant="outline" className="rounded-md border-border/70 bg-background/70 px-2.5 py-1 font-mono text-[11px]">
+          {(registriesQuery.data ?? []).length} configured
+        </Badge>
+      </div>
+
+      <form
+        className="mt-4 grid gap-2 md:grid-cols-[1.4fr_1fr_1fr_auto]"
+        onSubmit={event => {
+          event.preventDefault()
+          if (!registryPrefix.trim() || !registryUsername.trim() || (!editingRegistryId && !registryPassword.trim())) {
+            setRegistryError('Prefix, username, and password are required for new registries')
+            return
+          }
+          upsertRegistryMutation.mutate()
+        }}
+      >
+        <Input value={registryPrefix} onChange={event => setRegistryPrefix(event.target.value)} placeholder="ghcr.io/myorg" aria-label="Registry prefix" />
+        <Input value={registryUsername} onChange={event => setRegistryUsername(event.target.value)} placeholder="Username" aria-label="Registry username" />
+        <Input
+          type="password"
+          value={registryPassword}
+          onChange={event => setRegistryPassword(event.target.value)}
+          placeholder={editingRegistryId ? 'New password (optional)' : 'Password or token'}
+          aria-label="Registry password"
+        />
+        <div className="flex gap-2">
+          <Button type="submit" disabled={upsertRegistryMutation.isPending}>
+            {editingRegistryId ? 'Save' : 'Add'}
+          </Button>
+          {editingRegistryId && (
+            <Button type="button" variant="outline" onClick={resetRegistryForm}>
+              Cancel
+            </Button>
+          )}
+        </div>
+      </form>
+
+      {registryError && <p className="mt-2 text-sm text-destructive">{registryError}</p>}
+
+      <div className="mt-4 overflow-x-auto rounded-lg border border-border/60 bg-background/70">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border/60 text-left text-xs uppercase tracking-[0.13em] text-muted-foreground">
+              <th className="px-3 py-2">Prefix</th>
+              <th className="px-3 py-2">Username</th>
+              <th className="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(registriesQuery.data ?? []).map(registry => (
+              <tr key={registry.id} className="border-b border-border/40 last:border-0">
+                <td className="px-3 py-2 font-mono text-xs text-foreground">{registry.prefix}</td>
+                <td className="px-3 py-2 text-foreground">{registry.username}</td>
+                <td className="px-3 py-2">
+                  <div className="flex justify-end gap-2">
+                    <Button type="button" size="sm" variant="outline" onClick={() => beginEditRegistry(registry)}>
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={deleteRegistryMutation.isPending}
+                      onClick={() => deleteRegistryMutation.mutate(registry.id)}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {registriesQuery.isLoading && <p className="px-3 py-3 text-sm text-muted-foreground">Loading registries...</p>}
+        {!registriesQuery.isLoading && (registriesQuery.data ?? []).length === 0 && (
+          <p className="px-3 py-3 text-sm text-muted-foreground">No registries configured.</p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -7,7 +7,14 @@ import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog'
 import { Input } from '../components/ui/input'
-import { getHostProfile, getVersionInfo, getVersionReleases, triggerUpgrade, updateHostProfile, type VersionRelease } from '../lib/api'
+import {
+  getHostProfile,
+  getVersionInfo,
+  getVersionReleases,
+  triggerUpgrade,
+  updateHostProfile,
+  type VersionRelease,
+} from '../lib/api'
 import { UpgradeLogPanel } from '../settings/UpgradeLogPanel'
 import { useUpgradeLogsSSE } from '../settings/useUpgradeLogsSSE'
 import { useVersionCheck } from '../settings/useVersionCheck'

--- a/dashboard/src/router.tsx
+++ b/dashboard/src/router.tsx
@@ -9,7 +9,7 @@ import {
   useRouterState,
 } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { Gauge, HardDrive, LogOut, Moon, PackageSearch, Radar, Rocket, ScrollText, Sun, UserRound, UserRoundCog } from 'lucide-react'
+import { Gauge, HardDrive, KeyRound, LogOut, Moon, PackageSearch, Radar, Rocket, ScrollText, Sun, UserRound, UserRoundCog } from 'lucide-react'
 import { useEffect } from 'react'
 import { Button } from './components/ui/button'
 import {
@@ -28,6 +28,7 @@ import DeploymentList from './pages/DeploymentList'
 import { DeploymentDetailPage } from './pages/DeploymentDetailPage'
 import { LoginPage } from './pages/LoginPage'
 import { LogsPage } from './pages/LogsPage'
+import { RegistriesPage } from './pages/RegistriesPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { SystemStatusPage } from './pages/SystemStatusPage'
 import { TrafficPage } from './pages/TrafficPage'
@@ -62,6 +63,7 @@ function DashboardLayout() {
 
   const isSystemStatusPage = pathname === '/system-status'
   const isHostPage = pathname === '/host' || pathname === '/settings'
+  const isRegistriesPage = pathname === '/registries'
   const isUsersPage = pathname === '/users'
   const isTrafficPage = pathname === '/traffic'
   const isLogsPage = pathname === '/logs'
@@ -76,6 +78,8 @@ function DashboardLayout() {
       ? 'Logs'
       : isHostPage
       ? 'Host'
+      : isRegistriesPage
+      ? 'Registries'
       : isUsersPage
       ? 'Users'
       : isDeploymentDetailPage
@@ -89,6 +93,8 @@ function DashboardLayout() {
       ? 'Inspect core service output and deployment log streams without SSH.'
       : isHostPage
       ? 'Manage host naming, metadata, and runtime upgrades.'
+      : isRegistriesPage
+      ? 'Manage private registry credentials used for deployment image pulls.'
       : isUsersPage
       ? 'Create users, rotate passwords, and revoke dashboard access.'
       : isDeploymentDetailPage
@@ -188,6 +194,14 @@ function DashboardLayout() {
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
+                    <SidebarMenuButton asChild isActive={pathname === '/registries'} size="lg" className="rounded-lg">
+                      <Link to="/registries">
+                        <KeyRound className="h-4 w-4 shrink-0" />
+                        <span>Registries</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                  <SidebarMenuItem>
                     <SidebarMenuButton asChild isActive={pathname === '/host' || pathname === '/settings'} size="lg" className="rounded-lg">
                       <Link to="/host">
                         <HardDrive className="h-4 w-4 shrink-0" />
@@ -219,7 +233,7 @@ function DashboardLayout() {
         <div className="mx-auto w-full max-w-6xl">
           <section className="rounded-2xl border border-border/70 bg-card/92 p-4 shadow-sm backdrop-blur sm:p-5 lg:p-6">
               <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-              {isSystemStatusPage || isTrafficPage || isLogsPage ? 'Observability' : isHostPage || isUsersPage ? 'Configuration' : 'Deployments'}
+              {isSystemStatusPage || isTrafficPage || isLogsPage ? 'Observability' : isHostPage || isUsersPage || isRegistriesPage ? 'Configuration' : 'Deployments'}
               </p>
             <div className="mb-4">
               <h1 className="font-[family-name:var(--font-display)] text-2xl font-semibold tracking-tight text-foreground">{pageTitle}</h1>
@@ -316,6 +330,12 @@ const usersRoute = createRoute({
   component: UsersPage,
 })
 
+const registriesRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/registries',
+  component: RegistriesPage,
+})
+
 const routeTree = rootRoute.addChildren([
   loginRoute,
   appRoute.addChildren([
@@ -326,6 +346,7 @@ const routeTree = rootRoute.addChildren([
     trafficRoute,
     logsRoute,
     usersRoute,
+    registriesRoute,
     hostRoute,
     settingsRoute,
   ]),

--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/registry"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -379,7 +381,16 @@ func (d *Docker) pullImage(imageRef string) error {
 	}
 
 	log.Printf("docker: pulling image %s", imageRef)
-	rc, err := d.client.ImagePull(ctx, imageRef, image.PullOptions{})
+	options := image.PullOptions{}
+	registryAuth, err := d.resolveRegistryAuth(imageRef)
+	if err != nil {
+		return fmt.Errorf("docker: resolve registry auth for %s: %w", imageRef, err)
+	}
+	if registryAuth != "" {
+		options.RegistryAuth = registryAuth
+	}
+
+	rc, err := d.client.ImagePull(ctx, imageRef, options)
 	if err != nil {
 		if dockerclient.IsErrConnectionFailed(err) {
 			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
@@ -389,6 +400,36 @@ func (d *Docker) pullImage(imageRef string) error {
 	_, _ = io.Copy(io.Discard, rc)
 	rc.Close()
 	return nil
+}
+
+func (d *Docker) resolveRegistryAuth(imageRef string) (string, error) {
+	s, err := store.NewJSONStore(dataPath())
+	if err != nil {
+		log.Printf("docker: registry auth unavailable: %v", err)
+		return "", nil
+	}
+
+	auth, err := s.ResolveRegistryAuth(imageRef)
+	if err != nil {
+		return "", err
+	}
+	if auth == nil {
+		return "", nil
+	}
+
+	payload, err := json.Marshal(registry.AuthConfig{Username: auth.Username, Password: auth.Password})
+	if err != nil {
+		return "", err
+	}
+
+	return base64.URLEncoding.EncodeToString(payload), nil
+}
+
+func dataPath() string {
+	if p := strings.TrimSpace(os.Getenv("LOTSEN_DATA")); p != "" {
+		return p
+	}
+	return "/var/lib/lotsen/deployments.json"
 }
 
 // isLatestTag reports whether imageRef resolves to the mutable :latest tag.

--- a/store/store.go
+++ b/store/store.go
@@ -1,11 +1,17 @@
 package store
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 )
@@ -15,6 +21,12 @@ var ErrNotFound = errors.New("deployment not found")
 
 // ErrDuplicateName is returned by Create when a deployment with the same name already exists.
 var ErrDuplicateName = errors.New("deployment name already in use")
+
+// ErrRegistryNotFound is returned when a registry with the given ID does not exist.
+var ErrRegistryNotFound = errors.New("registry not found")
+
+// ErrDuplicateRegistryPrefix is returned when a registry with the same prefix already exists.
+var ErrDuplicateRegistryPrefix = errors.New("registry prefix already in use")
 
 // Status represents the lifecycle state of a deployment.
 type Status string
@@ -76,6 +88,29 @@ type SecurityConfig struct {
 	IPDenylist  []string `json:"ip_denylist,omitempty"`
 	IPAllowlist []string `json:"ip_allowlist,omitempty"`
 	CustomRules []string `json:"custom_rules,omitempty"`
+}
+
+type Registry struct {
+	ID       string `json:"id"`
+	Prefix   string `json:"prefix"`
+	Username string `json:"username"`
+	Secret   string `json:"secret"`
+}
+
+type RegistryEntry struct {
+	ID       string `json:"id"`
+	Prefix   string `json:"prefix"`
+	Username string `json:"username"`
+}
+
+type RegistryAuth struct {
+	Username string
+	Password string
+}
+
+type persistedState struct {
+	Deployments []Deployment `json:"deployments"`
+	Registries  []Registry   `json:"registries,omitempty"`
 }
 
 // JSONStore persists deployments as a JSON array on disk.
@@ -143,24 +178,56 @@ func (s *JSONStore) withRLock(fn func() error) error {
 }
 
 // read loads deployments from disk into a map. Caller must hold the lock.
-func (s *JSONStore) read() (map[string]Deployment, error) {
-	data := make(map[string]Deployment)
+func (s *JSONStore) readState() (persistedState, error) {
+	state := persistedState{
+		Deployments: []Deployment{},
+		Registries:  []Registry{},
+	}
 
 	f, err := os.Open(s.path)
 	if errors.Is(err, os.ErrNotExist) {
-		return data, nil
+		return state, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("store: open %s: %w", s.path, err)
+		return persistedState{}, fmt.Errorf("store: open %s: %w", s.path, err)
 	}
 	defer f.Close()
 
-	var deployments []Deployment
-	if err := json.NewDecoder(f).Decode(&deployments); err != nil {
-		return nil, fmt.Errorf("store: decode %s: %w", s.path, err)
+	decoder := json.NewDecoder(f)
+	var asObject persistedState
+	if err := decoder.Decode(&asObject); err == nil {
+		if asObject.Deployments == nil {
+			asObject.Deployments = []Deployment{}
+		}
+		if asObject.Registries == nil {
+			asObject.Registries = []Registry{}
+		}
+		return asObject, nil
 	}
 
-	for _, d := range deployments {
+	if _, seekErr := f.Seek(0, 0); seekErr != nil {
+		return persistedState{}, fmt.Errorf("store: rewind %s: %w", s.path, seekErr)
+	}
+
+	var deployments []Deployment
+	if err := json.NewDecoder(f).Decode(&deployments); err != nil {
+		return persistedState{}, fmt.Errorf("store: decode %s: %w", s.path, err)
+	}
+
+	state.Deployments = deployments
+	return state, nil
+}
+
+// read loads deployments from disk into a map. Caller must hold the lock.
+func (s *JSONStore) read() (map[string]Deployment, error) {
+	data := make(map[string]Deployment)
+
+	state, err := s.readState()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, d := range state.Deployments {
 		data[d.ID] = d
 	}
 
@@ -168,10 +235,12 @@ func (s *JSONStore) read() (map[string]Deployment, error) {
 }
 
 // persist writes data to disk atomically. Caller must hold the lock.
-func (s *JSONStore) persist(data map[string]Deployment) error {
-	deployments := make([]Deployment, 0, len(data))
-	for _, d := range data {
-		deployments = append(deployments, d)
+func (s *JSONStore) persistState(state persistedState) error {
+	if state.Deployments == nil {
+		state.Deployments = []Deployment{}
+	}
+	if state.Registries == nil {
+		state.Registries = []Registry{}
 	}
 
 	tmp := s.path + ".tmp"
@@ -181,7 +250,7 @@ func (s *JSONStore) persist(data map[string]Deployment) error {
 		return fmt.Errorf("store: create temp file: %w", err)
 	}
 
-	if err := json.NewEncoder(f).Encode(deployments); err != nil {
+	if err := json.NewEncoder(f).Encode(state); err != nil {
 		f.Close()
 		os.Remove(tmp)
 		return fmt.Errorf("store: encode: %w", err)
@@ -204,6 +273,269 @@ func (s *JSONStore) persist(data map[string]Deployment) error {
 	}
 
 	return nil
+}
+
+// persist writes data to disk atomically. Caller must hold the lock.
+func (s *JSONStore) persist(data map[string]Deployment) error {
+	deployments := make([]Deployment, 0, len(data))
+	for _, d := range data {
+		deployments = append(deployments, d)
+	}
+
+	state, err := s.readState()
+	if err != nil {
+		return err
+	}
+	state.Deployments = deployments
+
+	return s.persistState(state)
+}
+
+func (s *JSONStore) ListRegistries() ([]RegistryEntry, error) {
+	var result []RegistryEntry
+	err := s.withRLock(func() error {
+		state, err := s.readState()
+		if err != nil {
+			return err
+		}
+		result = make([]RegistryEntry, 0, len(state.Registries))
+		for _, r := range state.Registries {
+			result = append(result, RegistryEntry{ID: r.ID, Prefix: r.Prefix, Username: r.Username})
+		}
+		return nil
+	})
+	return result, err
+}
+
+func (s *JSONStore) CreateRegistry(id, prefix, username, password string) (RegistryEntry, error) {
+	prefix = normalizeRegistryPrefix(prefix)
+	username = strings.TrimSpace(username)
+	password = strings.TrimSpace(password)
+	if id == "" || prefix == "" || username == "" || password == "" {
+		return RegistryEntry{}, fmt.Errorf("store: registry id, prefix, username and password are required")
+	}
+
+	secret, err := s.encryptSecret(password)
+	if err != nil {
+		return RegistryEntry{}, err
+	}
+
+	err = s.withLock(func() error {
+		state, err := s.readState()
+		if err != nil {
+			return err
+		}
+		for _, existing := range state.Registries {
+			if existing.Prefix == prefix {
+				return ErrDuplicateRegistryPrefix
+			}
+		}
+		state.Registries = append(state.Registries, Registry{ID: id, Prefix: prefix, Username: username, Secret: secret})
+		return s.persistState(state)
+	})
+	if err != nil {
+		return RegistryEntry{}, err
+	}
+
+	return RegistryEntry{ID: id, Prefix: prefix, Username: username}, nil
+}
+
+func (s *JSONStore) UpdateRegistry(id, prefix, username, password string) (RegistryEntry, error) {
+	prefix = normalizeRegistryPrefix(prefix)
+	username = strings.TrimSpace(username)
+	if id == "" || prefix == "" || username == "" {
+		return RegistryEntry{}, fmt.Errorf("store: registry id, prefix, and username are required")
+	}
+
+	password = strings.TrimSpace(password)
+
+	err := s.withLock(func() error {
+		state, err := s.readState()
+		if err != nil {
+			return err
+		}
+
+		index := -1
+		for i, existing := range state.Registries {
+			if existing.ID == id {
+				index = i
+				continue
+			}
+			if existing.Prefix == prefix {
+				return ErrDuplicateRegistryPrefix
+			}
+		}
+		if index == -1 {
+			return ErrRegistryNotFound
+		}
+
+		updated := state.Registries[index]
+		updated.Prefix = prefix
+		updated.Username = username
+		if password != "" {
+			secret, err := s.encryptSecret(password)
+			if err != nil {
+				return err
+			}
+			updated.Secret = secret
+		}
+
+		state.Registries[index] = updated
+		return s.persistState(state)
+	})
+	if err != nil {
+		return RegistryEntry{}, err
+	}
+
+	return RegistryEntry{ID: id, Prefix: prefix, Username: username}, nil
+}
+
+func (s *JSONStore) DeleteRegistry(id string) error {
+	if strings.TrimSpace(id) == "" {
+		return ErrRegistryNotFound
+	}
+
+	return s.withLock(func() error {
+		state, err := s.readState()
+		if err != nil {
+			return err
+		}
+		for i, entry := range state.Registries {
+			if entry.ID != id {
+				continue
+			}
+			state.Registries = append(state.Registries[:i], state.Registries[i+1:]...)
+			return s.persistState(state)
+		}
+		return ErrRegistryNotFound
+	})
+}
+
+func (s *JSONStore) ResolveRegistryAuth(imageRef string) (*RegistryAuth, error) {
+	imageRef = normalizeImageRef(imageRef)
+	if imageRef == "" {
+		return nil, nil
+	}
+
+	var match *Registry
+	err := s.withRLock(func() error {
+		state, err := s.readState()
+		if err != nil {
+			return err
+		}
+		for i := range state.Registries {
+			candidate := state.Registries[i]
+			if !registryMatchesImage(candidate.Prefix, imageRef) {
+				continue
+			}
+			if match == nil || len(candidate.Prefix) > len(match.Prefix) {
+				copied := candidate
+				match = &copied
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if match == nil {
+		return nil, nil
+	}
+
+	password, err := s.decryptSecret(match.Secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegistryAuth{Username: match.Username, Password: password}, nil
+}
+
+func normalizeRegistryPrefix(prefix string) string {
+	prefix = strings.TrimSpace(strings.ToLower(prefix))
+	prefix = strings.TrimPrefix(prefix, "https://")
+	prefix = strings.TrimPrefix(prefix, "http://")
+	prefix = strings.TrimSuffix(prefix, "/")
+	return prefix
+}
+
+func normalizeImageRef(image string) string {
+	return strings.TrimSpace(strings.ToLower(image))
+}
+
+func registryMatchesImage(prefix, imageRef string) bool {
+	if !strings.HasPrefix(imageRef, prefix) {
+		return false
+	}
+	if len(imageRef) == len(prefix) {
+		return true
+	}
+	sep := imageRef[len(prefix)]
+	return sep == '/' || sep == ':' || sep == '@'
+}
+
+func (s *JSONStore) encryptSecret(secret string) (string, error) {
+	block, err := aes.NewCipher(s.secretKey())
+	if err != nil {
+		return "", fmt.Errorf("store: create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("store: create gcm: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("store: generate nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, []byte(secret), nil)
+	payload := append(nonce, ciphertext...)
+	return base64.StdEncoding.EncodeToString(payload), nil
+}
+
+func (s *JSONStore) decryptSecret(ciphertext string) (string, error) {
+	payload, err := base64.StdEncoding.DecodeString(ciphertext)
+	if err != nil {
+		return "", fmt.Errorf("store: decode secret: %w", err)
+	}
+
+	block, err := aes.NewCipher(s.secretKey())
+	if err != nil {
+		return "", fmt.Errorf("store: create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("store: create gcm: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(payload) < nonceSize {
+		return "", fmt.Errorf("store: invalid encrypted secret payload")
+	}
+
+	nonce := payload[:nonceSize]
+	enc := payload[nonceSize:]
+	plain, err := gcm.Open(nil, nonce, enc, nil)
+	if err != nil {
+		return "", fmt.Errorf("store: decrypt secret: %w", err)
+	}
+
+	return string(plain), nil
+}
+
+func (s *JSONStore) secretKey() []byte {
+	keyMaterial := strings.TrimSpace(os.Getenv("LOTSEN_REGISTRY_SECRET"))
+	if keyMaterial == "" {
+		keyMaterial = strings.TrimSpace(os.Getenv("LOTSEN_JWT_SECRET"))
+	}
+	if keyMaterial == "" {
+		keyMaterial = "dirigent-registry:" + s.path
+	}
+
+	sum := sha256.Sum256([]byte(keyMaterial))
+	key := make([]byte, len(sum))
+	copy(key, sum[:])
+	return key
 }
 
 // List returns a snapshot of all deployments.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ercadev/dirigent/store"
@@ -444,5 +445,106 @@ func TestJSONStore_Patch_StatusClearsError(t *testing.T) {
 	}
 	if updated.Error != "" {
 		t.Fatalf("want error cleared, got %q", updated.Error)
+	}
+}
+
+func TestJSONStore_RegistryCRUD(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deployments.json")
+	s, err := store.NewJSONStore(path)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	created, err := s.CreateRegistry("r1", "ghcr.io/myorg", "alice", "s3cret")
+	if err != nil {
+		t.Fatalf("create registry: %v", err)
+	}
+	if created.ID != "r1" || created.Prefix != "ghcr.io/myorg" || created.Username != "alice" {
+		t.Fatalf("unexpected create response: %#v", created)
+	}
+
+	list, err := s.ListRegistries()
+	if err != nil {
+		t.Fatalf("list registries: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("want 1 registry, got %d", len(list))
+	}
+
+	updated, err := s.UpdateRegistry("r1", "ghcr.io/myorg/team", "bob", "")
+	if err != nil {
+		t.Fatalf("update registry: %v", err)
+	}
+	if updated.Prefix != "ghcr.io/myorg/team" || updated.Username != "bob" {
+		t.Fatalf("unexpected update response: %#v", updated)
+	}
+
+	if err := s.DeleteRegistry("r1"); err != nil {
+		t.Fatalf("delete registry: %v", err)
+	}
+
+	list, err = s.ListRegistries()
+	if err != nil {
+		t.Fatalf("list registries after delete: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("want empty registries after delete, got %d", len(list))
+	}
+}
+
+func TestJSONStore_RegistrySecretNotStoredPlaintext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deployments.json")
+	s, err := store.NewJSONStore(path)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	if _, err := s.CreateRegistry("r1", "registry.example.com", "alice", "very-secret-token"); err != nil {
+		t.Fatalf("create registry: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read raw store: %v", err)
+	}
+
+	if strings.Contains(string(raw), "very-secret-token") {
+		t.Fatal("registry secret was stored in plaintext")
+	}
+}
+
+func TestJSONStore_ResolveRegistryAuth_LongestPrefixWins(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deployments.json")
+	s, err := store.NewJSONStore(path)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	_, err = s.CreateRegistry("r1", "ghcr.io", "general", "general-token")
+	if err != nil {
+		t.Fatalf("create registry r1: %v", err)
+	}
+	_, err = s.CreateRegistry("r2", "ghcr.io/myorg", "org", "org-token")
+	if err != nil {
+		t.Fatalf("create registry r2: %v", err)
+	}
+
+	auth, err := s.ResolveRegistryAuth("ghcr.io/myorg/app:1.0.0")
+	if err != nil {
+		t.Fatalf("resolve registry auth: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("want auth for matching image")
+	}
+	if auth.Username != "org" || auth.Password != "org-token" {
+		t.Fatalf("want org credentials, got %#v", auth)
+	}
+
+	auth, err = s.ResolveRegistryAuth("docker.io/library/nginx:latest")
+	if err != nil {
+		t.Fatalf("resolve non-matching auth: %v", err)
+	}
+	if auth != nil {
+		t.Fatalf("want nil for public image, got %#v", auth)
 	}
 }


### PR DESCRIPTION
## Summary
- add encrypted private registry credential storage in the API/store with CRUD endpoints and tests
- teach the orchestrator Docker pull flow to resolve matching registry credentials by longest image-prefix and pass auth to ImagePull
- add a dedicated Registries page in the dashboard sidebar for managing registry credentials, and keep Host settings focused on host/runtime controls
- align local dev env vars so API and orchestrator share a registry secret for successful credential decryption

## Validation
- make test
- cd dashboard && bun run build