### PR TITLE
feat(upgrade): avoid unnecessary proxy restart

### DIFF
--- a/cli/cmd/lotsen/main.go
+++ b/cli/cmd/lotsen/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -38,6 +40,8 @@ func main() {
 		err = runSetup(os.Args[2:])
 	case "upgrade":
 		err = runUpgrade(os.Args[2:])
+	case "upgrade-proxy":
+		err = runUpgradeProxy(os.Args[2:])
 	case "doctor":
 		err = runDoctor(os.Args[2:])
 	case "-h", "--help", "help":
@@ -59,6 +63,7 @@ func printUsage() {
 	fmt.Println("Usage:")
 	fmt.Println("  lotsen setup [flags]")
 	fmt.Println("  lotsen upgrade [flags]")
+	fmt.Println("  lotsen upgrade-proxy [flags]")
 	fmt.Println("  lotsen doctor [flags]")
 	fmt.Println("")
 	fmt.Println("Run `lotsen <command> --help` for command-specific options.")
@@ -194,6 +199,20 @@ func runUpgrade(args []string) error {
 	currentVersion, targetVersion := determineUpgradeVersions(*target, fetchLocalVersionSnapshot)
 	fmt.Printf("--> Upgrading Lotsen from %s to %s\n", currentVersion, targetVersion)
 
+	// --- Pre-upgrade prediction ---
+	localProxyHash, localErr := sha256File("/usr/local/bin/lotsen-proxy")
+	remoteProxyHash, remoteErr := fetchRemoteHash(*target, "lotsen-proxy")
+
+	switch {
+	case localErr != nil || remoteErr != nil || remoteProxyHash == "":
+		fmt.Println("--> Proxy downtime: unknown (could not determine if binary changes)")
+	case localProxyHash == remoteProxyHash:
+		fmt.Println("--> Proxy downtime: NO (binary unchanged, restart will be skipped)")
+	default:
+		fmt.Println("--> Proxy downtime: YES (binary changed, brief restart required)")
+	}
+	// --- end prediction ---
+
 	effectiveNonInteractive := *nonInteractive || !stdinIsTTY()
 	if !effectiveNonInteractive && !*yes {
 		confirmed, err := promptYesNo("Proceed with upgrade? [Y/n]: ", true)
@@ -205,10 +224,10 @@ func runUpgrade(args []string) error {
 		}
 	}
 
-	env := append(os.Environ(),
-		"LOTSEN_VERSION="+*target,
-		"LOTSEN_UPGRADE=1",
-	)
+	env := append(os.Environ(), "LOTSEN_VERSION="+*target, "LOTSEN_UPGRADE=1")
+	if localErr == nil {
+		env = append(env, "LOTSEN_PROXY_PRE_HASH="+localProxyHash)
+	}
 	if effectiveNonInteractive {
 		env = append(env, "LOTSEN_NON_INTERACTIVE=1")
 	}
@@ -219,6 +238,35 @@ func runUpgrade(args []string) error {
 	url := releaseScriptURL(*target, "setup.sh")
 	fmt.Printf("--> Running upgrade from %s\n", url)
 	return runRemoteScript(url, env)
+}
+
+func runUpgradeProxy(args []string) error {
+	fs := flag.NewFlagSet("upgrade-proxy", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	preHash := fs.String("pre-hash", "", "SHA-256 of proxy binary before upgrade")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("%w\n\nUsage: lotsen upgrade-proxy [--pre-hash <sha256>]", err)
+	}
+
+	currentHash, err := sha256File("/usr/local/bin/lotsen-proxy")
+	if err != nil {
+		return fmt.Errorf("hash proxy binary: %w", err)
+	}
+
+	if !proxyRestartNeeded(*preHash, currentHash) {
+		fmt.Println("--> lotsen-proxy binary unchanged — skipping restart")
+		return nil
+	}
+
+	fmt.Println("--> lotsen-proxy binary changed — restarting service")
+	cmd := exec.Command("systemctl", "restart", "lotsen-proxy")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("restart lotsen-proxy: %w", err)
+	}
+	fmt.Println("--> lotsen-proxy restarted successfully")
+	return nil
 }
 
 func determineUpgradeVersions(target string, lookup versionLookup) (string, string) {
@@ -270,6 +318,55 @@ func fetchLocalVersionSnapshot() (versionSnapshot, error) {
 	}
 
 	return snapshot, nil
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// fetchRemoteHash downloads sha256sums.txt from the target release and returns
+// the listed hash for the named binary. Returns ("", nil) if not found.
+func fetchRemoteHash(version, binaryName string) (string, error) {
+	url := releaseScriptURL(version, "sha256sums.txt")
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("fetch checksums: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil // older release without checksums file
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch checksums status: %d", resp.StatusCode)
+	}
+	return parseChecksumEntry(resp.Body, binaryName)
+}
+
+// parseChecksumEntry reads sha256sums.txt lines (<hash>  <name>) and returns
+// the hash for the named binary. Returns ("", nil) if not present.
+func parseChecksumEntry(r io.Reader, name string) (string, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && fields[1] == name {
+			return fields[0], nil
+		}
+	}
+	return "", scanner.Err()
+}
+
+func proxyRestartNeeded(preHash, currentHash string) bool {
+	return preHash == "" || currentHash != preHash
 }
 
 func runDoctor(args []string) error {

--- a/cli/cmd/lotsen/main_test.go
+++ b/cli/cmd/lotsen/main_test.go
@@ -1,9 +1,99 @@
 package main
 
 import (
+	"crypto/sha256"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 )
+
+func TestSha256File_ReturnsHashForKnownContent(t *testing.T) {
+	content := []byte("hello dirigent")
+	tmp, err := os.CreateTemp("", "sha256test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	got, err := sha256File(tmp.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sum := sha256.Sum256(content)
+	want := make([]byte, len(sum)*2)
+	const hextable = "0123456789abcdef"
+	for i, b := range sum {
+		want[i*2] = hextable[b>>4]
+		want[i*2+1] = hextable[b&0x0f]
+	}
+	if got != string(want) {
+		t.Fatalf("sha256File = %q, want %q", got, string(want))
+	}
+}
+
+func TestSha256File_ErrorsOnMissingFile(t *testing.T) {
+	_, err := sha256File("/nonexistent/path/to/binary")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestParseChecksumEntry_FindsMatchingBinary(t *testing.T) {
+	input := "abc123  lotsen-proxy\n"
+	hash, err := parseChecksumEntry(strings.NewReader(input), "lotsen-proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash != "abc123" {
+		t.Fatalf("hash = %q, want %q", hash, "abc123")
+	}
+}
+
+func TestParseChecksumEntry_ReturnsEmptyWhenNotFound(t *testing.T) {
+	input := "abc123  lotsen-api\n"
+	hash, err := parseChecksumEntry(strings.NewReader(input), "lotsen-proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash != "" {
+		t.Fatalf("hash = %q, want empty string", hash)
+	}
+}
+
+func TestParseChecksumEntry_HandlesMultipleEntries(t *testing.T) {
+	input := "aaa111  lotsen-api\nbbb222  lotsen-proxy\nccc333  lotsen-orchestrator\n"
+	hash, err := parseChecksumEntry(strings.NewReader(input), "lotsen-proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash != "bbb222" {
+		t.Fatalf("hash = %q, want %q", hash, "bbb222")
+	}
+}
+
+func TestProxyRestartNeeded_SkipsWhenHashesMatch(t *testing.T) {
+	if proxyRestartNeeded("deadbeef", "deadbeef") {
+		t.Fatal("expected no restart when hashes match")
+	}
+}
+
+func TestProxyRestartNeeded_RestartsWhenHashDiffers(t *testing.T) {
+	if !proxyRestartNeeded("deadbeef", "cafebabe") {
+		t.Fatal("expected restart when hashes differ")
+	}
+}
+
+func TestProxyRestartNeeded_RestartsWhenNoPreHash(t *testing.T) {
+	if !proxyRestartNeeded("", "cafebabe") {
+		t.Fatal("expected restart when no pre-hash provided")
+	}
+}
 
 func TestDetermineUpgradeVersions_WithLatestAndSnapshot(t *testing.T) {
 	lookup := func() (versionSnapshot, error) {


### PR DESCRIPTION
## Summary

- Adds a pre-upgrade downtime prediction to `lotsen upgrade`: fetches `sha256sums.txt` from the target release and compares the `lotsen-proxy` hash against the locally installed binary, printing a clear `YES/NO/unknown` downtime warning before the confirm prompt
- Introduces `lotsen upgrade-proxy` subcommand for use by `setup.sh` after placing new binaries — restarts `lotsen-proxy` via `systemctl` only when the binary hash actually changed
- Passes `LOTSEN_PROXY_PRE_HASH` env var into the upgrade script so the post-install comparison uses the pre-upgrade snapshot for accuracy

## Test plan

- [ ] `cd cli && go test ./cmd/lotsen/...` — all 11 tests pass
- [ ] `cd cli && go build ./...` — compiles cleanly
- [ ] Same-hash smoke: `lotsen upgrade-proxy --pre-hash $(sha256sum /usr/local/bin/lotsen-proxy | awk '{print $1}')` → prints "skipping restart"
- [ ] Different-hash smoke: `lotsen upgrade-proxy --pre-hash deadbeef` → attempts `systemctl restart lotsen-proxy`
- [ ] `lotsen upgrade --to <version>` prints a clear downtime YES/NO line before the confirm prompt

## Complementary changes (separate PR — dirigent-releases)

`setup.sh` needs to call `lotsen upgrade-proxy --pre-hash "$LOTSEN_PROXY_PRE_HASH"` instead of `systemctl restart lotsen-proxy` directly, and the release pipeline must publish `sha256sums.txt` alongside binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)