### PR TITLE
Preserve deployment visibility across patches and restarts

### DIFF
--- a/api/internal/api/handler_patch_deployment.go
+++ b/api/internal/api/handler_patch_deployment.go
@@ -67,6 +67,7 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 		Volumes:   body.Volumes,
 		Domain:    body.Domain,
 		Public:    public,
+		PublicSet: body.Public != nil,
 		BasicAuth: basicAuth,
 		Security:  body.Security,
 	}

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -107,6 +107,9 @@ func (m *memStore) Patch(id string, patch store.Deployment) (store.Deployment, e
 	if patch.Domain != "" {
 		d.Domain = patch.Domain
 	}
+	if patch.PublicSet {
+		d.Public = patch.Public
+	}
 	if patch.BasicAuth != nil {
 		d.BasicAuth = patch.BasicAuth
 	}
@@ -1694,6 +1697,7 @@ func TestPatchDeployment(t *testing.T) {
 		Envs:   map[string]string{"PORT": "80"},
 		Ports:  []string{"80:80"},
 		Status: store.StatusHealthy,
+		Public: true,
 	}
 
 	srv := newTestServer(s)
@@ -1914,6 +1918,7 @@ func TestUpdateDeployment(t *testing.T) {
 		ID:     "d1",
 		Name:   "web",
 		Image:  "nginx:1",
+		Public: true,
 		Status: store.StatusHealthy,
 	}
 
@@ -2306,6 +2311,7 @@ func TestRestartDeployment(t *testing.T) {
 		ID:     "d1",
 		Name:   "web",
 		Image:  "nginx:1",
+		Public: true,
 		Status: store.StatusHealthy,
 	}
 
@@ -2336,6 +2342,9 @@ func TestRestartDeployment(t *testing.T) {
 	}
 	if updated.Status != store.StatusDeploying {
 		t.Errorf("want status deploying, got %s", updated.Status)
+	}
+	if !updated.Public {
+		t.Errorf("want visibility preserved as public after restart")
 	}
 
 	select {

--- a/store/store.go
+++ b/store/store.go
@@ -66,6 +66,7 @@ type Deployment struct {
 	Volumes   []string          `json:"volumes"`
 	Domain    string            `json:"domain"`
 	Public    bool              `json:"public,omitempty"`
+	PublicSet bool              `json:"-"`
 	BasicAuth *BasicAuthConfig  `json:"basic_auth,omitempty"`
 	Security  *SecurityConfig   `json:"security,omitempty"`
 	Status    Status            `json:"status"`
@@ -645,7 +646,9 @@ func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
 		if patch.Domain != "" {
 			d.Domain = patch.Domain
 		}
-		d.Public = patch.Public
+		if patch.PublicSet {
+			d.Public = patch.Public
+		}
 		if patch.BasicAuth != nil {
 			d.BasicAuth = patch.BasicAuth
 		}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -396,6 +396,50 @@ func TestJSONStore_Patch_UpdatesSecurityConfig(t *testing.T) {
 	}
 }
 
+func TestJSONStore_Patch_PreservesPublicWhenUnset(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deployments.json")
+	s, err := store.NewJSONStore(path)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	_, err = s.Create(store.Deployment{ID: "d1", Name: "web", Public: true, Status: store.StatusHealthy})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	updated, err := s.Patch("d1", store.Deployment{Status: store.StatusDeploying})
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	if !updated.Public {
+		t.Fatalf("want public visibility to be preserved")
+	}
+}
+
+func TestJSONStore_Patch_UpdatesPublicWhenSet(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deployments.json")
+	s, err := store.NewJSONStore(path)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	_, err = s.Create(store.Deployment{ID: "d1", Name: "web", Public: true, Status: store.StatusHealthy})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	updated, err := s.Patch("d1", store.Deployment{Public: false, PublicSet: true})
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	if updated.Public {
+		t.Fatalf("want public visibility to be updated to private")
+	}
+}
+
 func TestJSONStore_Patch_NotFound(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "deployments.json")
 	s, err := store.NewJSONStore(path)


### PR DESCRIPTION
### Motivation
- Restart and status-only patch flows were unintentionally changing a deployment's visibility because `Patch` unconditionally overwrote `Public` when callers did not intend to change it.
- The goal is to ensure `public`/`private` remains stable across restarts or status-only updates unless a client explicitly requests a visibility change.

### Description
- Add an internal sentinel `PublicSet bool` to `store.Deployment` and mark it `json:"-"` so visibility is only changed when explicitly requested.
- Update `JSONStore.Patch` to mutate `Public` only when `PublicSet` is true.
- Make the API patch handler set `PublicSet` only when the incoming request includes the `public` field (in `api/internal/api/handler_patch_deployment.go`).
- Align the test `memStore` behavior in `api` tests with the new store semantics and add regression tests in `store/store_test.go` that cover preserving and updating `Public`.

### Testing
- `go test ./...` at the repository root initially failed due to workspace module configuration, so package-level runs were used to validate changes.
- `go test ./...` in `store/` passed and includes new regression tests for `Public` preservation and explicit updates.
- `go test ./...` in `api/` passed and verifies the restart endpoint and patch handler now preserve visibility when `public` is omitted, and apply it when provided.
- `go test ./...` in `orchestrator/` passed and showed no regressions related to the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ee3501048333a641766295d42d3b)