### PR TITLE
feat(deployments): require explicit proxy target port for domain routing

### DIFF
--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -103,6 +103,7 @@ type deploymentRequest struct {
 	Image     string                `json:"image"`
 	Envs      map[string]string     `json:"envs"`
 	Ports     []string              `json:"ports"`
+	ProxyPort int                   `json:"proxy_port"`
 	Volumes   []string              `json:"volumes"`
 	Domain    string                `json:"domain"`
 	Public    bool                  `json:"public"`
@@ -114,6 +115,7 @@ type patchDeploymentRequest struct {
 	Image     string                `json:"image"`
 	Envs      map[string]string     `json:"envs"`
 	Ports     []string              `json:"ports"`
+	ProxyPort *int                  `json:"proxy_port"`
 	Volumes   []string              `json:"volumes"`
 	Domain    string                `json:"domain"`
 	Public    *bool                 `json:"public"`
@@ -584,6 +586,7 @@ func updateRequiresRedeploy(existing store.Deployment, body deploymentRequest) b
 	return existing.Image != body.Image ||
 		!equalStringMap(existing.Envs, body.Envs) ||
 		!slices.Equal(existing.Ports, body.Ports) ||
+		existing.ProxyPort != body.ProxyPort ||
 		!slices.Equal(existing.Volumes, body.Volumes) ||
 		!equalBasicAuthConfig(existing.BasicAuth, body.BasicAuth)
 }
@@ -596,6 +599,9 @@ func patchRequiresRedeploy(existing store.Deployment, body patchDeploymentReques
 		return true
 	}
 	if body.Ports != nil && !slices.Equal(existing.Ports, body.Ports) {
+		return true
+	}
+	if body.ProxyPort != nil && existing.ProxyPort != *body.ProxyPort {
 		return true
 	}
 	if body.Volumes != nil && !slices.Equal(existing.Volumes, body.Volumes) {
@@ -756,9 +762,35 @@ func updateRequestMatchesExisting(existing store.Deployment, body deploymentRequ
 		existing.Image == body.Image &&
 		equalStringMap(existing.Envs, body.Envs) &&
 		slices.Equal(existing.Ports, body.Ports) &&
+		existing.ProxyPort == body.ProxyPort &&
 		slices.Equal(existing.Volumes, body.Volumes) &&
 		existing.Domain == body.Domain &&
 		existing.Public == body.Public &&
 		equalStoredBasicAuthConfig(existing.BasicAuth, basicAuth) &&
 		equalSecurityConfig(existing.Security, body.Security)
+}
+
+func validateProxyPortSelection(domain string, proxyPort int, ports []string) error {
+	if normalizeDomain(domain) == "" {
+		if proxyPort != 0 {
+			return fmt.Errorf("proxy port requires domain")
+		}
+		return nil
+	}
+
+	if proxyPort <= 0 {
+		return fmt.Errorf("proxy port is required when domain is set")
+	}
+
+	for _, raw := range ports {
+		spec, err := parsePortSpec(raw)
+		if err != nil {
+			continue
+		}
+		if spec.ContainerPort == proxyPort && spec.Protocol == "tcp" {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("proxy port must match a tcp container port in ports")
 }

--- a/api/internal/api/handler_create_deployment.go
+++ b/api/internal/api/handler_create_deployment.go
@@ -70,6 +70,10 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	if err := validateProxyPortSelection(body.Domain, body.ProxyPort, assignedPorts); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	d := store.Deployment{
 		ID:        id,
@@ -77,6 +81,7 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 		Image:     body.Image,
 		Envs:      body.Envs,
 		Ports:     assignedPorts,
+		ProxyPort: body.ProxyPort,
 		Volumes:   body.Volumes,
 		Domain:    body.Domain,
 		Public:    body.Public,

--- a/api/internal/api/handler_patch_deployment.go
+++ b/api/internal/api/handler_patch_deployment.go
@@ -48,6 +48,14 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 	if body.Public != nil {
 		effectivePublic = *body.Public
 	}
+	effectivePorts := existing.Ports
+	if body.Ports != nil {
+		effectivePorts = body.Ports
+	}
+	effectiveProxyPort := existing.ProxyPort
+	if body.ProxyPort != nil {
+		effectiveProxyPort = *body.ProxyPort
+	}
 	if !effectivePublic && !h.privateDomainAllowed(effectiveDomain) {
 		http.Error(w, "private deployments must use a domain within LOTSEN_AUTH_COOKIE_DOMAIN", http.StatusBadRequest)
 		return
@@ -73,6 +81,12 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		body.Ports = assignedPorts
+		effectivePorts = assignedPorts
+	}
+
+	if err := validateProxyPortSelection(effectiveDomain, effectiveProxyPort, effectivePorts); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	// Preserve Public when the field is absent from the patch request.
@@ -82,15 +96,17 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	patch := store.Deployment{
-		Image:     body.Image,
-		Envs:      body.Envs,
-		Ports:     body.Ports,
-		Volumes:   body.Volumes,
-		Domain:    body.Domain,
-		Public:    public,
-		PublicSet: body.Public != nil,
-		BasicAuth: basicAuth,
-		Security:  body.Security,
+		Image:        body.Image,
+		Envs:         body.Envs,
+		Ports:        body.Ports,
+		ProxyPort:    effectiveProxyPort,
+		ProxyPortSet: body.ProxyPort != nil,
+		Volumes:      body.Volumes,
+		Domain:       body.Domain,
+		Public:       public,
+		PublicSet:    body.Public != nil,
+		BasicAuth:    basicAuth,
+		Security:     body.Security,
 	}
 	if patchRequiresRedeploy(existing, body) {
 		patch.Status = store.StatusDeploying

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -1223,6 +1223,51 @@ func TestCreateDeployment_PrivateDomainMustMatchAuthCookieDomain(t *testing.T) {
 	}
 }
 
+func TestCreateDeployment_DomainRequiresProxyPort(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"name":    "web",
+		"image":   "nginx:latest",
+		"ports":   []string{"80"},
+		"volumes": []string{},
+		"domain":  "app.example.com",
+	})
+	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/deployments: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateDeployment_DomainRejectsUDPProxyPort(t *testing.T) {
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"name":       "dns",
+		"image":      "pihole/pihole:latest",
+		"ports":      []string{"53:53/udp", "80"},
+		"proxy_port": 53,
+		"volumes":    []string{},
+		"domain":     "dns.example.com",
+	})
+	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/deployments: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
 func TestCreateDeployment_InvalidBody(t *testing.T) {
 	srv := newTestServer(newMemStore())
 	defer srv.Close()
@@ -1863,11 +1908,13 @@ func TestPatchDeployment_EmitsDeployingEvent(t *testing.T) {
 func TestPatchDeployment_DomainOnly_DoesNotRedeploy(t *testing.T) {
 	s := newMemStore()
 	s.deployments["d1"] = store.Deployment{
-		ID:     "d1",
-		Name:   "web",
-		Image:  "nginx:1",
-		Domain: "old.example.com",
-		Status: store.StatusHealthy,
+		ID:        "d1",
+		Name:      "web",
+		Image:     "nginx:1",
+		Ports:     []string{"32768:80"},
+		ProxyPort: 80,
+		Domain:    "old.example.com",
+		Status:    store.StatusHealthy,
 	}
 
 	broker := events.NewBroker()
@@ -2019,27 +2066,29 @@ func TestUpdateDeployment(t *testing.T) {
 func TestUpdateDeployment_NoChanges_SkipsStoreUpdate(t *testing.T) {
 	base := newMemStore()
 	base.deployments["d1"] = store.Deployment{
-		ID:      "d1",
-		Name:    "web",
-		Image:   "nginx:1",
-		Envs:    map[string]string{"PORT": "80"},
-		Ports:   []string{"32768:80"},
-		Volumes: []string{"/data:/data"},
-		Domain:  "app.example.com",
-		Public:  false,
-		Status:  store.StatusHealthy,
+		ID:        "d1",
+		Name:      "web",
+		Image:     "nginx:1",
+		Envs:      map[string]string{"PORT": "80"},
+		Ports:     []string{"32768:80"},
+		ProxyPort: 80,
+		Volumes:   []string{"/data:/data"},
+		Domain:    "app.example.com",
+		Public:    false,
+		Status:    store.StatusHealthy,
 	}
 
 	srv := newTestServer(&failUpdateStore{memStore: base})
 	defer srv.Close()
 
 	body, _ := json.Marshal(map[string]any{
-		"name":    "web",
-		"image":   "nginx:1",
-		"envs":    map[string]string{"PORT": "80"},
-		"ports":   []string{"80"},
-		"volumes": []string{"/data:/data"},
-		"domain":  "app.example.com",
+		"name":       "web",
+		"image":      "nginx:1",
+		"envs":       map[string]string{"PORT": "80"},
+		"ports":      []string{"80"},
+		"proxy_port": 80,
+		"volumes":    []string{"/data:/data"},
+		"domain":     "app.example.com",
 	})
 	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -2066,28 +2115,30 @@ func TestUpdateDeployment_NoChanges_SkipsStoreUpdate(t *testing.T) {
 func TestUpdateDeployment_PublicOnly_UpdatesVisibility(t *testing.T) {
 	s := newMemStore()
 	s.deployments["d1"] = store.Deployment{
-		ID:      "d1",
-		Name:    "web",
-		Image:   "nginx:1",
-		Envs:    map[string]string{"PORT": "80"},
-		Ports:   []string{"32768:80"},
-		Volumes: []string{"/data:/data"},
-		Domain:  "app.example.com",
-		Public:  false,
-		Status:  store.StatusHealthy,
+		ID:        "d1",
+		Name:      "web",
+		Image:     "nginx:1",
+		Envs:      map[string]string{"PORT": "80"},
+		Ports:     []string{"32768:80"},
+		ProxyPort: 80,
+		Volumes:   []string{"/data:/data"},
+		Domain:    "app.example.com",
+		Public:    false,
+		Status:    store.StatusHealthy,
 	}
 
 	srv := newTestServer(s)
 	defer srv.Close()
 
 	body, _ := json.Marshal(map[string]any{
-		"name":    "web",
-		"image":   "nginx:1",
-		"envs":    map[string]string{"PORT": "80"},
-		"ports":   []string{"80"},
-		"volumes": []string{"/data:/data"},
-		"domain":  "app.example.com",
-		"public":  true,
+		"name":       "web",
+		"image":      "nginx:1",
+		"envs":       map[string]string{"PORT": "80"},
+		"ports":      []string{"80"},
+		"proxy_port": 80,
+		"volumes":    []string{"/data:/data"},
+		"domain":     "app.example.com",
+		"public":     true,
 	})
 	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -2118,28 +2169,30 @@ func TestUpdateDeployment_PublicOnly_UpdatesVisibility(t *testing.T) {
 func TestUpdateDeployment_PrivateDomainMustMatchAuthCookieDomain(t *testing.T) {
 	s := newMemStore()
 	s.deployments["d1"] = store.Deployment{
-		ID:      "d1",
-		Name:    "web",
-		Image:   "nginx:1",
-		Domain:  "app.example.com",
-		Public:  true,
-		Status:  store.StatusHealthy,
-		Envs:    map[string]string{},
-		Ports:   []string{"32768:80"},
-		Volumes: []string{},
+		ID:        "d1",
+		Name:      "web",
+		Image:     "nginx:1",
+		Domain:    "app.example.com",
+		ProxyPort: 80,
+		Public:    true,
+		Status:    store.StatusHealthy,
+		Envs:      map[string]string{},
+		Ports:     []string{"32768:80"},
+		Volumes:   []string{},
 	}
 
 	srv := newTestServerWithAuthCookieDomain(s, "example.com")
 	defer srv.Close()
 
 	body, _ := json.Marshal(map[string]any{
-		"name":    "web",
-		"image":   "nginx:1",
-		"domain":  "app.other.dev",
-		"public":  false,
-		"envs":    map[string]string{},
-		"ports":   []string{"80"},
-		"volumes": []string{},
+		"name":       "web",
+		"image":      "nginx:1",
+		"domain":     "app.other.dev",
+		"proxy_port": 80,
+		"public":     false,
+		"envs":       map[string]string{},
+		"ports":      []string{"80"},
+		"volumes":    []string{},
 	})
 	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -2310,14 +2363,15 @@ func TestUpdateDeployment_Lifecycle(t *testing.T) {
 func TestUpdateDeployment_DomainOnly_DoesNotRedeploy(t *testing.T) {
 	s := newMemStore()
 	s.deployments["d1"] = store.Deployment{
-		ID:      "d1",
-		Name:    "web",
-		Image:   "nginx:1",
-		Envs:    map[string]string{"PORT": "80"},
-		Ports:   []string{"80:80"},
-		Volumes: []string{"/data:/data"},
-		Domain:  "old.example.com",
-		Status:  store.StatusHealthy,
+		ID:        "d1",
+		Name:      "web",
+		Image:     "nginx:1",
+		Envs:      map[string]string{"PORT": "80"},
+		Ports:     []string{"80:80"},
+		ProxyPort: 80,
+		Volumes:   []string{"/data:/data"},
+		Domain:    "old.example.com",
+		Status:    store.StatusHealthy,
 	}
 
 	broker := events.NewBroker()
@@ -2331,12 +2385,13 @@ func TestUpdateDeployment_DomainOnly_DoesNotRedeploy(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	body, _ := json.Marshal(map[string]any{
-		"name":    "web",
-		"image":   "nginx:1",
-		"envs":    map[string]string{"PORT": "80"},
-		"ports":   []string{"80:80"},
-		"volumes": []string{"/data:/data"},
-		"domain":  "new.example.com",
+		"name":       "web",
+		"image":      "nginx:1",
+		"envs":       map[string]string{"PORT": "80"},
+		"ports":      []string{"80:80"},
+		"proxy_port": 80,
+		"volumes":    []string{"/data:/data"},
+		"domain":     "new.example.com",
 	})
 	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/deployments/d1", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -3295,7 +3350,7 @@ func TestCreateDeployment_HashesBasicAuthPasswords(t *testing.T) {
 	srv := newTestServer(s)
 	defer srv.Close()
 
-	body := []byte(`{"name":"web","image":"nginx:latest","envs":{},"ports":["80"],"volumes":[],"domain":"app.example.com","basic_auth":{"users":[{"username":"admin","password":"secret"}]}}`)
+	body := []byte(`{"name":"web","image":"nginx:latest","envs":{},"ports":["80"],"proxy_port":80,"volumes":[],"domain":"app.example.com","basic_auth":{"users":[{"username":"admin","password":"secret"}]}}`)
 	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("POST /api/deployments: %v", err)
@@ -3325,7 +3380,7 @@ func TestCreateDeployment_RejectsEmptyBasicAuthUsername(t *testing.T) {
 	srv := newTestServer(newMemStore())
 	defer srv.Close()
 
-	body := []byte(`{"name":"web","image":"nginx:latest","envs":{},"ports":["80"],"volumes":[],"domain":"app.example.com","basic_auth":{"users":[{"username":"","password":"secret"}]}}`)
+	body := []byte(`{"name":"web","image":"nginx:latest","envs":{},"ports":["80"],"proxy_port":80,"volumes":[],"domain":"app.example.com","basic_auth":{"users":[{"username":"","password":"secret"}]}}`)
 	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("POST /api/deployments: %v", err)
@@ -3342,7 +3397,7 @@ func TestCreateDeployment_PersistsSecurityConfig(t *testing.T) {
 	srv := newTestServer(s)
 	defer srv.Close()
 
-	body := []byte(`{"name":"web","image":"nginx:latest","envs":{},"ports":["80"],"volumes":[],"domain":"app.example.com","security":{"waf_enabled":true,"ip_denylist":["10.0.0.0/8"],"ip_allowlist":["203.0.113.0/24"],"custom_rules":["SecRule REQUEST_URI \"@contains blocked\" \"id:10001,phase:1,deny,status:403\""]}}`)
+	body := []byte(`{"name":"web","image":"nginx:latest","envs":{},"ports":["80"],"proxy_port":80,"volumes":[],"domain":"app.example.com","security":{"waf_enabled":true,"ip_denylist":["10.0.0.0/8"],"ip_allowlist":["203.0.113.0/24"],"custom_rules":["SecRule REQUEST_URI \"@contains blocked\" \"id:10001,phase:1,deny,status:403\""]}}`)
 	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("POST /api/deployments: %v", err)

--- a/api/internal/api/handler_update_deployment.go
+++ b/api/internal/api/handler_update_deployment.go
@@ -76,6 +76,10 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	body.Ports = assignedPorts
+	if err := validateProxyPortSelection(body.Domain, body.ProxyPort, body.Ports); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	if updateRequestMatchesExisting(existing, body, basicAuth) {
 		writeJSON(w, http.StatusOK, normalizeDeploymentSecurity(existing))
@@ -93,6 +97,7 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 		Image:     body.Image,
 		Envs:      body.Envs,
 		Ports:     body.Ports,
+		ProxyPort: body.ProxyPort,
 		Volumes:   body.Volumes,
 		Domain:    body.Domain,
 		Public:    body.Public,

--- a/dashboard/src/deployments/CreateDeploymentForm.tsx
+++ b/dashboard/src/deployments/CreateDeploymentForm.tsx
@@ -20,6 +20,7 @@ export default function CreateDeploymentForm({ onSuccess, className, hideHeader 
   const {
     name, setName, image, setImage, domain, setDomain,
     isPublic, setIsPublic,
+    selectedProxyRowId, setSelectedProxyRowId,
     envRows, portRows, volumeRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
     errors, handleSubmit, isPending,
   } = useCreateDeploymentForm({ onSuccess })
@@ -161,7 +162,7 @@ export default function CreateDeploymentForm({ onSuccess, className, hideHeader 
 
           <DynamicSection<PortRow>
             title="Port mappings"
-            description="Use container-only ports (for example 80) for auto host assignment, or explicit mappings like 53:53 and 53:53/udp."
+            description="Use container-only ports (for example 80) for auto host assignment, or explicit mappings like 53:53 and 53:53/udp. When domain is set, choose one TCP row as proxy target."
             addLabel="Add port mapping"
             removeLabel="Remove port mapping"
             rows={portRows.rows}
@@ -169,13 +170,25 @@ export default function CreateDeploymentForm({ onSuccess, className, hideHeader 
             onRemove={portRows.remove}
             errorFor={row => errors.ports[row.id]}
             renderRow={row => (
-              <Input
-                type="text"
-                placeholder="80 or 53:53/udp"
-                value={row.port}
-                onChange={e => portRows.update(row.id, { port: e.target.value })}
-                aria-invalid={Boolean(errors.ports[row.id])}
-              />
+              <>
+                <Input
+                  type="text"
+                  placeholder="80 or 53:53/udp"
+                  value={row.port}
+                  onChange={e => portRows.update(row.id, { port: e.target.value })}
+                  aria-invalid={Boolean(errors.ports[row.id])}
+                  className="flex-1"
+                />
+                <label className="inline-flex shrink-0 items-center gap-2 rounded-md border border-border/60 px-2 py-1 text-xs text-foreground">
+                  <input
+                    type="checkbox"
+                    checked={selectedProxyRowId === row.id}
+                    disabled={!domain.trim()}
+                    onChange={e => setSelectedProxyRowId(e.target.checked ? row.id : null)}
+                  />
+                  Proxy target
+                </label>
+              </>
             )}
           />
 

--- a/dashboard/src/deployments/EditDeploymentForm.tsx
+++ b/dashboard/src/deployments/EditDeploymentForm.tsx
@@ -21,6 +21,7 @@ export default function EditDeploymentForm({ deployment, onClose, className, hid
   const {
     name, setName, image, setImage, domain, setDomain,
     isPublic, setIsPublic,
+    selectedProxyRowId, setSelectedProxyRowId,
     envRows, portRows, volumeRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
     errors, handleSubmit, isDirty, isPending,
   } = useEditDeploymentForm(deployment, onClose)
@@ -109,14 +110,26 @@ export default function EditDeploymentForm({ deployment, onClose, className, hid
 
         <DynamicSection<PortRow>
           title="Port mappings"
-          description="Use container-only ports (for example 80) for auto host assignment, or explicit mappings like 53:53 and 53:53/udp."
+          description="Use container-only ports (for example 80) for auto host assignment, or explicit mappings like 53:53 and 53:53/udp. When domain is set, choose one TCP row as proxy target."
           addLabel="Add port mapping" removeLabel="Remove port mapping"
           rows={portRows.rows} onAdd={portRows.add} onRemove={portRows.remove}
           errorFor={row => errors.ports[row.id]}
           renderRow={row => (
-            <Input type="text" placeholder="80 or 53:53/udp" value={row.port}
-              onChange={e => portRows.update(row.id, { port: e.target.value })}
-              aria-invalid={Boolean(errors.ports[row.id])} />
+            <>
+              <Input type="text" placeholder="80 or 53:53/udp" value={row.port}
+                onChange={e => portRows.update(row.id, { port: e.target.value })}
+                aria-invalid={Boolean(errors.ports[row.id])}
+                className="flex-1" />
+              <label className="inline-flex shrink-0 items-center gap-2 rounded-md border border-border/60 px-2 py-1 text-xs text-foreground">
+                <input
+                  type="checkbox"
+                  checked={selectedProxyRowId === row.id}
+                  disabled={!domain.trim()}
+                  onChange={e => setSelectedProxyRowId(e.target.checked ? row.id : null)}
+                />
+                Proxy target
+              </label>
+            </>
           )}
         />
 

--- a/dashboard/src/deployments/portSpec.ts
+++ b/dashboard/src/deployments/portSpec.ts
@@ -1,0 +1,30 @@
+export type ParsedPortSpec = {
+  containerPort: number
+  protocol: 'tcp' | 'udp'
+}
+
+export function parsePortSpec(raw: string): ParsedPortSpec | null {
+  const trimmed = raw.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const [mainPart, protocolPart] = trimmed.split('/')
+  const protocol = (protocolPart?.trim().toLowerCase() || 'tcp') as 'tcp' | 'udp'
+  if (protocol !== 'tcp' && protocol !== 'udp') {
+    return null
+  }
+
+  const parts = mainPart.split(':').map(part => part.trim()).filter(Boolean)
+  if (parts.length < 1 || parts.length > 2) {
+    return null
+  }
+
+  const containerRaw = parts[parts.length - 1]
+  const containerPort = Number.parseInt(containerRaw, 10)
+  if (!Number.isInteger(containerPort) || containerPort < 1 || containerPort > 65535) {
+    return null
+  }
+
+  return { containerPort, protocol }
+}

--- a/dashboard/src/deployments/useCreateDeploymentForm.ts
+++ b/dashboard/src/deployments/useCreateDeploymentForm.ts
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createDeployment } from '../lib/api'
 import { hashPasswordIfNeeded } from '../lib/password'
+import { parsePortSpec } from './portSpec'
 import { useDynamicRows } from './useDynamicRows'
 
 export type EnvRow = { id: number; key: string; value: string }
@@ -33,6 +34,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
   const [domain, setDomain] = useState('')
   const [isPublic, setIsPublic] = useState(false)
   const [basicAuthEnabled, setBasicAuthEnabled] = useState(false)
+  const [selectedProxyRowId, setSelectedProxyRowId] = useState<number | null>(null)
   const [errors, setErrors] = useState<FormErrors>(EMPTY_ERRORS)
 
   const envRows = useDynamicRows<EnvRow>(id => ({ id, key: '', value: '' }))
@@ -49,6 +51,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
       setDomain('')
       setIsPublic(false)
       setBasicAuthEnabled(false)
+      setSelectedProxyRowId(null)
       envRows.reset()
       portRows.reset()
       volumeRows.reset()
@@ -68,6 +71,23 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
     }
     for (const row of portRows.rows) {
       if (!row.port.trim()) errs.ports[row.id] = 'Container port is required'
+    }
+    if (domain.trim()) {
+      if (selectedProxyRowId == null) {
+        errs.form = 'Select a proxy target port when domain is set'
+      } else {
+        const selected = portRows.rows.find(row => row.id === selectedProxyRowId)
+        if (!selected) {
+          errs.form = 'Select a valid proxy target port when domain is set'
+        } else {
+          const parsed = parsePortSpec(selected.port)
+          if (!parsed) {
+            errs.ports[selected.id] = 'Proxy target must be a valid port mapping'
+          } else if (parsed.protocol !== 'tcp') {
+            errs.ports[selected.id] = 'Proxy target must use TCP'
+          }
+        }
+      }
     }
     for (const row of volumeRows.rows) {
       if (!row.left.trim() || !row.right.trim()) errs.volumes[row.id] = 'Both host and container paths are required'
@@ -107,11 +127,21 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
         }
       : undefined
 
+    let proxyPort: number | undefined
+    if (domain.trim() && selectedProxyRowId != null) {
+      const selected = portRows.rows.find(row => row.id === selectedProxyRowId)
+      const parsed = selected ? parsePortSpec(selected.port) : null
+      if (parsed?.protocol === 'tcp') {
+        proxyPort = parsed.containerPort
+      }
+    }
+
     mutation.mutate({
       name: name.trim(),
       image: image.trim(),
       envs,
       ports: portRows.rows.map(r => r.port.trim()),
+      proxy_port: proxyPort,
       volumes: volumeRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
       domain: domain.trim(),
       public: isPublic,
@@ -125,6 +155,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
     domain, setDomain,
     isPublic, setIsPublic,
     basicAuthEnabled, setBasicAuthEnabled,
+    selectedProxyRowId, setSelectedProxyRowId,
     envRows,
     portRows,
     volumeRows,

--- a/dashboard/src/deployments/useEditDeploymentForm.ts
+++ b/dashboard/src/deployments/useEditDeploymentForm.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { updateDeployment, type BasicAuthConfig, type Deployment, type UpdateDeploymentInput } from '../lib/api'
 import { hashPasswordIfNeeded } from '../lib/password'
+import { parsePortSpec } from './portSpec'
 import { useDynamicRows } from './useDynamicRows'
 import type { BasicAuthUserRow, EnvRow, FormErrors, PairRow, PortRow } from './useCreateDeploymentForm'
 
@@ -23,6 +24,17 @@ function toPortRows(items: string[]): PortRow[] {
     const sep = item.indexOf(':')
     return { id: i, port: sep >= 0 ? item.slice(sep + 1) : item }
   })
+}
+
+function findProxyRowId(rows: PortRow[], proxyPort?: number): number | null {
+  if (!proxyPort) {
+    return null
+  }
+  const match = rows.find(row => {
+    const parsed = parsePortSpec(row.port)
+    return parsed?.protocol === 'tcp' && parsed.containerPort === proxyPort
+  })
+  return match?.id ?? null
 }
 
 function toBasicAuthRows(deployment: Deployment): BasicAuthUserRow[] {
@@ -57,6 +69,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
   const portRows = useDynamicRows<PortRow>(id => ({ id, port: '' }), toPortRows(deployment.ports))
   const volumeRows = useDynamicRows<PairRow>(id => ({ id, left: '', right: '' }), toPairRows(deployment.volumes))
   const basicAuthRows = useDynamicRows<BasicAuthUserRow>(id => ({ id, username: '', password: '' }), toBasicAuthRows(deployment))
+  const [selectedProxyRowId, setSelectedProxyRowId] = useState<number | null>(() => findProxyRowId(toPortRows(deployment.ports), deployment.proxy_port))
 
   const normalizedInput = useMemo<UpdateDeploymentInput>(() => {
     const envs: Record<string, string> = {}
@@ -64,11 +77,21 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
       envs[row.key.trim()] = row.value
     }
 
+    let proxyPort: number | undefined
+    if (domain.trim() && selectedProxyRowId != null) {
+      const selected = portRows.rows.find(row => row.id === selectedProxyRowId)
+      const parsed = selected ? parsePortSpec(selected.port) : null
+      if (parsed?.protocol === 'tcp') {
+        proxyPort = parsed.containerPort
+      }
+    }
+
     return {
       name: name.trim(),
       image: image.trim(),
       envs,
       ports: portRows.rows.map(r => r.port.trim()),
+      proxy_port: proxyPort,
       volumes: volumeRows.rows.map(r => `${r.left.trim()}:${r.right.trim()}`),
       domain: domain.trim(),
       public: isPublic,
@@ -82,7 +105,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
         : undefined,
       security: deployment.security,
     }
-  }, [name, image, domain, isPublic, envRows.rows, portRows.rows, volumeRows.rows, basicAuthEnabled, basicAuthRows.rows, deployment.security])
+  }, [name, image, domain, isPublic, envRows.rows, portRows.rows, selectedProxyRowId, volumeRows.rows, basicAuthEnabled, basicAuthRows.rows, deployment.security])
 
   const isDirty = useMemo(() => {
     const initial: UpdateDeploymentInput = {
@@ -93,6 +116,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
         const separator = port.indexOf(':')
         return separator >= 0 ? port.slice(separator + 1) : port
       }),
+      proxy_port: deployment.proxy_port,
       volumes: deployment.volumes,
       domain: deployment.domain,
       public: deployment.public,
@@ -103,7 +127,8 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
     if (initial.name !== normalizedInput.name ||
       initial.image !== normalizedInput.image ||
       initial.domain !== normalizedInput.domain ||
-      initial.public !== normalizedInput.public) {
+      initial.public !== normalizedInput.public ||
+      initial.proxy_port !== normalizedInput.proxy_port) {
       return true
     }
 
@@ -159,6 +184,23 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
     for (const row of portRows.rows) {
       if (!row.port.trim()) errs.ports[row.id] = 'Container port is required'
     }
+    if (domain.trim()) {
+      if (selectedProxyRowId == null) {
+        errs.form = 'Select a proxy target port when domain is set'
+      } else {
+        const selected = portRows.rows.find(row => row.id === selectedProxyRowId)
+        if (!selected) {
+          errs.form = 'Select a valid proxy target port when domain is set'
+        } else {
+          const parsed = parsePortSpec(selected.port)
+          if (!parsed) {
+            errs.ports[selected.id] = 'Proxy target must be a valid port mapping'
+          } else if (parsed.protocol !== 'tcp') {
+            errs.ports[selected.id] = 'Proxy target must use TCP'
+          }
+        }
+      }
+    }
     for (const row of volumeRows.rows) {
       if (!row.left.trim() || !row.right.trim()) errs.volumes[row.id] = 'Both host and container paths are required'
     }
@@ -206,6 +248,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
     domain, setDomain,
     isPublic, setIsPublic,
     basicAuthEnabled, setBasicAuthEnabled,
+    selectedProxyRowId, setSelectedProxyRowId,
     envRows,
     portRows,
     volumeRows,

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -237,6 +237,7 @@ export type Deployment = {
   image: string
   envs: Record<string, string>
   ports: string[]
+  proxy_port?: number
   volumes: string[]
   domain: string
   public: boolean
@@ -432,6 +433,7 @@ export type CreateDeploymentInput = {
   image: string
   envs: Record<string, string>
   ports: string[]
+  proxy_port?: number
   volumes: string[]
   domain: string
   public: boolean
@@ -453,6 +455,7 @@ export type UpdateDeploymentInput = {
   image: string
   envs: Record<string, string>
   ports: string[]
+  proxy_port?: number
   volumes: string[]
   domain: string
   public: boolean
@@ -474,6 +477,7 @@ export type PatchDeploymentInput = {
   image?: string
   envs?: Record<string, string>
   ports?: string[]
+  proxy_port?: number
   volumes?: string[]
   domain?: string
   public?: boolean

--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -358,7 +359,7 @@ func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldC
 		return nil, fmt.Errorf("docker: resolve runtime ports for %s: %w", resp.ID, err)
 	}
 
-	if err := d.swapProxyRoute(ctx, dep.Domain, runtimePorts); err != nil {
+	if err := d.swapProxyRoute(ctx, dep.Domain, dep.ProxyPort, runtimePorts); err != nil {
 		_ = d.client.ContainerStop(ctx, resp.ID, container.StopOptions{})
 		_ = d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
 		return nil, fmt.Errorf("docker: swap proxy route for %q: %w", dep.Domain, err)
@@ -603,13 +604,13 @@ type routeRequest struct {
 	Upstream string `json:"upstream"`
 }
 
-func (d *Docker) swapProxyRoute(ctx context.Context, domain string, runtimePorts []string) error {
+func (d *Docker) swapProxyRoute(ctx context.Context, domain string, proxyPort int, runtimePorts []string) error {
 	domain = normalizeDomain(domain)
 	if domain == "" {
 		return nil
 	}
 
-	upstream := upstreamFromRuntimePorts(runtimePorts)
+	upstream := upstreamFromRuntimePorts(runtimePorts, proxyPort)
 	if upstream == "" {
 		return fmt.Errorf("runtime upstream not available")
 	}
@@ -638,7 +639,21 @@ func (d *Docker) swapProxyRoute(ctx context.Context, domain string, runtimePorts
 	return nil
 }
 
-func upstreamFromRuntimePorts(runtimePorts []string) string {
+func upstreamFromRuntimePorts(runtimePorts []string, proxyPort int) string {
+	if proxyPort > 0 {
+		wanted := strconv.Itoa(proxyPort)
+		for _, binding := range runtimePorts {
+			host, container, ok := strings.Cut(binding, ":")
+			if !ok || host == "" || container == "" {
+				continue
+			}
+			if container == wanted {
+				return "localhost:" + host
+			}
+		}
+		return ""
+	}
+
 	for _, binding := range runtimePorts {
 		host, _, ok := strings.Cut(binding, ":")
 		if !ok || host == "" {

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -562,6 +562,46 @@ func TestDocker_StartAndReplace_DomainConfigured_SwapsProxyBeforeStoppingOld(t *
 	}
 }
 
+func TestDocker_StartAndReplace_DomainConfigured_UsesSelectedProxyPort(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/internal/routes" {
+			t.Fatalf("want POST /internal/routes, got %s %s", r.Method, r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		r.Body.Close()
+		if string(body) != `{"domain":"example.com","upstream":"localhost:49123"}` {
+			t.Fatalf("unexpected body: %s", string(body))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer proxy.Close()
+
+	t.Setenv("LOTSEN_PROXY_URL", proxy.URL)
+
+	mock := &mockClient{
+		containerCreate: container.CreateResponse{ID: "new-c1"},
+		listContainers:  []dockertypes.Container{{ID: "new-c1", State: "running"}},
+		inspectContainer: inspectWithPorts(map[string]string{
+			"53/udp":  "53",
+			"80/tcp":  "49123",
+			"443/tcp": "49443",
+		}),
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.Ports = []string{"53:53/udp", "80", "443"}
+	dep.Domain = "example.com"
+	dep.ProxyPort = 80
+
+	if _, err := d.StartAndReplace(context.Background(), dep, "old-c1"); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+}
+
 func TestDocker_StartAndReplace_ProxySwapFails_CleansUpNewAndKeepsOld(t *testing.T) {
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -677,12 +717,18 @@ func inspectWithState(exitCode int, oomKilled bool, errMsg string) dockertypes.C
 }
 
 func inspectWithPort(containerPort, hostPort string) dockertypes.ContainerJSON {
+	return inspectWithPorts(map[string]string{containerPort: hostPort})
+}
+
+func inspectWithPorts(bindings map[string]string) dockertypes.ContainerJSON {
+	ports := make(nat.PortMap, len(bindings))
+	for containerPort, hostPort := range bindings {
+		ports[nat.Port(containerPort)] = []nat.PortBinding{{HostPort: hostPort}}
+	}
 	return dockertypes.ContainerJSON{
 		NetworkSettings: &dockertypes.NetworkSettings{
 			NetworkSettingsBase: dockertypes.NetworkSettingsBase{
-				Ports: nat.PortMap{
-					nat.Port(containerPort): []nat.PortBinding{{HostPort: hostPort}},
-				},
+				Ports: ports,
 			},
 		},
 	}

--- a/proxy/internal/poller/poller.go
+++ b/proxy/internal/poller/poller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,6 +20,7 @@ type Table interface {
 type routeState struct {
 	Upstream      string
 	Public        bool
+	ProxyPort     int
 	BasicAuthJSON string
 	SecurityJSON  string
 }
@@ -84,13 +86,14 @@ func (p *Poller) sync() {
 		if domain == "" {
 			continue
 		}
-		upstream := upstreamFromPorts(d.Ports)
+		upstream := upstreamFromPorts(d.Ports, d.ProxyPort)
 		if upstream == "" {
 			continue
 		}
 		current[domain] = routeState{
 			Upstream:      upstream,
 			Public:        d.Public,
+			ProxyPort:     d.ProxyPort,
 			BasicAuthJSON: mustBasicAuthJSON(d.BasicAuth),
 			SecurityJSON:  mustSecurityJSON(d.Security),
 		}
@@ -157,27 +160,66 @@ func mustSecurityJSON(security *store.SecurityConfig) string {
 //   - "8080:80"              → localhost:8080
 //   - "8080:80/tcp"          → localhost:8080
 //   - "127.0.0.1:8080:80"   → localhost:8080
-func upstreamFromPorts(ports []string) string {
-	for _, p := range ports {
-		// Strip protocol suffix: "8080:80/tcp" → "8080:80"
-		if i := strings.IndexByte(p, '/'); i >= 0 {
-			p = p[:i]
+func upstreamFromPorts(ports []string, proxyPort int) string {
+	if proxyPort > 0 {
+		for _, p := range ports {
+			hostPort, containerPort, protocol, ok := parseBinding(p)
+			if !ok || protocol != "tcp" {
+				continue
+			}
+			if containerPort == proxyPort {
+				return "localhost:" + strconv.Itoa(hostPort)
+			}
 		}
-		parts := strings.Split(p, ":")
-		switch len(parts) {
-		case 2:
-			// "hostPort:containerPort"
-			if parts[0] != "" {
-				return "localhost:" + parts[0]
-			}
-		case 3:
-			// "ip:hostPort:containerPort"
-			if parts[1] != "" {
-				return "localhost:" + parts[1]
-			}
+		return ""
+	}
+
+	webPorts := map[int]struct{}{80: {}, 443: {}, 8080: {}, 3000: {}, 8000: {}}
+	fallback := ""
+	for _, p := range ports {
+		hostPort, containerPort, protocol, ok := parseBinding(p)
+		if !ok || protocol != "tcp" {
+			continue
+		}
+		upstream := "localhost:" + strconv.Itoa(hostPort)
+		if _, preferred := webPorts[containerPort]; preferred {
+			return upstream
+		}
+		if fallback == "" {
+			fallback = upstream
 		}
 	}
-	return ""
+	return fallback
+}
+
+func parseBinding(raw string) (hostPort int, containerPort int, protocol string, ok bool) {
+	mainPart := raw
+	protocol = "tcp"
+	if base, proto, hasProtocol := strings.Cut(raw, "/"); hasProtocol {
+		mainPart = base
+		protocol = strings.ToLower(strings.TrimSpace(proto))
+	}
+	if protocol != "tcp" && protocol != "udp" {
+		return 0, 0, "", false
+	}
+
+	parts := strings.Split(mainPart, ":")
+	if len(parts) != 2 && len(parts) != 3 {
+		return 0, 0, "", false
+	}
+
+	hostPart := strings.TrimSpace(parts[len(parts)-2])
+	containerPart := strings.TrimSpace(parts[len(parts)-1])
+	hostPort, err := strconv.Atoi(hostPart)
+	if err != nil || hostPort <= 0 || hostPort > 65535 {
+		return 0, 0, "", false
+	}
+	containerPort, err = strconv.Atoi(containerPart)
+	if err != nil || containerPort <= 0 || containerPort > 65535 {
+		return 0, 0, "", false
+	}
+
+	return hostPort, containerPort, protocol, true
 }
 
 func normalizeDomain(domain string) string {

--- a/proxy/internal/poller/poller_test.go
+++ b/proxy/internal/poller/poller_test.go
@@ -131,6 +131,26 @@ func TestPoller_SkipsDeploymentWithoutPorts(t *testing.T) {
 	}
 }
 
+func TestPoller_SkipsDeploymentWithOnlyUDPPorts(t *testing.T) {
+	ms := &memStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Domain: "dns.example.com", Ports: []string{"53:53/udp"}},
+		},
+	}
+	tbl := newSpyTable()
+	p := poller.New(ms, tbl, time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go p.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := tbl.get("dns.example.com"); ok {
+		t.Error("want no route for udp-only deployment, but route was registered")
+	}
+}
+
 func TestPoller_DeletesRemovedDomain(t *testing.T) {
 	ms := &memStore{
 		deployments: []store.Deployment{
@@ -193,6 +213,30 @@ func TestPoller_UpdatesChangedUpstream(t *testing.T) {
 
 	if route, _ := tbl.get("example.com"); route.Upstream != "localhost:9090" {
 		t.Errorf("updated upstream: want localhost:9090, got %s", route.Upstream)
+	}
+}
+
+func TestPoller_UsesSelectedProxyPort(t *testing.T) {
+	ms := &memStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Domain: "example.com", Ports: []string{"53:53/udp", "32770:8080", "49123:80"}, ProxyPort: 80},
+		},
+	}
+	tbl := newSpyTable()
+	p := poller.New(ms, tbl, time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go p.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	route, ok := tbl.get("example.com")
+	if !ok {
+		t.Fatal("want example.com registered, got not found")
+	}
+	if route.Upstream != "localhost:49123" {
+		t.Fatalf("want upstream localhost:49123 from selected proxy port, got %s", route.Upstream)
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -58,20 +58,22 @@ const (
 
 // Deployment holds the full configuration and runtime state of a container deployment.
 type Deployment struct {
-	ID        string            `json:"id"`
-	Name      string            `json:"name"`
-	Image     string            `json:"image"`
-	Envs      map[string]string `json:"envs"`
-	Ports     []string          `json:"ports"`
-	Volumes   []string          `json:"volumes"`
-	Domain    string            `json:"domain"`
-	Public    bool              `json:"public,omitempty"`
-	PublicSet bool              `json:"-"`
-	BasicAuth *BasicAuthConfig  `json:"basic_auth,omitempty"`
-	Security  *SecurityConfig   `json:"security,omitempty"`
-	Status    Status            `json:"status"`
-	Reason    StatusReason      `json:"reason,omitempty"`
-	Error     string            `json:"error,omitempty"`
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Image        string            `json:"image"`
+	Envs         map[string]string `json:"envs"`
+	Ports        []string          `json:"ports"`
+	ProxyPort    int               `json:"proxy_port,omitempty"`
+	Volumes      []string          `json:"volumes"`
+	Domain       string            `json:"domain"`
+	Public       bool              `json:"public,omitempty"`
+	PublicSet    bool              `json:"-"`
+	ProxyPortSet bool              `json:"-"`
+	BasicAuth    *BasicAuthConfig  `json:"basic_auth,omitempty"`
+	Security     *SecurityConfig   `json:"security,omitempty"`
+	Status       Status            `json:"status"`
+	Reason       StatusReason      `json:"reason,omitempty"`
+	Error        string            `json:"error,omitempty"`
 }
 
 type BasicAuthConfig struct {
@@ -642,6 +644,9 @@ func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
 		}
 		if patch.Volumes != nil {
 			d.Volumes = patch.Volumes
+		}
+		if patch.ProxyPortSet {
+			d.ProxyPort = patch.ProxyPort
 		}
 		if patch.Domain != "" {
 			d.Domain = patch.Domain


### PR DESCRIPTION
## Summary
- add a persisted `proxy_port` field and enforce that deployments with a domain must select a TCP container port to route through the proxy
- update proxy poller and orchestrator route-swapping to honor the selected proxy target instead of inferring from first port mapping
- add dashboard create/edit form controls to select a single proxy target port per deployment and send `proxy_port` in API payloads

## Validation
- `go test ./api/internal/api ./proxy/internal/poller ./orchestrator/internal/docker ./store`
- `bun run build` (in `dashboard/`)