### PR TITLE
fix(ci): align golangci-lint setup in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.65.1
+          version: v1.64.8
           install-mode: goinstall
           working-directory: api
 
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.65.1
+          version: v1.64.8
           install-mode: goinstall
           working-directory: orchestrator
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,16 +45,19 @@ jobs:
       - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+          install-mode: goinstall
           working-directory: api
 
       - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+          install-mode: goinstall
           working-directory: orchestrator
 
       - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+          install-mode: goinstall
           working-directory: proxy
 
   ci-react:


### PR DESCRIPTION
## Summary
- pin `golangci-lint` in the CI workflow to `v1.64.8`, replacing the invalid `v1.65.1` tag that breaks `goinstall`
- update the Release workflow lint steps (`api`, `orchestrator`, `proxy`) to use `install-mode: goinstall` so lint is built with the job's Go toolchain
- keep both workflows consistent to avoid Go toolchain/version mismatch lint failures