### PR TITLE
feat(settings): add configurable dashboard protection and host WAF controls

### DIFF
--- a/api/cmd/lotsen/main.go
+++ b/api/cmd/lotsen/main.go
@@ -62,6 +62,11 @@ func main() {
 
 	h := internalapi.NewWithVersion(s, broker, logStreamer, version)
 	h.SetAuth(userStore, jwtSecret)
+	dashboardAccessMode, err := dashboardAccessModeFromEnv()
+	if err != nil {
+		log.Fatalf("lotsen: %v", err)
+	}
+	h.SetDashboardAccessMode(dashboardAccessMode)
 	authCookieDomain, err := authCookieDomainFromEnv()
 	if err != nil {
 		log.Fatalf("lotsen: %v", err)
@@ -159,6 +164,21 @@ func authCookieDomainFromEnv() (string, error) {
 		return "", fmt.Errorf("LOTSEN_AUTH_COOKIE_DOMAIN must be a valid domain")
 	}
 	return domain, nil
+}
+
+func dashboardAccessModeFromEnv() (internalapi.DashboardAccessMode, error) {
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv("LOTSEN_DASHBOARD_ACCESS_MODE")))
+	if raw == "" {
+		return internalapi.DashboardAccessModeLoginOnly, nil
+	}
+
+	mode := internalapi.DashboardAccessMode(raw)
+	switch mode {
+	case internalapi.DashboardAccessModeLoginOnly, internalapi.DashboardAccessModeWAFOnly, internalapi.DashboardAccessModeWAFAndLogin:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("LOTSEN_DASHBOARD_ACCESS_MODE must be one of: login_only, waf_only, waf_and_login")
+	}
 }
 
 func normalizeDomain(domain string) string {

--- a/api/cmd/lotsen/main_test.go
+++ b/api/cmd/lotsen/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"path/filepath"
 	"testing"
+
+	internalapi "github.com/ercadev/dirigent/internal/api"
 )
 
 func TestAuthFromEnv_NoSecret(t *testing.T) {
@@ -89,5 +91,37 @@ func TestAuthCookieDomainFromEnv_RejectsInvalid(t *testing.T) {
 
 	if _, err := authCookieDomainFromEnv(); err == nil {
 		t.Fatal("want error for invalid cookie domain")
+	}
+}
+
+func TestDashboardAccessModeFromEnv_DefaultsToLoginOnly(t *testing.T) {
+	t.Setenv("LOTSEN_DASHBOARD_ACCESS_MODE", "")
+
+	mode, err := dashboardAccessModeFromEnv()
+	if err != nil {
+		t.Fatalf("dashboardAccessModeFromEnv() error = %v", err)
+	}
+	if mode != internalapi.DashboardAccessModeLoginOnly {
+		t.Fatalf("want %q, got %q", internalapi.DashboardAccessModeLoginOnly, mode)
+	}
+}
+
+func TestDashboardAccessModeFromEnv_AcceptsWAFAndLogin(t *testing.T) {
+	t.Setenv("LOTSEN_DASHBOARD_ACCESS_MODE", " waf_and_login ")
+
+	mode, err := dashboardAccessModeFromEnv()
+	if err != nil {
+		t.Fatalf("dashboardAccessModeFromEnv() error = %v", err)
+	}
+	if mode != internalapi.DashboardAccessModeWAFAndLogin {
+		t.Fatalf("want %q, got %q", internalapi.DashboardAccessModeWAFAndLogin, mode)
+	}
+}
+
+func TestDashboardAccessModeFromEnv_RejectsInvalid(t *testing.T) {
+	t.Setenv("LOTSEN_DASHBOARD_ACCESS_MODE", "strict")
+
+	if _, err := dashboardAccessModeFromEnv(); err == nil {
+		t.Fatal("want validation error for invalid dashboard access mode")
 	}
 }

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -86,8 +86,16 @@ type AuthUserStore interface {
 
 type HostProfileStore interface {
 	Get() (HostProfile, error)
-	UpdateDisplayName(displayName string) (HostProfile, error)
+	Update(profile HostProfile) (HostProfile, error)
 }
+
+type DashboardAccessMode string
+
+const (
+	DashboardAccessModeLoginOnly   DashboardAccessMode = "login_only"
+	DashboardAccessModeWAFOnly     DashboardAccessMode = "waf_only"
+	DashboardAccessModeWAFAndLogin DashboardAccessMode = "waf_and_login"
+)
 
 type basicAuthUserRequest struct {
 	Username string `json:"username"`
@@ -148,6 +156,7 @@ type Handler struct {
 	challenges       *passkeySessionStore
 	hostProfiles     HostProfileStore
 	hostMetadata     HostMetadataIngestor
+	dashboardAccess  DashboardAccessMode
 }
 
 const defaultOrchestratorStaleAfter = 30 * time.Second
@@ -197,23 +206,24 @@ func NewWithDependencies(s Store, eb EventBus, dl DockerLogs, statusSource Syste
 	hostMetadataIngestor, _ := statusSource.(HostMetadataIngestor)
 
 	return &Handler{
-		store:          s,
-		events:         eb,
-		dockerLogs:     dl,
-		statusEvents:   newSystemStatusBroker(),
-		accessLogDir:   proxyAccessLogDirFromEnv(),
-		statusSource:   statusSource,
-		heartbeats:     heartbeatIngestor,
-		docker:         dockerIngestor,
-		loadBalancer:   loadBalancerIngestor,
-		proxyClient:    &http.Client{Timeout: 3 * time.Second},
-		proxyBaseURL:   proxyInternalBaseURLFromEnv(),
-		cpu:            cpuIngestor,
-		ram:            ramIngestor,
-		versions:       versions,
-		upgrade:        upgrader,
-		containerStats: NewContainerStatsCache(),
-		hostMetadata:   hostMetadataIngestor,
+		store:           s,
+		events:          eb,
+		dockerLogs:      dl,
+		statusEvents:    newSystemStatusBroker(),
+		accessLogDir:    proxyAccessLogDirFromEnv(),
+		statusSource:    statusSource,
+		heartbeats:      heartbeatIngestor,
+		docker:          dockerIngestor,
+		loadBalancer:    loadBalancerIngestor,
+		proxyClient:     &http.Client{Timeout: 3 * time.Second},
+		proxyBaseURL:    proxyInternalBaseURLFromEnv(),
+		cpu:             cpuIngestor,
+		ram:             ramIngestor,
+		versions:        versions,
+		upgrade:         upgrader,
+		containerStats:  NewContainerStatsCache(),
+		hostMetadata:    hostMetadataIngestor,
+		dashboardAccess: DashboardAccessModeLoginOnly,
 	}
 }
 
@@ -236,6 +246,38 @@ func (h *Handler) SetWebAuthn(wa *webauthn.WebAuthn) {
 
 func (h *Handler) SetHostProfileStore(store HostProfileStore) {
 	h.hostProfiles = store
+}
+
+func (h *Handler) SetDashboardAccessMode(mode DashboardAccessMode) {
+	h.dashboardAccess = normalizeDashboardAccessMode(string(mode))
+}
+
+func normalizeDashboardAccessMode(raw string) DashboardAccessMode {
+	mode := DashboardAccessMode(strings.ToLower(strings.TrimSpace(raw)))
+	switch mode {
+	case DashboardAccessModeWAFOnly, DashboardAccessModeWAFAndLogin:
+		return mode
+	default:
+		return DashboardAccessModeLoginOnly
+	}
+}
+
+func (h *Handler) dashboardAccessMode() DashboardAccessMode {
+	mode := h.dashboardAccess
+	if h.hostProfiles == nil {
+		return mode
+	}
+
+	profile, err := h.hostProfiles.Get()
+	if err != nil {
+		return mode
+	}
+
+	if profile.DashboardAccessMode == "" {
+		return mode
+	}
+
+	return normalizeDashboardAccessMode(string(profile.DashboardAccessMode))
 }
 
 func buildAPIStoreChecker(s Store) func(context.Context) bool {

--- a/api/internal/api/handler_auth.go
+++ b/api/internal/api/handler_auth.go
@@ -21,6 +21,11 @@ func (h *Handler) logout(w http.ResponseWriter, r *http.Request) {
 
 // me handles GET /auth/me, returning the currently authenticated user.
 func (h *Handler) me(w http.ResponseWriter, r *http.Request) {
+	if h.dashboardAccessMode() == DashboardAccessModeWAFOnly {
+		http.Error(w, "auth not configured", http.StatusServiceUnavailable)
+		return
+	}
+
 	if len(h.jwtSecret) == 0 {
 		http.Error(w, "auth not configured", http.StatusServiceUnavailable)
 		return
@@ -39,6 +44,11 @@ func (h *Handler) me(w http.ResponseWriter, r *http.Request) {
 // When no authStore is configured it is a no-op (open access).
 func (h *Handler) requireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if h.dashboardAccessMode() == DashboardAccessModeWAFOnly {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		if h.authStore == nil || len(h.jwtSecret) == 0 {
 			next.ServeHTTP(w, r)
 			return

--- a/api/internal/api/handler_auth_test.go
+++ b/api/internal/api/handler_auth_test.go
@@ -144,6 +144,15 @@ func newAuthTestServerWithCookieDomain(store api.Store, authStore api.AuthUserSt
 	return httptest.NewServer(mux)
 }
 
+func newAuthTestServerWithDashboardAccessMode(store api.Store, authStore api.AuthUserStore, mode api.DashboardAccessMode) *httptest.Server {
+	mux := http.NewServeMux()
+	h := api.New(store, events.NewBroker(), noopDockerLogs{})
+	h.SetAuth(authStore, testJWTSecret)
+	h.SetDashboardAccessMode(mode)
+	h.RegisterRoutes(mux)
+	return httptest.NewServer(mux)
+}
+
 func TestLogout_ClearsCookie(t *testing.T) {
 	srv := newAuthTestServer(newMemStore(), newStubAuthStore("testuser"))
 	defer srv.Close()
@@ -264,6 +273,36 @@ func TestProtectedRoute_AllowsWithToken(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("want 200 with valid token, got %d", resp.StatusCode)
+	}
+}
+
+func TestMe_WAFOnlyModeReturnsDisabled(t *testing.T) {
+	srv := newAuthTestServerWithDashboardAccessMode(newMemStore(), newStubAuthStore("testuser"), api.DashboardAccessModeWAFOnly)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/auth/me")
+	if err != nil {
+		t.Fatalf("GET /auth/me: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", resp.StatusCode)
+	}
+}
+
+func TestProtectedRoute_WAFOnlyModeBypassesAuth(t *testing.T) {
+	srv := newAuthTestServerWithDashboardAccessMode(newMemStore(), newStubAuthStore("testuser"), api.DashboardAccessModeWAFOnly)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/deployments")
+	if err != nil {
+		t.Fatalf("GET /api/deployments: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
 	}
 }
 

--- a/api/internal/api/handler_host.go
+++ b/api/internal/api/handler_host.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 )
@@ -11,12 +12,22 @@ import (
 const maxHostDisplayNameLength = 64
 
 type HostProfile struct {
-	DisplayName string `json:"displayName"`
+	DisplayName         string              `json:"displayName"`
+	DashboardAccessMode DashboardAccessMode `json:"dashboardAccessMode,omitempty"`
+	DashboardWAF        DashboardWAFConfig  `json:"dashboardWaf,omitempty"`
+}
+
+type DashboardWAFConfig struct {
+	Mode        string   `json:"mode"`
+	IPAllowlist []string `json:"ipAllowlist,omitempty"`
+	CustomRules []string `json:"customRules,omitempty"`
 }
 
 type hostResponse struct {
-	DisplayName string                    `json:"displayName"`
-	Metadata    *HostMetadataSystemStatus `json:"metadata,omitempty"`
+	DisplayName         string                    `json:"displayName"`
+	DashboardAccessMode DashboardAccessMode       `json:"dashboardAccessMode"`
+	DashboardWAF        DashboardWAFConfig        `json:"dashboardWaf"`
+	Metadata            *HostMetadataSystemStatus `json:"metadata,omitempty"`
 }
 
 func (h *Handler) getHost(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +42,12 @@ func (h *Handler) getHost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	snapshot := h.currentSystemStatusSnapshot(r)
-	writeJSON(w, http.StatusOK, hostResponse{DisplayName: profile.DisplayName, Metadata: snapshot.Host.Metadata})
+	mode := normalizeDashboardAccessMode(string(profile.DashboardAccessMode))
+	if profile.DashboardAccessMode == "" {
+		mode = h.dashboardAccessMode()
+	}
+	wafConfig := normalizeDashboardWAFConfig(profile.DashboardWAF)
+	writeJSON(w, http.StatusOK, hostResponse{DisplayName: profile.DisplayName, DashboardAccessMode: mode, DashboardWAF: wafConfig, Metadata: snapshot.Host.Metadata})
 }
 
 func (h *Handler) updateHost(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +59,13 @@ func (h *Handler) updateHost(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
 	var body struct {
-		DisplayName *string `json:"displayName"`
+		DisplayName         *string `json:"displayName"`
+		DashboardAccessMode *string `json:"dashboardAccessMode"`
+		DashboardWAF        *struct {
+			Mode        *string   `json:"mode"`
+			IPAllowlist *[]string `json:"ipAllowlist"`
+			CustomRules *[]string `json:"customRules"`
+		} `json:"dashboardWaf"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
@@ -51,23 +73,110 @@ func (h *Handler) updateHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if body.DisplayName == nil {
-		http.Error(w, "displayName is required", http.StatusBadRequest)
+	if body.DisplayName == nil && body.DashboardAccessMode == nil && body.DashboardWAF == nil {
+		http.Error(w, "at least one field is required", http.StatusBadRequest)
 		return
 	}
 
-	displayName := strings.TrimSpace(*body.DisplayName)
-	if len(displayName) > maxHostDisplayNameLength {
-		http.Error(w, "displayName too long", http.StatusBadRequest)
+	profile, err := h.hostProfiles.Get()
+	if err != nil {
+		http.Error(w, "failed to load host profile", http.StatusInternalServerError)
 		return
 	}
 
-	updated, err := h.hostProfiles.UpdateDisplayName(displayName)
+	if body.DisplayName != nil {
+		displayName := strings.TrimSpace(*body.DisplayName)
+		if len(displayName) > maxHostDisplayNameLength {
+			http.Error(w, "displayName too long", http.StatusBadRequest)
+			return
+		}
+		profile.DisplayName = displayName
+	}
+
+	if body.DashboardAccessMode != nil {
+		raw := strings.ToLower(strings.TrimSpace(*body.DashboardAccessMode))
+		switch DashboardAccessMode(raw) {
+		case DashboardAccessModeWAFOnly, DashboardAccessModeLoginOnly, DashboardAccessModeWAFAndLogin:
+			profile.DashboardAccessMode = DashboardAccessMode(raw)
+		default:
+			http.Error(w, "invalid dashboardAccessMode", http.StatusBadRequest)
+			return
+		}
+	}
+
+	if body.DashboardWAF != nil {
+		next := profile.DashboardWAF
+
+		if body.DashboardWAF.Mode != nil {
+			rawMode := strings.ToLower(strings.TrimSpace(*body.DashboardWAF.Mode))
+			switch rawMode {
+			case "detection", "enforcement":
+				next.Mode = rawMode
+			default:
+				http.Error(w, "invalid dashboardWaf.mode", http.StatusBadRequest)
+				return
+			}
+		}
+
+		if body.DashboardWAF.IPAllowlist != nil {
+			next.IPAllowlist = normalizeCustomRules(*body.DashboardWAF.IPAllowlist)
+			if err := validateCIDRorIPList(next.IPAllowlist); err != nil {
+				http.Error(w, "invalid dashboardWaf.ipAllowlist", http.StatusBadRequest)
+				return
+			}
+		}
+
+		if body.DashboardWAF.CustomRules != nil {
+			next.CustomRules = normalizeCustomRules(*body.DashboardWAF.CustomRules)
+		}
+		profile.DashboardWAF = normalizeDashboardWAFConfig(next)
+	}
+
+	updated, err := h.hostProfiles.Update(profile)
 	if err != nil {
 		http.Error(w, "failed to update host profile", http.StatusInternalServerError)
 		return
 	}
 
 	snapshot := h.currentSystemStatusSnapshot(r)
-	writeJSON(w, http.StatusOK, hostResponse{DisplayName: updated.DisplayName, Metadata: snapshot.Host.Metadata})
+	mode := normalizeDashboardAccessMode(string(updated.DashboardAccessMode))
+	wafConfig := normalizeDashboardWAFConfig(updated.DashboardWAF)
+	writeJSON(w, http.StatusOK, hostResponse{DisplayName: updated.DisplayName, DashboardAccessMode: mode, DashboardWAF: wafConfig, Metadata: snapshot.Host.Metadata})
+}
+
+func normalizeDashboardWAFConfig(cfg DashboardWAFConfig) DashboardWAFConfig {
+	mode := strings.ToLower(strings.TrimSpace(cfg.Mode))
+	if mode != "enforcement" {
+		mode = "detection"
+	}
+	return DashboardWAFConfig{
+		Mode:        mode,
+		IPAllowlist: normalizeCustomRules(cfg.IPAllowlist),
+		CustomRules: normalizeCustomRules(cfg.CustomRules),
+	}
+}
+
+func normalizeCustomRules(raw []string) []string {
+	out := make([]string, 0, len(raw))
+	for _, rule := range raw {
+		rule = strings.TrimSpace(rule)
+		if rule == "" {
+			continue
+		}
+		out = append(out, rule)
+	}
+	return out
+}
+
+func validateCIDRorIPList(entries []string) error {
+	for _, entry := range entries {
+		if _, _, err := net.ParseCIDR(entry); err == nil {
+			continue
+		}
+		if ip := net.ParseIP(entry); ip != nil {
+			continue
+		}
+		return errors.New("invalid cidr or ip")
+	}
+	return nil
 }

--- a/api/internal/api/handler_host_test.go
+++ b/api/internal/api/handler_host_test.go
@@ -44,13 +44,25 @@ func TestHost_GetAndUpdateDisplayName(t *testing.T) {
 	}
 
 	var initial struct {
-		DisplayName string `json:"displayName"`
+		DisplayName         string `json:"displayName"`
+		DashboardAccessMode string `json:"dashboardAccessMode"`
+		DashboardWAF        struct {
+			Mode        string   `json:"mode"`
+			IPAllowlist []string `json:"ipAllowlist"`
+			CustomRules []string `json:"customRules"`
+		} `json:"dashboardWaf"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&initial); err != nil {
 		t.Fatalf("decode host response: %v", err)
 	}
 	if initial.DisplayName != "" {
 		t.Fatalf("want empty initial display name, got %q", initial.DisplayName)
+	}
+	if initial.DashboardAccessMode != "login_only" {
+		t.Fatalf("want default dashboardAccessMode login_only, got %q", initial.DashboardAccessMode)
+	}
+	if initial.DashboardWAF.Mode != "detection" {
+		t.Fatalf("want default dashboardWaf.mode detection, got %q", initial.DashboardWAF.Mode)
 	}
 
 	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/host", bytes.NewBufferString(`{"displayName":"prod-eu"}`))
@@ -70,13 +82,25 @@ func TestHost_GetAndUpdateDisplayName(t *testing.T) {
 	}
 
 	var updated struct {
-		DisplayName string `json:"displayName"`
+		DisplayName         string `json:"displayName"`
+		DashboardAccessMode string `json:"dashboardAccessMode"`
+		DashboardWAF        struct {
+			Mode        string   `json:"mode"`
+			IPAllowlist []string `json:"ipAllowlist"`
+			CustomRules []string `json:"customRules"`
+		} `json:"dashboardWaf"`
 	}
 	if err := json.NewDecoder(updateResp.Body).Decode(&updated); err != nil {
 		t.Fatalf("decode updated host response: %v", err)
 	}
 	if updated.DisplayName != "prod-eu" {
 		t.Fatalf("want updated display name prod-eu, got %q", updated.DisplayName)
+	}
+	if updated.DashboardAccessMode != "login_only" {
+		t.Fatalf("want dashboardAccessMode login_only, got %q", updated.DashboardAccessMode)
+	}
+	if updated.DashboardWAF.Mode != "detection" {
+		t.Fatalf("want dashboardWaf.mode detection, got %q", updated.DashboardWAF.Mode)
 	}
 
 	verifyResp, err := http.Get(srv.URL + "/api/host")
@@ -86,13 +110,124 @@ func TestHost_GetAndUpdateDisplayName(t *testing.T) {
 	defer verifyResp.Body.Close()
 
 	var persisted struct {
-		DisplayName string `json:"displayName"`
+		DisplayName         string `json:"displayName"`
+		DashboardAccessMode string `json:"dashboardAccessMode"`
+		DashboardWAF        struct {
+			Mode        string   `json:"mode"`
+			IPAllowlist []string `json:"ipAllowlist"`
+			CustomRules []string `json:"customRules"`
+		} `json:"dashboardWaf"`
 	}
 	if err := json.NewDecoder(verifyResp.Body).Decode(&persisted); err != nil {
 		t.Fatalf("decode persisted host response: %v", err)
 	}
 	if persisted.DisplayName != "prod-eu" {
 		t.Fatalf("want persisted display name prod-eu, got %q", persisted.DisplayName)
+	}
+	if persisted.DashboardAccessMode != "login_only" {
+		t.Fatalf("want persisted dashboardAccessMode login_only, got %q", persisted.DashboardAccessMode)
+	}
+	if persisted.DashboardWAF.Mode != "detection" {
+		t.Fatalf("want persisted dashboardWaf.mode detection, got %q", persisted.DashboardWAF.Mode)
+	}
+}
+
+func TestHost_UpdateDashboardAccessMode(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServerWithHostProfileStore(t, filepath.Join(t.TempDir(), "host_profile.json"))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/host", bytes.NewBufferString(`{"dashboardAccessMode":"waf_and_login"}`))
+	if err != nil {
+		t.Fatalf("build PUT /api/host request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/host: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var updated struct {
+		DashboardAccessMode string `json:"dashboardAccessMode"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode updated host response: %v", err)
+	}
+	if updated.DashboardAccessMode != "waf_and_login" {
+		t.Fatalf("want updated dashboardAccessMode waf_and_login, got %q", updated.DashboardAccessMode)
+	}
+}
+
+func TestHost_UpdateDashboardWAFConfig(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServerWithHostProfileStore(t, filepath.Join(t.TempDir(), "host_profile.json"))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/host", bytes.NewBufferString(`{"dashboardWaf":{"mode":"enforcement","ipAllowlist":["203.0.113.0/24"],"customRules":["SecRule REQUEST_URI \"@contains blocked\" \"id:10010,phase:1,deny,status:403\""]}}`))
+	if err != nil {
+		t.Fatalf("build PUT /api/host request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/host: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var updated struct {
+		DashboardWAF struct {
+			Mode        string   `json:"mode"`
+			IPAllowlist []string `json:"ipAllowlist"`
+			CustomRules []string `json:"customRules"`
+		} `json:"dashboardWaf"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode updated host response: %v", err)
+	}
+	if updated.DashboardWAF.Mode != "enforcement" {
+		t.Fatalf("want dashboardWaf.mode enforcement, got %q", updated.DashboardWAF.Mode)
+	}
+	if len(updated.DashboardWAF.CustomRules) != 1 {
+		t.Fatalf("want 1 custom rule, got %d", len(updated.DashboardWAF.CustomRules))
+	}
+	if len(updated.DashboardWAF.IPAllowlist) != 1 || updated.DashboardWAF.IPAllowlist[0] != "203.0.113.0/24" {
+		t.Fatalf("want ipAllowlist [203.0.113.0/24], got %#v", updated.DashboardWAF.IPAllowlist)
+	}
+}
+
+func TestHost_UpdateDashboardWAFConfigRejectsInvalidAllowlist(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServerWithHostProfileStore(t, filepath.Join(t.TempDir(), "host_profile.json"))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/host", bytes.NewBufferString(`{"dashboardWaf":{"ipAllowlist":["not-a-cidr"]}}`))
+	if err != nil {
+		t.Fatalf("build PUT /api/host request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/host: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
 	}
 }
 

--- a/api/internal/api/host_profile_store.go
+++ b/api/internal/api/host_profile_store.go
@@ -46,14 +46,9 @@ func (s *FileHostProfileStore) Get() (HostProfile, error) {
 	return result, nil
 }
 
-func (s *FileHostProfileStore) UpdateDisplayName(displayName string) (HostProfile, error) {
+func (s *FileHostProfileStore) Update(profile HostProfile) (HostProfile, error) {
 	updated := HostProfile{}
 	err := s.withLock(func() error {
-		profile, err := s.read()
-		if err != nil {
-			return err
-		}
-		profile.DisplayName = displayName
 		if err := s.persist(profile); err != nil {
 			return err
 		}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -371,6 +371,12 @@ export type HostSystemStatus = {
 
 export type HostProfile = {
   displayName: string
+  dashboardAccessMode: 'login_only' | 'waf_only' | 'waf_and_login'
+  dashboardWaf: {
+    mode: 'detection' | 'enforcement'
+    ipAllowlist: string[]
+    customRules: string[]
+  }
   metadata?: HostMetadata
 }
 
@@ -518,11 +524,15 @@ export async function getHostProfile(): Promise<HostProfile> {
   return res.json()
 }
 
-export async function updateHostProfile(displayName: string): Promise<HostProfile> {
+export async function updateHostProfile(input: {
+  displayName?: string
+  dashboardAccessMode?: HostProfile['dashboardAccessMode']
+  dashboardWaf?: { mode?: HostProfile['dashboardWaf']['mode']; ipAllowlist?: string[]; customRules?: string[] }
+}): Promise<HostProfile> {
   const res = await apiFetch('/api/host', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ displayName }),
+    body: JSON.stringify(input),
   })
   if (!res.ok) throw new Error('Failed to update host profile')
   return res.json()

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog'
 import { Input } from '../components/ui/input'
+import { SecurityCIDRListField } from '../deployments/SecurityCIDRListField'
 import {
   getHostProfile,
   getVersionInfo,
@@ -138,6 +139,13 @@ export function SettingsPage() {
   const [upgradeError, setUpgradeError] = useState<string | null>(null)
   const [hostNameDraft, setHostNameDraft] = useState('')
   const [hostUpdateError, setHostUpdateError] = useState<string | null>(null)
+  const [dashboardAccessModeDraft, setDashboardAccessModeDraft] = useState<'login_only' | 'waf_only' | 'waf_and_login'>('login_only')
+  const [dashboardAccessModeError, setDashboardAccessModeError] = useState<string | null>(null)
+  const [dashboardWAFModeDraft, setDashboardWAFModeDraft] = useState<'detection' | 'enforcement'>('detection')
+  const [dashboardWAFAllowlistInput, setDashboardWAFAllowlistInput] = useState('')
+  const [dashboardWAFAllowlistDraft, setDashboardWAFAllowlistDraft] = useState<string[]>([])
+  const [dashboardWAFRulesDraft, setDashboardWAFRulesDraft] = useState('')
+  const [dashboardWAFError, setDashboardWAFError] = useState<string | null>(null)
   const [attemptId, setAttemptId] = useState(0)
 
   const { currentVersion, latestVersion, publishedAt, releaseNotes, upgradeAvailable, cachedAt, isLoading, isError } = useVersionCheck()
@@ -253,10 +261,14 @@ export function SettingsPage() {
 
   useEffect(() => {
     setHostNameDraft(hostProfileQuery.data?.displayName ?? '')
-  }, [hostProfileQuery.data?.displayName])
+    setDashboardAccessModeDraft(hostProfileQuery.data?.dashboardAccessMode ?? 'login_only')
+    setDashboardWAFModeDraft(hostProfileQuery.data?.dashboardWaf?.mode ?? 'detection')
+    setDashboardWAFAllowlistDraft(hostProfileQuery.data?.dashboardWaf?.ipAllowlist ?? [])
+    setDashboardWAFRulesDraft((hostProfileQuery.data?.dashboardWaf?.customRules ?? []).join('\n'))
+  }, [hostProfileQuery.data?.displayName, hostProfileQuery.data?.dashboardAccessMode, hostProfileQuery.data?.dashboardWaf])
 
   const hostNameUpdate = useMutation({
-    mutationFn: updateHostProfile,
+    mutationFn: (displayName: string) => updateHostProfile({ displayName }),
     onSuccess: profile => {
       queryClient.setQueryData(['hostProfile'], profile)
       setHostUpdateError(null)
@@ -266,8 +278,42 @@ export function SettingsPage() {
     },
   })
 
+  const dashboardAccessModeUpdate = useMutation({
+    mutationFn: (dashboardAccessMode: 'login_only' | 'waf_only' | 'waf_and_login') => updateHostProfile({ dashboardAccessMode }),
+    onSuccess: profile => {
+      queryClient.setQueryData(['hostProfile'], profile)
+      setDashboardAccessModeError(null)
+      setDashboardAccessModeDraft(profile.dashboardAccessMode)
+    },
+    onError: error => {
+      setDashboardAccessModeError(error instanceof Error ? error.message : 'Failed to update dashboard protection mode')
+    },
+  })
+
+  const dashboardWAFUpdate = useMutation({
+    mutationFn: (input: { mode: 'detection' | 'enforcement'; ipAllowlist: string[]; customRules: string[] }) => updateHostProfile({ dashboardWaf: input }),
+    onSuccess: profile => {
+      queryClient.setQueryData(['hostProfile'], profile)
+      setDashboardWAFError(null)
+      setDashboardWAFModeDraft(profile.dashboardWaf.mode)
+      setDashboardWAFAllowlistDraft(profile.dashboardWaf.ipAllowlist)
+      setDashboardWAFAllowlistInput('')
+      setDashboardWAFRulesDraft(profile.dashboardWaf.customRules.join('\n'))
+    },
+    onError: error => {
+      setDashboardWAFError(error instanceof Error ? error.message : 'Failed to update dashboard WAF settings')
+    },
+  })
+
   const activeTarget = selectedUpgradeTarget ?? (upgradeAvailable ? latestVersion ?? null : null)
   const canStartUpgrade = upgradeAvailable && Boolean(activeTarget) && !isUpgradeRunning && !startUpgrade.isPending
+  const dashboardProtectionLabel =
+    dashboardAccessModeDraft === 'login_only'
+      ? 'Login only'
+      : dashboardAccessModeDraft === 'waf_only'
+        ? 'WAF only'
+        : 'WAF and login'
+  const dashboardWAFActive = dashboardAccessModeDraft !== 'login_only'
 
   return (
     <section className="space-y-4">
@@ -308,32 +354,156 @@ export function SettingsPage() {
         </div>
 
         <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)]">
-          <section className="rounded-lg border border-border/55 bg-background/70 p-4">
-            <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Host identity</p>
-            <p className="mt-1 text-sm text-muted-foreground">Name shown in navigation and logs.</p>
+          <div className="space-y-3">
+            <section className="rounded-lg border border-border/55 bg-background/70 p-4">
+              <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Host identity</p>
+              <p className="mt-1 text-sm text-muted-foreground">Name shown in navigation and logs.</p>
 
-            <form
-              className="mt-3 flex flex-col gap-2 sm:flex-row"
-              onSubmit={event => {
-                event.preventDefault()
-                hostNameUpdate.mutate(hostNameDraft)
-              }}
-            >
-              <Input
-                value={hostNameDraft}
-                onChange={event => setHostNameDraft(event.target.value)}
-                placeholder="e.g. prod-eu-1"
-                maxLength={64}
-                className="sm:max-w-sm"
-                aria-label="Host display name"
-              />
-              <Button type="submit" disabled={hostNameUpdate.isPending || hostProfileQuery.isLoading}>
-                Save host name
-              </Button>
-            </form>
+              <form
+                className="mt-3 flex flex-col gap-2 sm:flex-row"
+                onSubmit={event => {
+                  event.preventDefault()
+                  hostNameUpdate.mutate(hostNameDraft)
+                }}
+              >
+                <Input
+                  value={hostNameDraft}
+                  onChange={event => setHostNameDraft(event.target.value)}
+                  placeholder="e.g. prod-eu-1"
+                  maxLength={64}
+                  className="sm:max-w-sm"
+                  aria-label="Host display name"
+                />
+                <Button type="submit" disabled={hostNameUpdate.isPending || hostProfileQuery.isLoading}>
+                  Save host name
+                </Button>
+              </form>
 
-            {hostUpdateError && <p className="mt-2 text-sm text-destructive">{hostUpdateError}</p>}
-          </section>
+              {hostUpdateError && <p className="mt-2 text-sm text-destructive">{hostUpdateError}</p>}
+            </section>
+
+            <section className="rounded-lg border border-border/55 bg-background/70 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Dashboard protection</p>
+                  <p className="mt-1 text-sm text-muted-foreground">Choose whether dashboard traffic is protected by login, WAF, or both.</p>
+                </div>
+                <Badge variant="outline" className="rounded-md border-border/70 bg-background/80 px-2 py-0.5 text-[11px]">
+                  {dashboardProtectionLabel}
+                </Badge>
+              </div>
+
+              <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+                <select
+                  value={dashboardAccessModeDraft}
+                  onChange={event => setDashboardAccessModeDraft(event.target.value as 'login_only' | 'waf_only' | 'waf_and_login')}
+                  className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                  aria-label="Dashboard protection mode"
+                >
+                  <option value="login_only">Login only</option>
+                  <option value="waf_only">WAF only</option>
+                  <option value="waf_and_login">WAF and login</option>
+                </select>
+                <Button
+                  type="button"
+                  disabled={dashboardAccessModeUpdate.isPending || hostProfileQuery.isLoading}
+                  onClick={() => dashboardAccessModeUpdate.mutate(dashboardAccessModeDraft)}
+                >
+                  Save protection mode
+                </Button>
+              </div>
+              {dashboardAccessModeError && <p className="mt-2 text-sm text-destructive">{dashboardAccessModeError}</p>}
+            </section>
+
+            <section className="rounded-lg border border-border/55 bg-background/70 p-4">
+              <details className="group">
+                <summary className="flex cursor-pointer list-none items-start justify-between gap-3 [&::-webkit-details-marker]:hidden">
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Dashboard WAF controls</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Configure dashboard WAF mode, allowlist, and custom rules when WAF is part of protection.
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2 pt-0.5">
+                    <Badge variant={dashboardWAFActive ? 'info' : 'secondary'}>{dashboardWAFActive ? 'active' : 'inactive'}</Badge>
+                    <Badge variant="outline" className="rounded-md border-border/70 bg-background/80 px-2 py-0.5 text-[11px]">
+                      {dashboardWAFModeDraft}
+                    </Badge>
+                  </div>
+                </summary>
+
+                <div className="mt-4 rounded-md border border-border/60 bg-background/60 p-3">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <label className="text-sm text-muted-foreground" htmlFor="dashboard-waf-mode">WAF mode</label>
+                    <select
+                      id="dashboard-waf-mode"
+                      value={dashboardWAFModeDraft}
+                      onChange={event => setDashboardWAFModeDraft(event.target.value as 'detection' | 'enforcement')}
+                      className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                    >
+                      <option value="detection">Detection</option>
+                      <option value="enforcement">Enforcement</option>
+                    </select>
+                  </div>
+
+                  <div className="mt-3 space-y-2">
+                    <SecurityCIDRListField
+                      id="dashboard-waf-ip-allowlist"
+                      label="IP allowlist"
+                      value={dashboardWAFAllowlistInput}
+                      entries={dashboardWAFAllowlistDraft}
+                      emptyLabel="No IP allowlist configured."
+                      badgeVariant="info"
+                      onChange={setDashboardWAFAllowlistInput}
+                      onAdd={value => {
+                        const next = value.trim()
+                        if (!next || dashboardWAFAllowlistDraft.includes(next)) {
+                          return
+                        }
+                        setDashboardWAFAllowlistDraft(prev => [...prev, next])
+                        setDashboardWAFAllowlistInput('')
+                      }}
+                      onRemove={value => setDashboardWAFAllowlistDraft(prev => prev.filter(entry => entry !== value))}
+                    />
+                  </div>
+
+                  <details className="mt-3 rounded-md border border-border/60 bg-background/70 p-3">
+                    <summary className="cursor-pointer text-xs font-medium uppercase tracking-[0.13em] text-muted-foreground">
+                      Advanced custom rules
+                    </summary>
+                    <div className="mt-3 space-y-2">
+                      <label htmlFor="dashboard-waf-rules" className="text-sm text-muted-foreground">Custom rules (one per line)</label>
+                      <textarea
+                        id="dashboard-waf-rules"
+                        value={dashboardWAFRulesDraft}
+                        onChange={event => setDashboardWAFRulesDraft(event.target.value)}
+                        className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs text-foreground"
+                        placeholder={'SecRule REQUEST_URI "@contains blocked" "id:10010,phase:1,deny,status:403"'}
+                      />
+                    </div>
+                  </details>
+
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      disabled={dashboardWAFUpdate.isPending || hostProfileQuery.isLoading}
+                      onClick={() => {
+                        const customRules = dashboardWAFRulesDraft
+                          .split('\n')
+                          .map(rule => rule.trim())
+                          .filter(Boolean)
+                        dashboardWAFUpdate.mutate({ mode: dashboardWAFModeDraft, ipAllowlist: dashboardWAFAllowlistDraft, customRules })
+                      }}
+                    >
+                      Save dashboard WAF settings
+                    </Button>
+                  </div>
+
+                  {dashboardWAFError && <p className="mt-2 text-sm text-destructive">{dashboardWAFError}</p>}
+                </div>
+              </details>
+            </section>
+          </div>
 
           <section className="rounded-lg border border-border/55 bg-background/70 p-4">
             <p className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Machine runtime facts</p>

--- a/go.work.sum
+++ b/go.work.sum
@@ -5,6 +5,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/foxcpp/go-mockdns v1.1.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:EFYHy8/1y2KfgTAsx7Luu7NGhoxtuVHnNo8jE7FikKc=
 github.com/jcchavezs/mergefs v0.1.0/go.mod h1:eRLTrsA+vFwQZ48hj8p8gki/5v9C2bFtHH5Mnn4bcGk=
 github.com/kisielk/errcheck v1.5.0 h1:e8esj/e4R+SAOwFwN+n3zr0nYeCyeweozKfO23MvHzY=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
@@ -23,16 +24,13 @@ github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNl
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/yuin/goldmark v1.2.1 h1:ruQGxdhGHe7FWOJPT0mKs5+pD2Xs1Bm/kdGlHO04FmM=
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/mod v0.32.0 h1:9F4d3PHLljb6x//jOyokMv3eX+YDeepZSEo3mFJy93c=
-golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
-golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
-golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/telemetry v0.0.0-20260109210033-bd525da824e2/go.mod h1:b7fPSJ0pKZ3ccUh8gnTONJxhn3c/PS6tyzQvyqw4iA8=
 golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
 golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
-golang.org/x/tools v0.41.0 h1:a9b8iMweWG+S0OBnlU36rzLp20z1Rp10w+IY2czHTQc=
-golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -52,6 +54,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("proxy: %v", err)
 	}
+	dashboardAccessMode, err := dashboardAccessModeFromEnv()
+	if err != nil {
+		log.Fatalf("proxy: %v", err)
+	}
+	dashboardWAFConfig, err := dashboardWAFConfigFromEnv()
+	if err != nil {
+		log.Fatalf("proxy: %v", err)
+	}
+	profilePath := hostProfilePath(dataPath())
+	dashboardAccessModeResolver := dashboardAccessModeResolver(profilePath, dashboardAccessMode)
+	dashboardWAFResolver := dashboardWAFConfigResolver(profilePath, dashboardWAFConfig)
 	authCookieDomain, err := authCookieDomainFromEnv()
 	if err != nil {
 		log.Fatalf("proxy: %v", err)
@@ -104,6 +117,8 @@ func main() {
 	h := handler.New(
 		table,
 		dashboardAuth,
+		handler.WithDashboardAccessModeResolver(dashboardAccessModeResolver),
+		handler.WithDashboardWAFConfigResolver(dashboardWAFResolver),
 		handler.WithHardeningProfile(hardeningProfile),
 		handler.WithAccessLogger(accessLogger),
 		handler.WithIPFilter(ipFilter),
@@ -249,6 +264,10 @@ func normalizeDomain(domain string) string {
 	return strings.ToLower(domain)
 }
 
+func hostProfilePath(storePath string) string {
+	return filepath.Join(filepath.Dir(storePath), "host_profile.json")
+}
+
 func portFromAddr(addr string) string {
 	addr = strings.TrimSpace(addr)
 	if strings.HasPrefix(addr, ":") {
@@ -286,6 +305,119 @@ func dashboardAuthFromEnv() (*handler.DashboardAuth, error) {
 	return &handler.DashboardAuth{
 		Domain: domain,
 	}, nil
+}
+
+func dashboardAccessModeFromEnv() (handler.DashboardAccessMode, error) {
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv("LOTSEN_DASHBOARD_ACCESS_MODE")))
+	if raw == "" {
+		return handler.DashboardAccessModeLoginOnly, nil
+	}
+
+	mode := handler.DashboardAccessMode(raw)
+	switch mode {
+	case handler.DashboardAccessModeLoginOnly, handler.DashboardAccessModeWAFOnly, handler.DashboardAccessModeWAFAndLogin:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("LOTSEN_DASHBOARD_ACCESS_MODE must be one of: login_only, waf_only, waf_and_login")
+	}
+}
+
+func dashboardWAFConfigFromEnv() (handler.DashboardWAFConfig, error) {
+	modeRaw := strings.ToLower(strings.TrimSpace(envOrDefault("LOTSEN_DASHBOARD_WAF_MODE", string(middleware.WAFModeDetection))))
+	mode := middleware.WAFMode(modeRaw)
+	switch mode {
+	case middleware.WAFModeDetection, middleware.WAFModeEnforcement:
+	default:
+		return handler.DashboardWAFConfig{}, fmt.Errorf("LOTSEN_DASHBOARD_WAF_MODE must be one of: detection, enforcement")
+	}
+
+	ipAllowlist := parseCSVList(os.Getenv("LOTSEN_DASHBOARD_IP_ALLOWLIST"))
+
+	rules := []string{}
+	if rawRules := strings.TrimSpace(os.Getenv("LOTSEN_DASHBOARD_WAF_RULES")); rawRules != "" {
+		for _, line := range strings.Split(rawRules, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			rules = append(rules, line)
+		}
+	}
+
+	return handler.DashboardWAFConfig{Mode: mode, IPAllowlist: ipAllowlist, CustomRules: rules}, nil
+}
+
+func dashboardAccessModeResolver(profilePath string, fallback handler.DashboardAccessMode) func() handler.DashboardAccessMode {
+	return func() handler.DashboardAccessMode {
+		raw, err := os.ReadFile(profilePath)
+		if err != nil {
+			return fallback
+		}
+
+		var profile struct {
+			DashboardAccessMode string `json:"dashboardAccessMode"`
+		}
+		if err := json.Unmarshal(raw, &profile); err != nil {
+			return fallback
+		}
+		mode := handler.DashboardAccessMode(strings.ToLower(strings.TrimSpace(profile.DashboardAccessMode)))
+		switch mode {
+		case handler.DashboardAccessModeLoginOnly, handler.DashboardAccessModeWAFOnly, handler.DashboardAccessModeWAFAndLogin:
+			return mode
+		default:
+			return fallback
+		}
+	}
+}
+
+func dashboardWAFConfigResolver(profilePath string, fallback handler.DashboardWAFConfig) func() handler.DashboardWAFConfig {
+	return func() handler.DashboardWAFConfig {
+		raw, err := os.ReadFile(profilePath)
+		if err != nil {
+			return fallback
+		}
+
+		var profile struct {
+			DashboardWAF struct {
+				Mode        string   `json:"mode"`
+				IPAllowlist []string `json:"ipAllowlist"`
+				CustomRules []string `json:"customRules"`
+			} `json:"dashboardWaf"`
+		}
+		if err := json.Unmarshal(raw, &profile); err != nil {
+			return fallback
+		}
+		if strings.TrimSpace(profile.DashboardWAF.Mode) == "" && len(profile.DashboardWAF.IPAllowlist) == 0 && len(profile.DashboardWAF.CustomRules) == 0 {
+			return fallback
+		}
+
+		mode := middleware.WAFMode(strings.ToLower(strings.TrimSpace(profile.DashboardWAF.Mode)))
+		switch mode {
+		case middleware.WAFModeDetection, middleware.WAFModeEnforcement:
+		default:
+			mode = fallback.Mode
+		}
+
+		allowlist := make([]string, 0, len(profile.DashboardWAF.IPAllowlist))
+		for _, entry := range profile.DashboardWAF.IPAllowlist {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			allowlist = append(allowlist, entry)
+		}
+
+		rules := make([]string, 0, len(profile.DashboardWAF.CustomRules))
+		for _, rule := range profile.DashboardWAF.CustomRules {
+			rule = strings.TrimSpace(rule)
+			if rule == "" {
+				continue
+			}
+			rules = append(rules, rule)
+		}
+
+		return handler.DashboardWAFConfig{Mode: mode, IPAllowlist: allowlist, CustomRules: rules}
+	}
 }
 
 func hardeningProfileFromEnv() (handler.HardeningProfile, error) {

--- a/proxy/cmd/proxy/main_test.go
+++ b/proxy/cmd/proxy/main_test.go
@@ -5,12 +5,15 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
 	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/ercadev/dirigent/proxy/internal/handler"
+	"github.com/ercadev/dirigent/proxy/internal/middleware"
 	"github.com/ercadev/dirigent/proxy/internal/routing"
 	"github.com/ercadev/dirigent/store"
 )
@@ -242,5 +245,74 @@ func TestAuthCookieDomainFromEnv_RejectsInvalid(t *testing.T) {
 
 	if _, err := authCookieDomainFromEnv(); err == nil {
 		t.Fatal("want validation error for invalid cookie domain")
+	}
+}
+
+func TestDashboardAccessModeFromEnv_DefaultsToLoginOnly(t *testing.T) {
+	t.Setenv("LOTSEN_DASHBOARD_ACCESS_MODE", "")
+
+	mode, err := dashboardAccessModeFromEnv()
+	if err != nil {
+		t.Fatalf("dashboardAccessModeFromEnv: %v", err)
+	}
+	if mode != handler.DashboardAccessModeLoginOnly {
+		t.Fatalf("want %q, got %q", handler.DashboardAccessModeLoginOnly, mode)
+	}
+}
+
+func TestDashboardAccessModeFromEnv_RejectsInvalidValue(t *testing.T) {
+	t.Setenv("LOTSEN_DASHBOARD_ACCESS_MODE", "strict")
+
+	if _, err := dashboardAccessModeFromEnv(); err == nil {
+		t.Fatal("want validation error for invalid dashboard access mode")
+	}
+}
+
+func TestDashboardAccessModeResolver_UsesHostProfileOverride(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "host_profile.json")
+	if err := os.WriteFile(profilePath, []byte(`{"displayName":"prod","dashboardAccessMode":"waf_and_login"}`), 0o644); err != nil {
+		t.Fatalf("write host profile: %v", err)
+	}
+
+	resolve := dashboardAccessModeResolver(profilePath, handler.DashboardAccessModeLoginOnly)
+	if got := resolve(); got != handler.DashboardAccessModeWAFAndLogin {
+		t.Fatalf("want %q, got %q", handler.DashboardAccessModeWAFAndLogin, got)
+	}
+}
+
+func TestDashboardWAFConfigFromEnv_DefaultsToDetection(t *testing.T) {
+	t.Setenv("LOTSEN_DASHBOARD_WAF_MODE", "")
+	t.Setenv("LOTSEN_DASHBOARD_WAF_RULES", "")
+
+	cfg, err := dashboardWAFConfigFromEnv()
+	if err != nil {
+		t.Fatalf("dashboardWAFConfigFromEnv: %v", err)
+	}
+	if cfg.Mode != middleware.WAFModeDetection {
+		t.Fatalf("want mode detection, got %q", cfg.Mode)
+	}
+	if len(cfg.CustomRules) != 0 {
+		t.Fatalf("want no rules, got %d", len(cfg.CustomRules))
+	}
+}
+
+func TestDashboardWAFConfigResolver_UsesHostProfileOverride(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "host_profile.json")
+	if err := os.WriteFile(profilePath, []byte(`{"dashboardWaf":{"mode":"enforcement","ipAllowlist":["203.0.113.0/24"],"customRules":["SecRule REQUEST_URI \"@contains block\" \"id:10001,phase:1,deny,status:403\""]}}`), 0o644); err != nil {
+		t.Fatalf("write host profile: %v", err)
+	}
+
+	fallback := handler.DashboardWAFConfig{Mode: middleware.WAFModeDetection}
+	resolve := dashboardWAFConfigResolver(profilePath, fallback)
+	got := resolve()
+
+	if got.Mode != middleware.WAFModeEnforcement {
+		t.Fatalf("want mode enforcement, got %q", got.Mode)
+	}
+	if len(got.CustomRules) != 1 {
+		t.Fatalf("want 1 custom rule, got %d", len(got.CustomRules))
+	}
+	if len(got.IPAllowlist) != 1 || got.IPAllowlist[0] != "203.0.113.0/24" {
+		t.Fatalf("want ip allowlist [203.0.113.0/24], got %#v", got.IPAllowlist)
 	}
 }

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -34,6 +34,10 @@ type RoutingTable interface {
 type Handler struct {
 	table            RoutingTable
 	dashboardAuth    *DashboardAuth
+	dashboardAccess  DashboardAccessMode
+	dashboardResolve func() DashboardAccessMode
+	dashboardWAF     DashboardWAFConfig
+	dashboardWAFLoad func() DashboardWAFConfig
 	authCookieDomain string
 	hardening        HardeningProfile
 	scanner          *scannerLimiter
@@ -44,6 +48,20 @@ type Handler struct {
 	wafBlocked       atomic.Int64
 	uaBlocked        atomic.Int64
 	jwtSecret        []byte
+}
+
+type DashboardAccessMode string
+
+const (
+	DashboardAccessModeLoginOnly   DashboardAccessMode = "login_only"
+	DashboardAccessModeWAFOnly     DashboardAccessMode = "waf_only"
+	DashboardAccessModeWAFAndLogin DashboardAccessMode = "waf_and_login"
+)
+
+type DashboardWAFConfig struct {
+	Mode        middleware.WAFMode
+	IPAllowlist []string
+	CustomRules []string
 }
 
 // HardeningProfile controls request filtering and anti-scan behavior.
@@ -67,7 +85,7 @@ type DashboardAuth struct {
 
 // New creates a Handler backed by the given routing table.
 func New(table RoutingTable, dashboardAuth *DashboardAuth, options ...Option) *Handler {
-	h := &Handler{table: table, dashboardAuth: dashboardAuth, hardening: HardeningStandard}
+	h := &Handler{table: table, dashboardAuth: dashboardAuth, hardening: HardeningStandard, dashboardAccess: DashboardAccessModeLoginOnly, dashboardWAF: defaultDashboardWAFConfig()}
 	for _, apply := range options {
 		if apply != nil {
 			apply(h)
@@ -76,6 +94,75 @@ func New(table RoutingTable, dashboardAuth *DashboardAuth, options ...Option) *H
 	h.hardening = normalizeHardeningProfile(h.hardening)
 	h.scanner = newScannerLimiter(h.hardening)
 	return h
+}
+
+func normalizeDashboardAccessMode(mode DashboardAccessMode) DashboardAccessMode {
+	switch DashboardAccessMode(strings.ToLower(strings.TrimSpace(string(mode)))) {
+	case DashboardAccessModeWAFOnly, DashboardAccessModeWAFAndLogin:
+		return DashboardAccessMode(strings.ToLower(strings.TrimSpace(string(mode))))
+	default:
+		return DashboardAccessModeLoginOnly
+	}
+}
+
+func (h *Handler) dashboardAccessMode() DashboardAccessMode {
+	if h.dashboardResolve != nil {
+		return normalizeDashboardAccessMode(h.dashboardResolve())
+	}
+	return normalizeDashboardAccessMode(h.dashboardAccess)
+}
+
+func defaultDashboardWAFConfig() DashboardWAFConfig {
+	return DashboardWAFConfig{Mode: middleware.WAFModeDetection}
+}
+
+func normalizeDashboardWAFConfig(cfg DashboardWAFConfig) DashboardWAFConfig {
+	mode := middleware.WAFMode(strings.ToLower(strings.TrimSpace(string(cfg.Mode))))
+	if mode != middleware.WAFModeEnforcement {
+		mode = middleware.WAFModeDetection
+	}
+	return DashboardWAFConfig{
+		Mode:        mode,
+		IPAllowlist: slices.Clone(cfg.IPAllowlist),
+		CustomRules: slices.Clone(cfg.CustomRules),
+	}
+}
+
+func (h *Handler) dashboardWAFConfig() DashboardWAFConfig {
+	if h.dashboardWAFLoad != nil {
+		return normalizeDashboardWAFConfig(h.dashboardWAFLoad())
+	}
+	return normalizeDashboardWAFConfig(h.dashboardWAF)
+}
+
+func (m DashboardAccessMode) IncludesWAF() bool {
+	return normalizeDashboardAccessMode(m) == DashboardAccessModeWAFOnly || normalizeDashboardAccessMode(m) == DashboardAccessModeWAFAndLogin
+}
+
+// WithDashboardAccessMode sets dashboard domain protection mode.
+func WithDashboardAccessMode(mode DashboardAccessMode) Option {
+	return func(h *Handler) {
+		h.dashboardAccess = normalizeDashboardAccessMode(mode)
+	}
+}
+
+// WithDashboardAccessModeResolver sets a callback used to resolve mode dynamically.
+func WithDashboardAccessModeResolver(resolve func() DashboardAccessMode) Option {
+	return func(h *Handler) {
+		h.dashboardResolve = resolve
+	}
+}
+
+func WithDashboardWAFConfig(cfg DashboardWAFConfig) Option {
+	return func(h *Handler) {
+		h.dashboardWAF = normalizeDashboardWAFConfig(cfg)
+	}
+}
+
+func WithDashboardWAFConfigResolver(resolve func() DashboardWAFConfig) Option {
+	return func(h *Handler) {
+		h.dashboardWAFLoad = resolve
+	}
 }
 
 // WithHardeningProfile applies proxy hardening rules.
@@ -227,7 +314,12 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.ipFilter != nil {
-		switch h.ipFilter.EvaluateDeployment(client, route.Security) {
+		effectiveSecurity := route.Security
+		if h.dashboardAuth != nil && host == h.dashboardAuth.Domain {
+			dashboardWAF := h.dashboardWAFConfig()
+			effectiveSecurity = &store.SecurityConfig{IPAllowlist: dashboardWAF.IPAllowlist}
+		}
+		switch h.ipFilter.EvaluateDeployment(client, effectiveSecurity) {
 		case middleware.IPFilterDenied:
 			outcome = "ip_denied"
 			http.Error(rw, "forbidden", http.StatusForbidden)
@@ -248,14 +340,18 @@ func (h *Handler) proxy(w http.ResponseWriter, r *http.Request) {
 
 	applyWAF := true
 	if h.dashboardAuth != nil && host == h.dashboardAuth.Domain {
-		applyWAF = false
+		applyWAF = h.dashboardAccessMode().IncludesWAF()
 	} else if route.Security != nil {
 		applyWAF = route.Security.WAFEnabled
 	}
 	if h.waf != nil && applyWAF {
 		customRules := []string(nil)
 		mode := middleware.WAFModeDetection
-		if route.Security != nil {
+		if h.dashboardAuth != nil && host == h.dashboardAuth.Domain {
+			dashboardWAF := h.dashboardWAFConfig()
+			customRules = dashboardWAF.CustomRules
+			mode = dashboardWAF.Mode
+		} else if route.Security != nil {
 			customRules = route.Security.CustomRules
 			mode = middleware.WAFMode(route.Security.WAFMode)
 		}

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -457,14 +457,8 @@ func TestProxy_DashboardDomainBypassesWAF(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	wafRule := `SecRule REQUEST_URI "@contains dashboard-waf-trigger" "id:10098,phase:1,deny,status:403,log,msg:'dashboard waf trigger'"`
-
 	tbl := newTestTable()
-	tbl.Set("dashboard.example.com", backend.Listener.Addr().String(), false, nil, &store.SecurityConfig{
-		WAFEnabled:  true,
-		WAFMode:     "enforcement",
-		CustomRules: []string{wafRule},
-	})
+	tbl.Set("dashboard.example.com", backend.Listener.Addr().String(), false, nil, nil)
 
 	waf, err := middleware.NewWAF()
 	if err != nil {
@@ -506,6 +500,79 @@ func TestProxy_DashboardDomainBypassesWAF(t *testing.T) {
 	}
 	if body.WAFBlockedRequests != 0 {
 		t.Fatalf("want waf blocked requests 0, got %d", body.WAFBlockedRequests)
+	}
+}
+
+func TestProxy_DashboardDomainAppliesWAFWhenEnabledByMode(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	wafRule := `SecRule REQUEST_URI "@contains dashboard-waf-trigger" "id:10100,phase:1,deny,status:403,log,msg:'dashboard waf trigger mode'"`
+
+	tbl := newTestTable()
+	tbl.Set("dashboard.example.com", backend.Listener.Addr().String(), false, nil, nil)
+
+	waf, err := middleware.NewWAF()
+	if err != nil {
+		t.Fatalf("NewWAF enforcement: %v", err)
+	}
+	proxy := newProxyServerWithDashboardAuthAndOptions(tbl, &handler.DashboardAuth{
+		Domain: "dashboard.example.com",
+	},
+		handler.WithWAF(waf),
+		handler.WithDashboardAccessMode(handler.DashboardAccessModeWAFAndLogin),
+		handler.WithDashboardWAFConfig(handler.DashboardWAFConfig{Mode: middleware.WAFModeEnforcement, CustomRules: []string{wafRule}}),
+	)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, proxy.URL+"/api/deployments/dashboard-waf-trigger", strings.NewReader(`{"name":"ok"}`))
+	req.Host = "dashboard.example.com"
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/deployments/dashboard-waf-trigger: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxy_DashboardDomainIPAllowlistBlocksNonMatchingClient(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tbl := newTestTable()
+	tbl.Set("dashboard.example.com", backend.Listener.Addr().String(), false, nil, nil)
+
+	ipFilter, err := middleware.NewIPFilter(nil, nil)
+	if err != nil {
+		t.Fatalf("NewIPFilter: %v", err)
+	}
+
+	proxy := newProxyServerWithDashboardAuthAndOptions(tbl, &handler.DashboardAuth{Domain: "dashboard.example.com"},
+		handler.WithIPFilter(ipFilter),
+		handler.WithDashboardWAFConfig(handler.DashboardWAFConfig{IPAllowlist: []string{"203.0.113.0/24"}}),
+	)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	req.Host = "dashboard.example.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", resp.StatusCode)
 	}
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -58,12 +58,25 @@ validate_domain() {
     return 0
 }
 
+validate_dashboard_access_mode() {
+    local mode="$1"
+    case "${mode}" in
+        login_only|waf_only|waf_and_login)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 write_dashboard_env() {
     local dashboard_domain="$1"
     local auth_user="$2"
     local auth_password="$3"
     local jwt_secret="$4"
     local auth_cookie_domain="$5"
+    local dashboard_access_mode="$6"
     local rp_origin=""
     local tmp
 
@@ -71,7 +84,7 @@ write_dashboard_env() {
     tmp=$(mktemp)
 
     if [ -f "${ENV_FILE}" ]; then
-        awk '!/^(DIRIGENT|LOTSEN)_(DASHBOARD_(DOMAIN|USER|PASSWORD)|AUTH_(USER|PASSWORD|COOKIE_DOMAIN)|JWT_SECRET|RP_ID|RP_ORIGINS)=/' "${ENV_FILE}" > "${tmp}"
+        awk '!/^(DIRIGENT|LOTSEN)_(DASHBOARD_(DOMAIN|USER|PASSWORD|ACCESS_MODE)|AUTH_(USER|PASSWORD|COOKIE_DOMAIN)|JWT_SECRET|RP_ID|RP_ORIGINS)=/' "${ENV_FILE}" > "${tmp}"
     fi
 
     if [ -n "${dashboard_domain}" ]; then
@@ -90,9 +103,11 @@ write_dashboard_env() {
         echo "DIRIGENT_JWT_SECRET=${jwt_secret}"
         echo "DIRIGENT_AUTH_USER=${auth_user}"
         echo "DIRIGENT_AUTH_PASSWORD=${auth_password}"
+        echo "DIRIGENT_DASHBOARD_ACCESS_MODE=${dashboard_access_mode}"
         echo "LOTSEN_JWT_SECRET=${jwt_secret}"
         echo "LOTSEN_AUTH_USER=${auth_user}"
         echo "LOTSEN_AUTH_PASSWORD=${auth_password}"
+        echo "LOTSEN_DASHBOARD_ACCESS_MODE=${dashboard_access_mode}"
     } >> "${tmp}"
 
     if [ -n "${auth_cookie_domain}" ]; then
@@ -445,6 +460,7 @@ AUTH_USER="${DIRIGENT_AUTH_USER:-${LOTSEN_AUTH_USER:-}}"
 AUTH_PASSWORD="${DIRIGENT_AUTH_PASSWORD:-${LOTSEN_AUTH_PASSWORD:-}}"
 JWT_SECRET="${DIRIGENT_JWT_SECRET:-${LOTSEN_JWT_SECRET:-}}"
 AUTH_COOKIE_DOMAIN="${DIRIGENT_AUTH_COOKIE_DOMAIN:-${LOTSEN_AUTH_COOKIE_DOMAIN:-}}"
+DASHBOARD_ACCESS_MODE="${DIRIGENT_DASHBOARD_ACCESS_MODE:-${LOTSEN_DASHBOARD_ACCESS_MODE:-}}"
 GENERATED_AUTH_PASSWORD=0
 GENERATED_JWT_SECRET=0
 EXISTING_DASHBOARD_DOMAIN=""
@@ -452,6 +468,7 @@ EXISTING_AUTH_USER=""
 EXISTING_AUTH_PASSWORD=""
 EXISTING_JWT_SECRET=""
 EXISTING_AUTH_COOKIE_DOMAIN=""
+EXISTING_DASHBOARD_ACCESS_MODE=""
 
 if [ -f "${ENV_FILE}" ]; then
     EXISTING_DASHBOARD_DOMAIN=$(read_env_value "DIRIGENT_DASHBOARD_DOMAIN")
@@ -459,6 +476,7 @@ if [ -f "${ENV_FILE}" ]; then
     EXISTING_AUTH_PASSWORD=$(read_env_value "DIRIGENT_AUTH_PASSWORD")
     EXISTING_JWT_SECRET=$(read_env_value "DIRIGENT_JWT_SECRET")
     EXISTING_AUTH_COOKIE_DOMAIN=$(read_env_value "DIRIGENT_AUTH_COOKIE_DOMAIN")
+    EXISTING_DASHBOARD_ACCESS_MODE=$(read_env_value "DIRIGENT_DASHBOARD_ACCESS_MODE")
     if [ -z "${EXISTING_DASHBOARD_DOMAIN}" ]; then
         EXISTING_DASHBOARD_DOMAIN=$(read_env_value "LOTSEN_DASHBOARD_DOMAIN")
     fi
@@ -473,6 +491,9 @@ if [ -f "${ENV_FILE}" ]; then
     fi
     if [ -z "${EXISTING_AUTH_COOKIE_DOMAIN}" ]; then
         EXISTING_AUTH_COOKIE_DOMAIN=$(read_env_value "LOTSEN_AUTH_COOKIE_DOMAIN")
+    fi
+    if [ -z "${EXISTING_DASHBOARD_ACCESS_MODE}" ]; then
+        EXISTING_DASHBOARD_ACCESS_MODE=$(read_env_value "LOTSEN_DASHBOARD_ACCESS_MODE")
     fi
 
     if [ -z "${DASHBOARD_DOMAIN}" ] && [ -n "${EXISTING_DASHBOARD_DOMAIN}" ]; then
@@ -490,6 +511,13 @@ if [ -f "${ENV_FILE}" ]; then
     if [ -z "${AUTH_COOKIE_DOMAIN}" ] && [ -n "${EXISTING_AUTH_COOKIE_DOMAIN}" ]; then
         AUTH_COOKIE_DOMAIN="${EXISTING_AUTH_COOKIE_DOMAIN}"
     fi
+    if [ -z "${DASHBOARD_ACCESS_MODE}" ] && [ -n "${EXISTING_DASHBOARD_ACCESS_MODE}" ]; then
+        DASHBOARD_ACCESS_MODE="${EXISTING_DASHBOARD_ACCESS_MODE}"
+    fi
+fi
+
+if [ -z "${DASHBOARD_ACCESS_MODE}" ]; then
+    DASHBOARD_ACCESS_MODE="login_only"
 fi
 
 if [ -z "${AUTH_USER}" ]; then
@@ -531,6 +559,31 @@ if [ -t 0 ] && [ "${NON_INTERACTIVE_MODE}" != "1" ] && [ "${UPGRADE_MODE}" != "1
     done
 fi
 
+if [ -t 0 ] && [ "${NON_INTERACTIVE_MODE}" != "1" ] && [ "${UPGRADE_MODE}" != "1" ]; then
+    echo ""
+    echo "Dashboard protection mode"
+    echo "  1) login only (default)"
+    echo "  2) waf only"
+    echo "  3) waf + login"
+
+    DASHBOARD_ACCESS_CHOICE=""
+    case "${DASHBOARD_ACCESS_MODE}" in
+        waf_only) DASHBOARD_ACCESS_CHOICE="2" ;;
+        waf_and_login) DASHBOARD_ACCESS_CHOICE="3" ;;
+        *) DASHBOARD_ACCESS_CHOICE="1" ;;
+    esac
+
+    read -r -p "Choose mode [${DASHBOARD_ACCESS_CHOICE}]: " INPUT_DASHBOARD_ACCESS_CHOICE
+    case "${INPUT_DASHBOARD_ACCESS_CHOICE:-${DASHBOARD_ACCESS_CHOICE}}" in
+        1|login_only) DASHBOARD_ACCESS_MODE="login_only" ;;
+        2|waf_only) DASHBOARD_ACCESS_MODE="waf_only" ;;
+        3|waf_and_login) DASHBOARD_ACCESS_MODE="waf_and_login" ;;
+        *)
+            echo "Invalid selection, keeping ${DASHBOARD_ACCESS_MODE}."
+            ;;
+    esac
+fi
+
 if [ -z "${AUTH_PASSWORD}" ]; then
     AUTH_PASSWORD=$(generate_hex_secret 16)
     GENERATED_AUTH_PASSWORD=1
@@ -569,8 +622,12 @@ if [ -n "${DASHBOARD_DOMAIN}" ]; then
     fi
 fi
 
+if ! validate_dashboard_access_mode "${DASHBOARD_ACCESS_MODE}"; then
+    error "DIRIGENT_DASHBOARD_ACCESS_MODE must be one of: login_only, waf_only, waf_and_login"
+fi
+
 step "Writing shared environment file"
-write_dashboard_env "${DASHBOARD_DOMAIN}" "${AUTH_USER}" "${AUTH_PASSWORD}" "${JWT_SECRET}" "${AUTH_COOKIE_DOMAIN}"
+write_dashboard_env "${DASHBOARD_DOMAIN}" "${AUTH_USER}" "${AUTH_PASSWORD}" "${JWT_SECRET}" "${AUTH_COOKIE_DOMAIN}" "${DASHBOARD_ACCESS_MODE}"
 
 if [ "${UPGRADE_MODE}" = "1" ]; then
     step "Upgrade mode: preserving host firewall and SSH settings"
@@ -707,6 +764,7 @@ else
     echo "  Dashboard:  http://${SERVER_IP}:8080"
 fi
 echo "  Dashboard login user: ${AUTH_USER}"
+echo "  Dashboard protection: ${DASHBOARD_ACCESS_MODE}"
 if [ "${GENERATED_AUTH_PASSWORD}" = "1" ]; then
     echo "  Dashboard login password: ${AUTH_PASSWORD}"
 fi


### PR DESCRIPTION
## Summary
- add dashboard access mode support (`login_only`, `waf_only`, `waf_and_login`) across setup, API, and proxy so operators can choose login, WAF, or both
- extend Host settings and `/api/host` profile persistence with dashboard WAF config (mode, IP allowlist, custom rules), including validation and runtime proxy resolution
- refine the Host settings UX into clearer sections with expandable WAF controls and advanced rules to reduce visual clutter while keeping security controls accessible

## Validation
- `go test ./api/... ./proxy/...`
- `bun run build` (dashboard)