### PR TITLE
fix(upgrade): avoid host firewall and SSH changes during upgrade

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -72,6 +72,7 @@ sudo lotsen upgrade
 
 By default, `lotsen upgrade` now shows the current and target version, then asks for confirmation before continuing.
 For unattended runs (for example CI/automation), pass `--non-interactive --yes`.
+Upgrades refresh Lotsen binaries/services only and do not modify host firewall or SSH hardening settings.
 
 ### Manage services
 

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -478,6 +478,7 @@ export function SettingsPage() {
               <li>- API and orchestrator restart briefly.</li>
               <li>- Dashboard may disconnect for a short window.</li>
               <li>- A reconnect check confirms upgrade completion.</li>
+              <li>- Host firewall and SSH settings are not modified by upgrade.</li>
             </ul>
           </div>
           <DialogFooter>

--- a/setup.sh
+++ b/setup.sh
@@ -25,6 +25,9 @@
 set -euo pipefail
 
 ENV_FILE="/etc/dirigent/dirigent.env"
+UPGRADE_MODE="${DIRIGENT_UPGRADE:-${LOTSEN_UPGRADE:-0}}"
+NON_INTERACTIVE_MODE="${DIRIGENT_NON_INTERACTIVE:-${LOTSEN_NON_INTERACTIVE:-0}}"
+REQUESTED_SECURITY_PROFILE="${DIRIGENT_SECURITY_PROFILE:-${LOTSEN_SECURITY_PROFILE:-}}"
 
 # ─── output helpers ───────────────────────────────────────────────────────────
 
@@ -121,19 +124,19 @@ generate_hex_secret() {
 }
 
 choose_security_profile() {
-    local selected="${DIRIGENT_SECURITY_PROFILE:-}"
+    local selected="${REQUESTED_SECURITY_PROFILE}"
 
     if [ -n "${selected}" ]; then
         echo "${selected}"
         return 0
     fi
 
-    if [ "${DIRIGENT_UPGRADE:-0}" = "1" ]; then
+    if [ "${UPGRADE_MODE}" = "1" ]; then
         echo "standard"
         return 0
     fi
 
-    if [ "${DIRIGENT_NON_INTERACTIVE:-0}" = "1" ] || [ ! -t 0 ]; then
+    if [ "${NON_INTERACTIVE_MODE}" = "1" ] || [ ! -t 0 ]; then
         echo "standard"
         return 0
     fi
@@ -309,18 +312,21 @@ case "${SECURITY_PROFILE}" in
     strict|standard|off)
         ;;
     *)
-        error "Invalid DIRIGENT_SECURITY_PROFILE='${SECURITY_PROFILE}'. Expected strict, standard, or off."
+        error "Invalid security profile '${SECURITY_PROFILE}'. Set DIRIGENT_SECURITY_PROFILE or LOTSEN_SECURITY_PROFILE to strict, standard, or off."
         ;;
 esac
 
 step "Using security profile: ${SECURITY_PROFILE}"
-if [ "${SECURITY_PROFILE}" = "strict" ]; then
+if [ "${UPGRADE_MODE}" = "1" ] && [ -n "${REQUESTED_SECURITY_PROFILE}" ]; then
+    step "Warning: upgrade mode ignores host security profile changes; keeping existing firewall and SSH settings"
+fi
+if [ "${UPGRADE_MODE}" != "1" ] && [ "${SECURITY_PROFILE}" = "strict" ]; then
     ensure_strict_prerequisites
 fi
 
 # ─── version resolution ───────────────────────────────────────────────────────
 
-DIRIGENT_VERSION="${DIRIGENT_VERSION:-latest}"
+DIRIGENT_VERSION="${DIRIGENT_VERSION:-${LOTSEN_VERSION:-latest}}"
 
 if [ "${DIRIGENT_VERSION}" = "latest" ]; then
     RELEASE_BASE="https://github.com/ercadev/dirigent-releases/releases/latest/download"
@@ -494,7 +500,7 @@ if [ -z "${JWT_SECRET}" ]; then
     GENERATED_JWT_SECRET=1
 fi
 
-if [ -t 0 ] && [ "${DIRIGENT_NON_INTERACTIVE:-0}" != "1" ] && [ "${DIRIGENT_UPGRADE:-0}" != "1" ] && [ -z "${AUTH_PASSWORD}" ]; then
+if [ -t 0 ] && [ "${NON_INTERACTIVE_MODE}" != "1" ] && [ "${UPGRADE_MODE}" != "1" ] && [ -z "${AUTH_PASSWORD}" ]; then
     echo ""
     echo "Dashboard /login bootstrap credentials"
     echo "  These credentials are used for the first dashboard login user."
@@ -530,7 +536,7 @@ if [ -z "${AUTH_PASSWORD}" ]; then
     GENERATED_AUTH_PASSWORD=1
 fi
 
-if [ -t 0 ] && [ "${DIRIGENT_NON_INTERACTIVE:-0}" != "1" ] && [ "${DIRIGENT_UPGRADE:-0}" != "1" ]; then
+if [ -t 0 ] && [ "${NON_INTERACTIVE_MODE}" != "1" ] && [ "${UPGRADE_MODE}" != "1" ]; then
     echo ""
     echo "Dashboard public exposure setup"
     echo "  Configure HTTPS on a dedicated domain (optional)."
@@ -566,9 +572,13 @@ fi
 step "Writing shared environment file"
 write_dashboard_env "${DASHBOARD_DOMAIN}" "${AUTH_USER}" "${AUTH_PASSWORD}" "${JWT_SECRET}" "${AUTH_COOKIE_DOMAIN}"
 
-configure_firewall "${SECURITY_PROFILE}"
-if [ "${SECURITY_PROFILE}" = "strict" ]; then
-    apply_strict_ssh_hardening
+if [ "${UPGRADE_MODE}" = "1" ]; then
+    step "Upgrade mode: preserving host firewall and SSH settings"
+else
+    configure_firewall "${SECURITY_PROFILE}"
+    if [ "${SECURITY_PROFILE}" = "strict" ]; then
+        apply_strict_ssh_hardening
+    fi
 fi
 
 # ─── Docker network ───────────────────────────────────────────────────────────

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -136,10 +136,9 @@ Back on the Deployments table, wait for status to become `healthy`.
 Lotsen can be upgraded in two ways:
 
 - **Dashboard:** Open **Settings → System** and click **Check for updates**. If a new version is available, click **Upgrade** to trigger an in-place upgrade without leaving the browser.
-- **CLI:** Re-run the installer on your VPS:
+- **CLI:** Run the upgrade command on your VPS:
   ```bash
-  curl -fsSL https://github.com/ercadev/dirigent-releases/releases/latest/download/install.sh | sudo bash
-  sudo lotsen setup
+  sudo lotsen upgrade
   ```
 
-Both paths perform an in-place upgrade and restart the services.
+Both paths perform an in-place upgrade and restart the services. Upgrade flow does not modify host firewall or SSH settings.


### PR DESCRIPTION
## Summary
- Keep upgrade runs runtime-focused by skipping host-level firewall (`ufw`) reset and SSH hardening changes when `LOTSEN_UPGRADE`/`DIRIGENT_UPGRADE` is set.
- Normalize setup env handling to accept both `LOTSEN_*` and `DIRIGENT_*` variables for upgrade/profile/non-interactive behavior, and warn (without failing) when host security profile input is provided during upgrade.
- Clarify the behavior in the dashboard upgrade confirmation and getting-started docs: upgrades restart services but do not modify host firewall/SSH settings.

## Validation
- `go test ./cli/cmd/lotsen`