### PR TITLE
feat(deployments): support explicit host ports and mixed mappings

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -364,129 +365,219 @@ const (
 	wafModeEnforce   = "enforcement"
 )
 
-// containerPortOnly strips any user-supplied host port prefix and protocol suffix
-// from a port spec, returning only the container port number.
-// "8080:80" → "80", "80/tcp" → "80", "80" → "80".
-func containerPortOnly(spec string) string {
-	if idx := strings.LastIndex(spec, ":"); idx != -1 {
-		spec = spec[idx+1:]
-	}
-	if idx := strings.Index(spec, "/"); idx != -1 {
-		spec = spec[:idx]
-	}
-	return strings.TrimSpace(spec)
+var errNoHostPortsAvailable = errors.New("no host ports available")
+
+type hostPortConflictError struct {
+	HostPort int
+	Protocol string
 }
 
-// normalizeContainerPorts strips host port prefixes from every entry and
-// deduplicates the result, preserving order.
-func normalizeContainerPorts(specs []string) []string {
-	seen := make(map[string]struct{}, len(specs))
-	out := make([]string, 0, len(specs))
-	for _, s := range specs {
-		cp := containerPortOnly(s)
-		if cp == "" {
-			continue
-		}
-		if _, dup := seen[cp]; dup {
-			continue
-		}
-		seen[cp] = struct{}{}
-		out = append(out, cp)
-	}
-	return out
+func (e hostPortConflictError) Error() string {
+	return fmt.Sprintf("host port %d/%s is already in use", e.HostPort, e.Protocol)
 }
 
-// hostPortFromBinding extracts the host port number from a "hostPort:containerPort"
-// binding string. Returns 0 if the binding is not in that format.
-func hostPortFromBinding(binding string) int {
-	idx := strings.Index(binding, ":")
-	if idx == -1 {
-		return 0
+type portSpec struct {
+	HostPort      int
+	ContainerPort int
+	Protocol      string
+}
+
+func (p portSpec) withHostPort(hostPort int) portSpec {
+	p.HostPort = hostPort
+	return p
+}
+
+func (p portSpec) containerKey() string {
+	return fmt.Sprintf("%d/%s", p.ContainerPort, p.Protocol)
+}
+
+func (p portSpec) hostProtocolKey() string {
+	if p.HostPort <= 0 {
+		return ""
 	}
-	n, err := strconv.Atoi(binding[:idx])
+	return fmt.Sprintf("%d/%s", p.HostPort, p.Protocol)
+}
+
+func (p portSpec) binding() string {
+	binding := fmt.Sprintf("%d:%d", p.HostPort, p.ContainerPort)
+	if p.Protocol != "tcp" {
+		binding += "/" + p.Protocol
+	}
+	return binding
+}
+
+func parsePortSpecs(specs []string) ([]portSpec, error) {
+	parsed := make([]portSpec, 0, len(specs))
+	seenContainer := make(map[string]struct{}, len(specs))
+	seenBinding := make(map[string]struct{}, len(specs))
+
+	for _, raw := range specs {
+		p, err := parsePortSpec(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		if p.HostPort > 0 {
+			key := p.hostProtocolKey() + ":" + p.containerKey()
+			if _, dup := seenBinding[key]; dup {
+				continue
+			}
+			seenBinding[key] = struct{}{}
+			parsed = append(parsed, p)
+			continue
+		}
+
+		key := p.containerKey()
+		if _, dup := seenContainer[key]; dup {
+			continue
+		}
+		seenContainer[key] = struct{}{}
+		parsed = append(parsed, p)
+	}
+
+	return parsed, nil
+}
+
+func parsePortSpec(raw string) (portSpec, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return portSpec{}, fmt.Errorf("invalid port mapping: value is empty")
+	}
+
+	mainPart, protocol, hasProtocol := strings.Cut(raw, "/")
+	if hasProtocol {
+		protocol = strings.ToLower(strings.TrimSpace(protocol))
+		if protocol != "tcp" && protocol != "udp" {
+			return portSpec{}, fmt.Errorf("invalid port mapping %q: protocol must be tcp or udp", raw)
+		}
+	} else {
+		protocol = "tcp"
+	}
+
+	parts := strings.Split(mainPart, ":")
+	if len(parts) > 2 {
+		return portSpec{}, fmt.Errorf("invalid port mapping %q", raw)
+	}
+
+	containerPart := strings.TrimSpace(parts[len(parts)-1])
+	containerPort, err := parseValidPortNumber(containerPart)
 	if err != nil {
-		return 0
+		return portSpec{}, fmt.Errorf("invalid port mapping %q: %w", raw, err)
 	}
-	return n
+
+	p := portSpec{ContainerPort: containerPort, Protocol: protocol}
+	if len(parts) == 1 {
+		return p, nil
+	}
+
+	hostPart := strings.TrimSpace(parts[0])
+	hostPort, err := parseValidPortNumber(hostPart)
+	if err != nil {
+		return portSpec{}, fmt.Errorf("invalid port mapping %q: %w", raw, err)
+	}
+	p.HostPort = hostPort
+
+	return p, nil
 }
 
-// containerPortFromBinding extracts the container port from a "hostPort:containerPort"
-// binding string. Returns the full string if there is no colon.
-func containerPortFromBinding(binding string) string {
-	idx := strings.Index(binding, ":")
-	if idx == -1 {
-		return binding
+func parseValidPortNumber(value string) (int, error) {
+	port, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0, fmt.Errorf("port must be numeric")
 	}
-	return binding[idx+1:]
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("port must be between 1 and 65535")
+	}
+	return port, nil
 }
 
-// assignHostPorts returns stable, conflict-free "hostPort:containerPort" bindings
-// for the given container ports.
+// assignHostPorts returns stable, conflict-free host bindings for requested
+// port specs.
 //
 //   - allDeployments: current store snapshot used to find occupied host ports.
 //   - skipID: deployment being created/updated — its existing host ports are NOT
 //     counted as occupied so they can be reused (stability).
 //   - currentBindings: the Ports slice of the deployment being updated, used to
 //     carry over existing host-port assignments for unchanged container ports.
-func assignHostPorts(allDeployments []store.Deployment, skipID string, currentBindings []string, containerPorts []string) ([]string, error) {
-	if len(containerPorts) == 0 {
+func assignHostPorts(allDeployments []store.Deployment, skipID string, currentBindings []string, requestedPorts []string) ([]string, error) {
+	if len(requestedPorts) == 0 {
 		return []string{}, nil
 	}
 
-	// Collect host ports in use by other deployments.
-	usedHostPorts := make(map[int]struct{})
+	requested, err := parsePortSpecs(requestedPorts)
+	if err != nil {
+		return nil, err
+	}
+
+	usedHostPorts := make(map[string]struct{})
 	for _, d := range allDeployments {
 		if d.ID == skipID {
 			continue
 		}
 		for _, p := range d.Ports {
-			if hp := hostPortFromBinding(p); hp > 0 {
-				usedHostPorts[hp] = struct{}{}
+			spec, err := parsePortSpec(p)
+			if err != nil {
+				continue
+			}
+			if key := spec.hostProtocolKey(); key != "" {
+				usedHostPorts[key] = struct{}{}
 			}
 		}
 	}
 
-	// Build a map of containerPort → existing host port for the deployment being
-	// updated so we can reuse the same host port (stable across redeployments).
 	existing := make(map[string]int, len(currentBindings))
 	for _, p := range currentBindings {
-		hp := hostPortFromBinding(p)
-		cp := containerPortFromBinding(p)
-		if hp > 0 && cp != "" {
-			existing[cp] = hp
+		spec, err := parsePortSpec(p)
+		if err != nil {
+			continue
+		}
+		if spec.HostPort > 0 {
+			existing[spec.containerKey()] = spec.HostPort
 		}
 	}
 
-	result := make([]string, 0, len(containerPorts))
-	for _, cp := range containerPorts {
-		// Reuse the existing host port for this container port when it is still free.
-		if hp, ok := existing[cp]; ok {
-			if _, inUse := usedHostPorts[hp]; !inUse {
-				result = append(result, fmt.Sprintf("%d:%s", hp, cp))
-				usedHostPorts[hp] = struct{}{} // prevent double-allocation within batch
+	result := make([]string, 0, len(requested))
+	for _, requestedPort := range requested {
+		if requestedPort.HostPort > 0 {
+			key := requestedPort.hostProtocolKey()
+			if _, inUse := usedHostPorts[key]; inUse {
+				return nil, hostPortConflictError{HostPort: requestedPort.HostPort, Protocol: requestedPort.Protocol}
+			}
+			usedHostPorts[key] = struct{}{}
+			result = append(result, requestedPort.binding())
+			continue
+		}
+
+		if hp, ok := existing[requestedPort.containerKey()]; ok {
+			port := requestedPort.withHostPort(hp)
+			key := port.hostProtocolKey()
+			if _, inUse := usedHostPorts[key]; !inUse {
+				usedHostPorts[key] = struct{}{}
+				result = append(result, port.binding())
 				continue
 			}
 		}
 
-		// Assign a new free host port from the reserved range.
-		hp, err := allocateHostPort(usedHostPorts)
+		hostPort, err := allocateHostPort(usedHostPorts, requestedPort.Protocol)
 		if err != nil {
 			return nil, err
 		}
-		usedHostPorts[hp] = struct{}{}
-		result = append(result, fmt.Sprintf("%d:%s", hp, cp))
+		port := requestedPort.withHostPort(hostPort)
+		usedHostPorts[port.hostProtocolKey()] = struct{}{}
+		result = append(result, port.binding())
 	}
 
 	return result, nil
 }
 
-func allocateHostPort(used map[int]struct{}) (int, error) {
+func allocateHostPort(used map[string]struct{}, protocol string) (int, error) {
 	for port := hostPortRangeMin; port <= hostPortRangeMax; port++ {
-		if _, inUse := used[port]; !inUse {
+		key := fmt.Sprintf("%d/%s", port, protocol)
+		if _, inUse := used[key]; !inUse {
 			return port, nil
 		}
 	}
-	return 0, fmt.Errorf("no free host port available in range %d–%d", hostPortRangeMin, hostPortRangeMax)
+	return 0, errNoHostPortsAvailable
 }
 
 func updateRequiresRedeploy(existing store.Deployment, body deploymentRequest) bool {

--- a/api/internal/api/handler_create_deployment.go
+++ b/api/internal/api/handler_create_deployment.go
@@ -57,9 +57,17 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	assignedPorts, err := assignHostPorts(allDeployments, "", nil, normalizeContainerPorts(body.Ports))
+	assignedPorts, err := assignHostPorts(allDeployments, "", nil, body.Ports)
 	if err != nil {
-		http.Error(w, "no host ports available", http.StatusServiceUnavailable)
+		var conflictErr hostPortConflictError
+		switch {
+		case errors.As(err, &conflictErr):
+			http.Error(w, conflictErr.Error(), http.StatusConflict)
+		case errors.Is(err, errNoHostPortsAvailable):
+			http.Error(w, "no host ports available", http.StatusServiceUnavailable)
+		default:
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
 		return
 	}
 

--- a/api/internal/api/handler_patch_deployment.go
+++ b/api/internal/api/handler_patch_deployment.go
@@ -59,9 +59,17 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed to list deployments", http.StatusInternalServerError)
 			return
 		}
-		assignedPorts, err := assignHostPorts(allDeployments, id, existing.Ports, normalizeContainerPorts(body.Ports))
+		assignedPorts, err := assignHostPorts(allDeployments, id, existing.Ports, body.Ports)
 		if err != nil {
-			http.Error(w, "no host ports available", http.StatusServiceUnavailable)
+			var conflictErr hostPortConflictError
+			switch {
+			case errors.As(err, &conflictErr):
+				http.Error(w, conflictErr.Error(), http.StatusConflict)
+			case errors.Is(err, errNoHostPortsAvailable):
+				http.Error(w, "no host ports available", http.StatusServiceUnavailable)
+			default:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			}
 			return
 		}
 		body.Ports = assignedPorts

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -2853,6 +2853,15 @@ func portHostPart(t *testing.T, binding string) int {
 	return n
 }
 
+func hasPortBinding(bindings []string, expected string) bool {
+	for _, binding := range bindings {
+		if binding == expected {
+			return true
+		}
+	}
+	return false
+}
+
 func TestCreateDeployment_AutoAssignsHostPort(t *testing.T) {
 	srv := newTestServer(newMemStore())
 	defer srv.Close()
@@ -2886,7 +2895,7 @@ func TestCreateDeployment_AutoAssignsHostPort(t *testing.T) {
 	}
 }
 
-func TestCreateDeployment_StripsUserHostPort(t *testing.T) {
+func TestCreateDeployment_PreservesExplicitHostPort(t *testing.T) {
 	srv := newTestServer(newMemStore())
 	defer srv.Close()
 
@@ -2913,9 +2922,123 @@ func TestCreateDeployment_StripsUserHostPort(t *testing.T) {
 	if len(created.Ports) != 1 {
 		t.Fatalf("want 1 port binding, got %d", len(created.Ports))
 	}
-	hp := portHostPart(t, created.Ports[0])
-	if hp == 8080 {
-		t.Errorf("user-specified host port 8080 was not stripped; got binding %s", created.Ports[0])
+	if created.Ports[0] != "8080:80" {
+		t.Errorf("want binding 8080:80, got %s", created.Ports[0])
+	}
+}
+
+func TestCreateDeployment_MixedMappingsPreserveExplicitAndAutoAssignContainerOnly(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"name":  "dns",
+		"image": "pihole/pihole:latest",
+		"ports": []string{"53:53/udp", "80"},
+	})
+	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/deployments: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("want 201, got %d", resp.StatusCode)
+	}
+
+	var created store.Deployment
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(created.Ports) != 2 {
+		t.Fatalf("want 2 port bindings, got %d", len(created.Ports))
+	}
+	if !hasPortBinding(created.Ports, "53:53/udp") {
+		t.Fatalf("want explicit 53:53/udp to be preserved, got %v", created.Ports)
+	}
+
+	autoBinding := ""
+	for _, binding := range created.Ports {
+		if strings.HasSuffix(binding, ":80") {
+			autoBinding = binding
+			break
+		}
+	}
+	if autoBinding == "" {
+		t.Fatalf("want an auto-assigned binding for container port 80, got %v", created.Ports)
+	}
+	autoHostPort := portHostPart(t, autoBinding)
+	if autoHostPort < 32768 || autoHostPort > 60999 {
+		t.Fatalf("host port %d not in auto-assigned range [32768, 60999]", autoHostPort)
+	}
+}
+
+func TestCreateDeployment_ExplicitHostPortConflictReturns409(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	firstBody, _ := json.Marshal(map[string]any{
+		"name":  "dns-a",
+		"image": "nginx:latest",
+		"ports": []string{"53:53/udp"},
+	})
+	firstResp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(firstBody))
+	if err != nil {
+		t.Fatalf("POST first deployment: %v", err)
+	}
+	defer firstResp.Body.Close()
+	if firstResp.StatusCode != http.StatusCreated {
+		t.Fatalf("want first create 201, got %d", firstResp.StatusCode)
+	}
+
+	secondBody, _ := json.Marshal(map[string]any{
+		"name":  "dns-b",
+		"image": "nginx:latest",
+		"ports": []string{"53:53/udp"},
+	})
+	secondResp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(secondBody))
+	if err != nil {
+		t.Fatalf("POST second deployment: %v", err)
+	}
+	defer secondResp.Body.Close()
+
+	if secondResp.StatusCode != http.StatusConflict {
+		t.Fatalf("want 409, got %d", secondResp.StatusCode)
+	}
+	bodyBytes, err := io.ReadAll(secondResp.Body)
+	if err != nil {
+		t.Fatalf("read conflict body: %v", err)
+	}
+	if !strings.Contains(string(bodyBytes), "host port 53/udp is already in use") {
+		t.Fatalf("unexpected conflict body: %q", string(bodyBytes))
+	}
+}
+
+func TestCreateDeployment_ProtocolAwareHostPortConflicts(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	post := func(name string, ports []string) int {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{
+			"name":  name,
+			"image": "nginx:latest",
+			"ports": ports,
+		})
+		resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST /api/deployments (%s): %v", name, err)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if got := post("dns-tcp", []string{"53:53/tcp"}); got != http.StatusCreated {
+		t.Fatalf("want tcp deployment create 201, got %d", got)
+	}
+	if got := post("dns-udp", []string{"53:53/udp"}); got != http.StatusCreated {
+		t.Fatalf("want udp deployment create 201, got %d", got)
 	}
 }
 
@@ -3008,6 +3131,100 @@ func TestUpdateDeployment_HostPortStableOnRedeploy(t *testing.T) {
 	updatedHostPort := portHostPart(t, updated.Ports[0])
 	if updatedHostPort != originalHostPort {
 		t.Errorf("host port changed from %d to %d — should be stable", originalHostPort, updatedHostPort)
+	}
+}
+
+func TestUpdateDeployment_PreservesExplicitHostPort(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	createBody, _ := json.Marshal(map[string]any{
+		"name":  "dns",
+		"image": "pihole/pihole:latest",
+		"ports": []string{"53:53/udp"},
+	})
+	createResp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("POST /api/deployments: %v", err)
+	}
+	defer createResp.Body.Close()
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("want create 201, got %d", createResp.StatusCode)
+	}
+
+	var created store.Deployment
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	updateBody, _ := json.Marshal(map[string]any{
+		"name":  "dns",
+		"image": "pihole/pihole:latest",
+		"ports": []string{"53:53/udp"},
+	})
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/"+created.ID, bytes.NewReader(updateBody))
+	req.Header.Set("Content-Type", "application/json")
+	updateResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/deployments/%s: %v", created.ID, err)
+	}
+	defer updateResp.Body.Close()
+
+	if updateResp.StatusCode != http.StatusOK {
+		t.Fatalf("want update 200, got %d", updateResp.StatusCode)
+	}
+
+	var updated store.Deployment
+	if err := json.NewDecoder(updateResp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode update response: %v", err)
+	}
+	if len(updated.Ports) != 1 || updated.Ports[0] != "53:53/udp" {
+		t.Fatalf("want preserved explicit binding [53:53/udp], got %v", updated.Ports)
+	}
+}
+
+func TestPatchDeployment_ExplicitHostPortConflictReturns409(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	create := func(name string, ports []string) store.Deployment {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{
+			"name":  name,
+			"image": "nginx:latest",
+			"ports": ports,
+		})
+		resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST /api/deployments (%s): %v", name, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("POST (%s): want 201, got %d", name, resp.StatusCode)
+		}
+		var created store.Deployment
+		if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+			t.Fatalf("decode create response (%s): %v", name, err)
+		}
+		return created
+	}
+
+	create("dns-a", []string{"53:53/udp"})
+	second := create("dns-b", []string{"80"})
+
+	patchBody, _ := json.Marshal(map[string]any{
+		"ports": []string{"53:53/udp"},
+	})
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/deployments/"+second.ID, bytes.NewReader(patchBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/deployments/%s: %v", second.ID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("want 409, got %d", resp.StatusCode)
 	}
 }
 

--- a/api/internal/api/handler_update_deployment.go
+++ b/api/internal/api/handler_update_deployment.go
@@ -62,9 +62,17 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	assignedPorts, err := assignHostPorts(allDeployments, id, existing.Ports, normalizeContainerPorts(body.Ports))
+	assignedPorts, err := assignHostPorts(allDeployments, id, existing.Ports, body.Ports)
 	if err != nil {
-		http.Error(w, "no host ports available", http.StatusServiceUnavailable)
+		var conflictErr hostPortConflictError
+		switch {
+		case errors.As(err, &conflictErr):
+			http.Error(w, conflictErr.Error(), http.StatusConflict)
+		case errors.Is(err, errNoHostPortsAvailable):
+			http.Error(w, "no host ports available", http.StatusServiceUnavailable)
+		default:
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
 		return
 	}
 	body.Ports = assignedPorts

--- a/dashboard/src/deployments/CreateDeploymentForm.tsx
+++ b/dashboard/src/deployments/CreateDeploymentForm.tsx
@@ -161,7 +161,7 @@ export default function CreateDeploymentForm({ onSuccess, className, hideHeader 
 
           <DynamicSection<PortRow>
             title="Port mappings"
-            description="Specify the container port to expose. A host port is automatically assigned."
+            description="Use container-only ports (for example 80) for auto host assignment, or explicit mappings like 53:53 and 53:53/udp."
             addLabel="Add port mapping"
             removeLabel="Remove port mapping"
             rows={portRows.rows}
@@ -171,7 +171,7 @@ export default function CreateDeploymentForm({ onSuccess, className, hideHeader 
             renderRow={row => (
               <Input
                 type="text"
-                placeholder="Container port"
+                placeholder="80 or 53:53/udp"
                 value={row.port}
                 onChange={e => portRows.update(row.id, { port: e.target.value })}
                 aria-invalid={Boolean(errors.ports[row.id])}

--- a/dashboard/src/deployments/EditDeploymentForm.tsx
+++ b/dashboard/src/deployments/EditDeploymentForm.tsx
@@ -109,12 +109,12 @@ export default function EditDeploymentForm({ deployment, onClose, className, hid
 
         <DynamicSection<PortRow>
           title="Port mappings"
-          description="Specify the container port to expose. A host port is automatically assigned."
+          description="Use container-only ports (for example 80) for auto host assignment, or explicit mappings like 53:53 and 53:53/udp."
           addLabel="Add port mapping" removeLabel="Remove port mapping"
           rows={portRows.rows} onAdd={portRows.add} onRemove={portRows.remove}
           errorFor={row => errors.ports[row.id]}
           renderRow={row => (
-            <Input type="text" placeholder="Container port" value={row.port}
+            <Input type="text" placeholder="80 or 53:53/udp" value={row.port}
               onChange={e => portRows.update(row.id, { port: e.target.value })}
               aria-invalid={Boolean(errors.ports[row.id])} />
           )}

--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -555,18 +555,18 @@ func (d *Docker) shouldStopBeforeStart(ctx context.Context, oldContainerID strin
 	}
 
 	current := make(map[string]struct{}, len(inspect.NetworkSettings.Ports))
-	for _, bindings := range inspect.NetworkSettings.Ports {
+	for port, bindings := range inspect.NetworkSettings.Ports {
 		for _, b := range bindings {
 			if b.HostPort == "" {
 				continue
 			}
-			current[b.HostPort] = struct{}{}
+			current[b.HostPort+"/"+port.Proto()] = struct{}{}
 			break
 		}
 	}
 
-	for _, hostPort := range desired {
-		if _, overlap := current[hostPort]; overlap {
+	for _, hostPortProto := range desired {
+		if _, overlap := current[hostPortProto]; overlap {
 			return true, nil
 		}
 	}
@@ -585,7 +585,7 @@ func desiredExplicitHostPorts(ports []string) ([]string, error) {
 	}
 
 	result := make([]string, 0, len(bindings))
-	for _, b := range bindings {
+	for port, b := range bindings {
 		if len(b) == 0 {
 			continue
 		}
@@ -593,7 +593,7 @@ func desiredExplicitHostPorts(ports []string) ([]string, error) {
 		if hostPort == "" || hostPort == "0" {
 			continue
 		}
-		result = append(result, hostPort)
+		result = append(result, hostPort+"/"+port.Proto())
 	}
 	return result, nil
 }

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -46,6 +46,7 @@ type mockClient struct {
 	removed          []string
 	renamed          []string
 	onStop           func(id string)
+	onList           func()
 }
 
 func (m *mockClient) Ping(_ context.Context) (dockertypes.Ping, error) {
@@ -74,6 +75,9 @@ func (m *mockClient) ContainerStart(_ context.Context, _ string, _ container.Sta
 }
 
 func (m *mockClient) ContainerList(_ context.Context, _ container.ListOptions) ([]dockertypes.Container, error) {
+	if m.onList != nil {
+		m.onList()
+	}
 	return m.listContainers, m.listErr
 }
 
@@ -472,6 +476,37 @@ func TestDocker_StartAndReplace_OverlappingExplicitHostPort_FallsBackToStopThenS
 	}
 	if len(mock.removed) != 1 || mock.removed[0] != "old-c1" {
 		t.Fatalf("want old-c1 removed first, got %v", mock.removed)
+	}
+}
+
+func TestDocker_StartAndReplace_DifferentProtocolSameHostPort_DoesNotFallback(t *testing.T) {
+	var listedBeforeStop atomic.Bool
+
+	mock := &mockClient{
+		containerCreate:  container.CreateResponse{ID: "new-c1"},
+		inspectContainer: inspectWithPort("53/udp", "53"),
+		listContainers:   []dockertypes.Container{{ID: "new-c1", State: "running"}},
+		onList: func() {
+			listedBeforeStop.Store(true)
+		},
+		onStop: func(_ string) {
+			if !listedBeforeStop.Load() {
+				t.Fatal("old container was stopped before new container readiness check")
+			}
+		},
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.Ports = []string{"53:53/tcp"}
+
+	ports, err := d.StartAndReplace(context.Background(), dep, "old-c1")
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+
+	if len(ports) != 1 || ports[0] != "53:53" {
+		t.Fatalf("want runtime ports [53:53], got %v", ports)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow deployment `ports` to include both container-only entries and explicit host mappings, preserving user-specified host ports on create/update/patch
- make allocation and conflict checks protocol-aware so `53/tcp` and `53/udp` can coexist, while explicit host-port conflicts return `409 Conflict` with a clear error
- add API/orchestrator coverage for mixed mappings and protocol-aware overlap behavior, and update dashboard port mapping helper text to document both formats

## Testing
- go test ./api/internal/api ./orchestrator/internal/docker
- cd dashboard && bun run build