### PR TITLE
fix(deployments): restore WAF IP chip remove action

### DIFF
--- a/dashboard/src/deployments/DeploymentSecurityPanel.test.tsx
+++ b/dashboard/src/deployments/DeploymentSecurityPanel.test.tsx
@@ -80,4 +80,26 @@ describe('DeploymentSecurityPanel', () => {
       })
     })
   })
+
+  it('removes an existing denylist entry when clicking chip remove', async () => {
+    const user = userEvent.setup()
+    renderWithQuery(
+      <DeploymentSecurityPanel
+        deployment={{
+          ...deployment,
+          security: {
+            waf_enabled: true,
+            waf_mode: 'detection',
+            ip_denylist: ['10.0.0.0/8'],
+            ip_allowlist: [],
+            custom_rules: [],
+          },
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Remove 10.0.0.0/8' }))
+
+    expect(screen.queryByText('10.0.0.0/8')).not.toBeInTheDocument()
+  })
 })

--- a/dashboard/src/deployments/SecurityCIDRListField.tsx
+++ b/dashboard/src/deployments/SecurityCIDRListField.tsx
@@ -51,7 +51,7 @@ export function SecurityCIDRListField({
       {entries.length > 0 ? (
         <div className="flex flex-wrap gap-2">
           {entries.map(item => (
-            <Badge key={`${id}-${item}`} variant={badgeVariant} className="gap-1 pr-1">
+            <Badge key={`${id}-${item}`} variant={badgeVariant} className="pointer-events-auto gap-1 pr-1">
               <span className="font-mono">{item}</span>
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- restore click handling for WAF IP chips by overriding badge pointer-events so the remove button is interactive
- add a regression test that verifies clicking the chip remove control deletes an existing denylist entry
- fix deployment security UX where clicking the `x` on IP chips previously did nothing