### PR TITLE
fix(proxy): stop dashboard login redirect loop

### DIFF
--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -280,7 +280,12 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !route.Public && h.jwtSecret != nil {
+	requireProxyToken := !route.Public && h.jwtSecret != nil
+	if h.dashboardAuth != nil && host == h.dashboardAuth.Domain {
+		requireProxyToken = false
+	}
+
+	if requireProxyToken {
 		if !h.validProxyToken(r) {
 			outcome = "unauthorized"
 			h.serveLoginRedirect(rw, r)

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -509,6 +509,71 @@ func TestProxy_DashboardDomainBypassesWAF(t *testing.T) {
 	}
 }
 
+func TestProxy_DashboardDomainBypassesJWTGate(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("dashboard.example.com", backend.Listener.Addr().String(), false, nil, nil)
+
+	proxy := newProxyServerWithDashboardAuthAndOptions(tbl, &handler.DashboardAuth{
+		Domain: "dashboard.example.com",
+	}, handler.WithJWTSecret([]byte("secret")))
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/login", nil)
+	req.Host = "dashboard.example.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /login: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxy_NonDashboardDomainRedirectsToLoginWithoutJWT(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("app.example.com", backend.Listener.Addr().String(), false, nil, nil)
+
+	proxy := newProxyServerWithDashboardAuthAndOptions(tbl, &handler.DashboardAuth{
+		Domain: "dashboard.example.com",
+	}, handler.WithJWTSecret([]byte("secret")))
+	defer proxy.Close()
+
+	noRedirectClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "app.example.com"
+
+	resp, err := noRedirectClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("want 302, got %d", resp.StatusCode)
+	}
+	if location := resp.Header.Get("Location"); location != "/login?redirect=/" {
+		t.Fatalf("want redirect to /login?redirect=/, got %q", location)
+	}
+}
+
 func TestProxy_NonDashboardDomainDoesNotRequireBasicAuth(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- prevent the proxy JWT gate from applying to the configured dashboard domain, so unauthenticated users can load `/login` instead of being recursively redirected
- preserve JWT redirect behavior for non-dashboard private domains
- add proxy handler tests covering dashboard-domain bypass and non-dashboard redirect behavior

## Verification
- go test ./proxy/internal/handler
- go test ./proxy/...