### PR TITLE
fix(setup): seed passkey RP env from dashboard domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Then `lotsen setup` will:
 - Offer security profiles in guided mode (`strict` is recommended)
 - Configure proxy hardening profiles (`standard` by default, `strict` recommended for internet-facing hosts)
 - Prompt for initial dashboard `/login` credentials in interactive setup (blank password auto-generates one)
+- Configure passkey relying-party settings automatically when `DIRIGENT_DASHBOARD_DOMAIN` is set
 
 Re-running the installer performs an in-place upgrade.
 

--- a/setup.sh
+++ b/setup.sh
@@ -60,19 +60,25 @@ write_dashboard_env() {
     local auth_user="$2"
     local auth_password="$3"
     local jwt_secret="$4"
+    local rp_origin=""
     local tmp
 
     install -m 700 -d /etc/dirigent
     tmp=$(mktemp)
 
     if [ -f "${ENV_FILE}" ]; then
-        awk '!/^(DIRIGENT|LOTSEN)_(DASHBOARD_(DOMAIN|USER|PASSWORD)|AUTH_(USER|PASSWORD)|JWT_SECRET)=/' "${ENV_FILE}" > "${tmp}"
+        awk '!/^(DIRIGENT|LOTSEN)_(DASHBOARD_(DOMAIN|USER|PASSWORD)|AUTH_(USER|PASSWORD)|JWT_SECRET|RP_ID|RP_ORIGINS)=/' "${ENV_FILE}" > "${tmp}"
     fi
 
     if [ -n "${dashboard_domain}" ]; then
+        rp_origin="https://${dashboard_domain}"
         {
             echo "DIRIGENT_DASHBOARD_DOMAIN=${dashboard_domain}"
             echo "LOTSEN_DASHBOARD_DOMAIN=${dashboard_domain}"
+            echo "DIRIGENT_RP_ID=${dashboard_domain}"
+            echo "DIRIGENT_RP_ORIGINS=${rp_origin}"
+            echo "LOTSEN_RP_ID=${dashboard_domain}"
+            echo "LOTSEN_RP_ORIGINS=${rp_origin}"
         } >> "${tmp}"
     fi
 


### PR DESCRIPTION
## Summary
- update `setup.sh` to write `LOTSEN_RP_ID`/`LOTSEN_RP_ORIGINS` (and `DIRIGENT_` aliases) whenever `DIRIGENT_DASHBOARD_DOMAIN` is configured
- ensure setup rewrites existing RP env keys cleanly to avoid duplicate or stale values in `/etc/dirigent/dirigent.env`
- document that passkey relying-party settings are now auto-configured during setup when a dashboard domain is provided

## Why
This aligns installer behavior with passkey auth expectations so new installs don't log passkeys as disabled when a public dashboard domain is already configured.