### PR TITLE
chore(repo): hard-cut rename dirigent to lotsen

### DIFF
--- a/.claude/skills/go-engineer/SKILL.md
+++ b/.claude/skills/go-engineer/SKILL.md
@@ -9,7 +9,7 @@ description: Senior Go engineer that reads GitHub issues, plans architecture, an
 
 ### 1. Read the issue
 
-Fetch the issue with `mcp__github__get_issue` (`owner=ercadev`, `repo=dirigent`). Read all comments via `mcp__github__get_issue_comments`. Internalize:
+Fetch the issue with `mcp__github__get_issue` (`owner=ercadev`, `repo=lotsen`). Read all comments via `mcp__github__get_issue_comments`. Internalize:
 
 - What problem is being solved (not just what to build)
 - Acceptance criteria

--- a/.claude/skills/pickup-issue/SKILL.md
+++ b/.claude/skills/pickup-issue/SKILL.md
@@ -9,7 +9,7 @@ description: Reads a GitHub issue, determines whether it is frontend (React) or 
 
 ### 1. Read the issue
 
-Use `mcp__github__get_issue` with `owner=ercadev`, `repo=dirigent`, and the issue number.
+Use `mcp__github__get_issue` with `owner=ercadev`, `repo=lotsen`, and the issue number.
 Also call `mcp__github__get_issue_comments` to read any discussion.
 
 Read the full body, acceptance criteria, and any comments.

--- a/.claude/skills/react-engineer/SKILL.md
+++ b/.claude/skills/react-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-engineer
-description: Senior React engineer that reads GitHub issues, plans UI architecture, and delivers clean, maintainable frontend code for the Dirigent web GUI. Use when working on React frontend tickets, implementing UI features or fixes, or when asked to pick up, implement, or review a GitHub issue in the React codebase.
+description: Senior React engineer that reads GitHub issues, plans UI architecture, and delivers clean, maintainable frontend code for the Lotsen web GUI. Use when working on React frontend tickets, implementing UI features or fixes, or when asked to pick up, implement, or review a GitHub issue in the React codebase.
 ---
 
 # React Engineer
@@ -21,7 +21,7 @@ description: Senior React engineer that reads GitHub issues, plans UI architectu
 
 ### 1. Read the issue
 
-Fetch the issue with `mcp__github__get_issue` (`owner=ercadev`, `repo=dirigent`). Read all comments via `mcp__github__get_issue_comments`. Internalize:
+Fetch the issue with `mcp__github__get_issue` (`owner=ercadev`, `repo=lotsen`). Read all comments via `mcp__github__get_issue_comments`. Internalize:
 
 - What user problem is being solved (not just what to build)
 - Acceptance criteria

--- a/.claude/skills/refine-issue/SKILL.md
+++ b/.claude/skills/refine-issue/SKILL.md
@@ -36,7 +36,7 @@ Iterate until the user approves.
 
 ```bash
 gh issue create \
-  --repo ercadev/dirigent \
+  --repo ercadev/lotsen \
   --title "<title>" \
   --body "<body>"
 ```

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -35,7 +35,7 @@ description: Reviews GitHub pull requests by fetching PR diffs, summarizing chan
 
 ## Posting to GitHub
 
-Use `mcp__github__create_pull_request_review` with `owner=ercadev`, `repo=dirigent`, and the PR number.
+Use `mcp__github__create_pull_request_review` with `owner=ercadev`, `repo=lotsen`, and the PR number.
 
 ### Approve
 Set `event=APPROVE` and `body="<summary>"`.

--- a/.claudeignore
+++ b/.claudeignore
@@ -45,8 +45,8 @@ bun.lockb
 
 # --- Backend (Go) ---
 # Ignore the compiled binary and temporary state file
-dirigent
-/tmp/dirigent.json
+lotsen
+/tmp/lotsen.json
 vendor/
 *.out
 *.test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,9 +188,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASES_TOKEN }}
         run: |
-          gh release delete ${{ env.RELEASE_TAG }} --repo ercadev/dirigent-releases --yes || true
+          gh release delete ${{ env.RELEASE_TAG }} --repo ercadev/lotsen-releases --yes || true
           gh release create ${{ env.RELEASE_TAG }} \
-            --repo ercadev/dirigent-releases \
+            --repo ercadev/lotsen-releases \
             --title "${{ env.RELEASE_TAG }}" \
             --notes-file release-notes.md \
             --latest \
@@ -230,5 +230,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ercadevapps/dirigent:${{ env.RELEASE_TAG }}
-            ercadevapps/dirigent:latest
+            ercadevapps/lotsen:${{ env.RELEASE_TAG }}
+            ercadevapps/lotsen:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Go
-/dirigent
-control-plane/dirigent
+/lotsen
+control-plane/lotsen
 orchestrator/orchestrator
 
 # Air hot reload

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# CLAUDE.md - Dirigent
+# CLAUDE.md - Lotsen
 
 ## Project Context
 Docker orchestration for solo devs/VPS. Lightweight K8s alternative.
-- **Repo:** `ercadev/dirigent` (Always use for `gh` commands).
+- **Repo:** `ercadev/lotsen` (Always use for `gh` commands).
 - **Stack:** Go (Backend/Orchestrator), Bun + React + Vite (Frontend).
 - **Data Flow:** Dashboard → API → JSON Store ← Orchestrator → Docker.
 
@@ -21,4 +21,4 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/).
 ### Coding Standards
 - **Backend:** Go 1.23. Use `internal/` for shared logic.
 - **Frontend:** React with Vite. Pages go in `dashboard/src/pages/`.
-- **State:** Shared via `/tmp/dirigent.json` in dev.
+- **State:** Shared via `/tmp/lotsen.json` in dev.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,4 +1,4 @@
-# Dirigent — Brand & Design System
+# Lotsen — Brand & Design System
 
 A living reference for colours, typography, spacing, and component patterns across the dashboard and landing page.
 
@@ -6,7 +6,7 @@ A living reference for colours, typography, spacing, and component patterns acro
 
 ## Brand Identity
 
-**Dirigent** is a lightweight Docker orchestration tool for solo devs and VPS deployments. The aesthetic balances developer pragmatism with visual refinement — clean, approachable, and quietly elegant.
+**Lotsen** is a lightweight Docker orchestration tool for solo devs and VPS deployments. The aesthetic balances developer pragmatism with visual refinement — clean, approachable, and quietly elegant.
 
 ### Mascot
 A corgi sitting at a navy keyboard. The mascot's palette is the direct source of the two brand colours: navy (keyboard) and orange (corgi coat).

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,6 +1,6 @@
-# Getting Started with Dirigent
+# Getting Started with Lotsen
 
-This guide covers two paths: running Dirigent on a VPS (production) and running it locally for development.
+This guide covers two paths: running Lotsen on a VPS (production) and running it locally for development.
 
 ---
 
@@ -15,7 +15,7 @@ This guide covers two paths: running Dirigent on a VPS (production) and running 
 ### Install
 
 ```bash
-curl -fsSL https://github.com/ercadev/dirigent-releases/releases/latest/download/install.sh | sudo bash
+curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash
 sudo lotsen setup
 ```
 
@@ -23,7 +23,7 @@ The bootstrap installer installs the `lotsen` CLI.
 
 Then `lotsen setup` will:
 1. Install Docker Engine if not already present
-2. Download all Dirigent components for your architecture (`amd64` or `arm64`)
+2. Download all Lotsen components for your architecture (`amd64` or `arm64`)
 3. Create and enable three systemd services
 4. Print a summary of running services and their ports
 
@@ -49,13 +49,13 @@ You can re-run dashboard exposure/auth setup at any time:
 sudo lotsen setup
 ```
 
-This command updates `/etc/dirigent/dirigent.env` and restarts `lotsen-proxy`.
+This command updates `/etc/lotsen/lotsen.env` and restarts `lotsen-proxy`.
 
 ### Pin a specific version
 
 ```bash
-DIRIGENT_VERSION=v0.1.0 curl -fsSL https://github.com/ercadev/dirigent-releases/releases/download/v0.1.0/install.sh | sudo bash
-sudo DIRIGENT_VERSION=v0.1.0 lotsen setup
+LOTSEN_VERSION=v0.1.0 curl -fsSL https://github.com/ercadev/lotsen-releases/releases/download/v0.1.0/install.sh | sudo bash
+sudo LOTSEN_VERSION=v0.1.0 lotsen setup
 ```
 
 ### Upgrade
@@ -137,7 +137,7 @@ make clean   # remove build artifacts
 
 ### State
 
-All services share a single JSON file at `/tmp/dirigent.json` in dev mode. Delete it to reset state.
+All services share a single JSON file at `/tmp/lotsen.json` in dev mode. Delete it to reset state.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ dev-website:
 
 # Trigger a release via conventional-commit analysis (requires gh CLI).
 release:
-	gh workflow run auto-tag.yml --repo ercadev/dirigent
+	gh workflow run auto-tag.yml --repo ercadev/lotsen
 
 # Remove build artifacts.
 clean:

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,4 +1,4 @@
-# Product Definition: Dirigent
+# Product Definition: Lotsen
 
 ## Vision
 Give any solo developer or small team the power of a production-grade Docker orchestration platform without the complexity tax of Kubernetes.
@@ -10,7 +10,7 @@ Running Docker containers in production on a VPS is manual, fragile, and undocum
 Solo developers and small engineering teams (1–5 people) running production workloads on one or a few VPS instances. They know Docker, they don't want to learn Kubernetes, and they value their time over configurability.
 
 ## Core Value Proposition
-Dirigent is the simplest path from "a VPS with Docker" to "production-ready container orchestration." No YAML sprawl, no cluster setup, no ops expertise required. Install in one command, deploy in minutes.
+Lotsen is the simplest path from "a VPS with Docker" to "production-ready container orchestration." No YAML sprawl, no cluster setup, no ops expertise required. Install in one command, deploy in minutes.
 
 ## Key Features (v1)
 - **One-script installer**: Full setup in a single command. Zero prerequisites beyond Docker.
@@ -26,6 +26,6 @@ Dirigent is the simplest path from "a VPS with Docker" to "production-ready cont
 - **App marketplace / templates**: No one-click app catalog.
 
 ## Success Metrics
-- Dirigent is running in at least one personal production environment (dogfood signal)
+- Lotsen is running in at least one personal production environment (dogfood signal)
 - 100+ installs within 60 days of public release
 - End-to-end time from blank VPS to running container is under 5 minutes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dirigent
+# Lotsen
 
 A lightweight Docker orchestration tool for solo developers and small teams running production workloads on a VPS — a simpler alternative to Kubernetes.
 
@@ -7,15 +7,15 @@ A lightweight Docker orchestration tool for solo developers and small teams runn
 Run the following command on a fresh Ubuntu 22.04+ or Debian 11+ VPS as root (or with `sudo`):
 
 ```bash
-curl -fsSL https://github.com/ercadev/dirigent-releases/releases/latest/download/install.sh | sudo bash
+curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash
 sudo lotsen setup
 ```
 
 To pin a specific version:
 
 ```bash
-DIRIGENT_VERSION=v0.0.2 curl -fsSL https://github.com/ercadev/dirigent-releases/releases/download/v0.0.2/install.sh | sudo bash
-sudo DIRIGENT_VERSION=v0.0.2 lotsen setup
+LOTSEN_VERSION=v0.0.2 curl -fsSL https://github.com/ercadev/lotsen-releases/releases/download/v0.0.2/install.sh | sudo bash
+sudo LOTSEN_VERSION=v0.0.2 lotsen setup
 ```
 
 The bootstrap installer will:
@@ -23,19 +23,19 @@ The bootstrap installer will:
 
 Then `lotsen setup` will:
 - Install Docker Engine if not already present
-- Download all Dirigent components for your architecture (`amd64` / `arm64`)
+- Download all Lotsen components for your architecture (`amd64` / `arm64`)
 - Register and start three systemd services that survive reboots
-- Create the `/var/lib/dirigent/` data directory and the `dirigent` Docker network
+- Create the `/var/lib/lotsen/` data directory and the `lotsen` Docker network
 - Offer security profiles in guided mode (`strict` is recommended)
 - Configure proxy hardening profiles (`standard` by default, `strict` recommended for internet-facing hosts)
 - Prompt for initial dashboard `/login` credentials in interactive setup (blank password auto-generates one)
-- Configure passkey relying-party settings automatically when `DIRIGENT_DASHBOARD_DOMAIN` is set
+- Configure passkey relying-party settings automatically when `LOTSEN_DASHBOARD_DOMAIN` is set
 
 Re-running the installer performs an in-place upgrade.
 
 ### Proxy hardening profiles
 
-Dirigent proxy supports three hardening levels:
+Lotsen proxy supports three hardening levels:
 
 - `standard` (default): blocks sensitive file and dot-path probes like `/.env`, `/.git`, and `/.vscode`
 - `strict`: includes `standard` plus broader scanner-target blocks (`/swagger*`, `/actuator`, `/wp-*`, etc.) and tighter anti-scan throttling
@@ -50,7 +50,7 @@ sudo lotsen setup --proxy-hardening-profile strict
 Or via environment variable:
 
 ```bash
-sudo DIRIGENT_PROXY_HARDENING_PROFILE=strict dirigent setup
+sudo LOTSEN_PROXY_HARDENING_PROFILE=strict lotsen setup
 ```
 
 ### Ports
@@ -61,11 +61,11 @@ sudo DIRIGENT_PROXY_HARDENING_PROFILE=strict dirigent setup
 | `lotsen-orchestrator` | —      | Reconciler — syncs state with Docker (no port) |
 | `lotsen-proxy`        | `:80`  | Reverse proxy — routes traffic to containers   |
 
-The dashboard is served by `lotsen-api` on `:8080` by default. If you set `DIRIGENT_DASHBOARD_DOMAIN` during setup, the proxy exposes it on `:80/:443` over HTTPS.
+The dashboard is served by `lotsen-api` on `:8080` by default. If you set `LOTSEN_DASHBOARD_DOMAIN` during setup, the proxy exposes it on `:80/:443` over HTTPS.
 
-`DIRIGENT_AUTH_USER`/`DIRIGENT_AUTH_PASSWORD` (`LOTSEN_` aliases also supported) are bootstrap-only: they seed the first dashboard user when `users.db` is empty and are ignored after users already exist.
+`LOTSEN_AUTH_USER`/`LOTSEN_AUTH_PASSWORD` are bootstrap-only: they seed the first dashboard user when `users.db` is empty and are ignored after users already exist.
 
-Set `DIRIGENT_AUTH_COOKIE_DOMAIN` (or `LOTSEN_AUTH_COOKIE_DOMAIN`) to enable shared dashboard/deployment auth on subdomains of the same parent domain (for example `d0001.erca.dev`).
+Set `LOTSEN_AUTH_COOKIE_DOMAIN` to enable shared dashboard/deployment auth on subdomains of the same parent domain (for example `d0001.erca.dev`).
 
 ## Features
 
@@ -130,7 +130,7 @@ Starts both the Go API (Air hot reload on `:8080`) and the Vite dashboard dev se
 ### Other targets
 
 ```bash
-make build   # compile the Go binary → ./dirigent
+make build   # compile the Go binary → ./lotsen
 make test    # run go test ./...
 make clean   # remove build artifacts
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
 # api
 
-The Dirigent REST API, written in Go. Reads and writes the shared JSON store.
+The Lotsen REST API, written in Go. Reads and writes the shared JSON store.
 
 ## Requirements
 
@@ -12,25 +12,25 @@ The Dirigent REST API, written in Go. Reads and writes the shared JSON store.
 # From the api/ directory
 
 # Run the API server (port 8080)
-go run ./cmd/dirigent
+go run ./cmd/lotsen
 
 # Run all tests
 go test ./...
 
 # Build the binary
-go build -o dirigent ./cmd/dirigent
+go build -o lotsen ./cmd/lotsen
 ```
 
 ## Configuration
 
 | Environment variable | Default                                   | Description                        |
 |----------------------|-------------------------------------------|------------------------------------|
-| `DIRIGENT_DATA`      | `/var/lib/dirigent/deployments.json`      | Path to the JSON state file        |
+| `LOTSEN_DATA`      | `/var/lib/lotsen/deployments.json`      | Path to the JSON state file        |
 
-For local development, set `DIRIGENT_DATA` to a writable path:
+For local development, set `LOTSEN_DATA` to a writable path:
 
 ```bash
-DIRIGENT_DATA=/tmp/dirigent.json go run ./cmd/dirigent
+LOTSEN_DATA=/tmp/lotsen.json go run ./cmd/lotsen
 ```
 
 ## API
@@ -71,9 +71,9 @@ curl -X POST http://localhost:8080/api/deployments \
 
 ```
 api/
-├── cmd/dirigent/     Entry point
+├── cmd/lotsen/     Entry point
 └── internal/
     └── api/          HTTP handlers and Store interface
 ```
 
-Deployment persistence is provided by the shared `store/` module at the repo root (`github.com/ercadev/dirigent/store`).
+Deployment persistence is provided by the shared `store/` module at the repo root (`github.com/ercadev/lotsen/store`).

--- a/api/cmd/lotsen/main.go
+++ b/api/cmd/lotsen/main.go
@@ -12,12 +12,12 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 
-	"github.com/ercadev/dirigent/auth"
-	internalapi "github.com/ercadev/dirigent/internal/api"
-	"github.com/ercadev/dirigent/internal/dashboard"
-	"github.com/ercadev/dirigent/internal/docker"
-	"github.com/ercadev/dirigent/internal/events"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/auth"
+	internalapi "github.com/ercadev/lotsen/internal/api"
+	"github.com/ercadev/lotsen/internal/dashboard"
+	"github.com/ercadev/lotsen/internal/docker"
+	"github.com/ercadev/lotsen/internal/events"
+	"github.com/ercadev/lotsen/store"
 )
 
 const addr = ":8080"

--- a/api/cmd/lotsen/main_test.go
+++ b/api/cmd/lotsen/main_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	internalapi "github.com/ercadev/dirigent/internal/api"
+	internalapi "github.com/ercadev/lotsen/internal/api"
 )
 
 func TestAuthFromEnv_NoSecret(t *testing.T) {

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,11 +1,11 @@
-module github.com/ercadev/dirigent
+module github.com/ercadev/lotsen
 
 go 1.25.0
 
 require (
 	github.com/docker/docker v27.5.1+incompatible
-	github.com/ercadev/dirigent/auth v0.0.0
-	github.com/ercadev/dirigent/store v0.0.0
+	github.com/ercadev/lotsen/auth v0.0.0
+	github.com/ercadev/lotsen/store v0.0.0
 	github.com/go-webauthn/webauthn v0.16.0
 	golang.org/x/crypto v0.48.0
 )
@@ -57,6 +57,6 @@ require (
 	modernc.org/sqlite v1.37.0 // indirect
 )
 
-replace github.com/ercadev/dirigent/auth => ../auth
+replace github.com/ercadev/lotsen/auth => ../auth
 
-replace github.com/ercadev/dirigent/store => ../store
+replace github.com/ercadev/lotsen/store => ../store

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/go-webauthn/webauthn/webauthn"
 
-	"github.com/ercadev/dirigent/auth"
-	"github.com/ercadev/dirigent/internal/events"
-	"github.com/ercadev/dirigent/internal/upgrade"
-	"github.com/ercadev/dirigent/internal/version"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/auth"
+	"github.com/ercadev/lotsen/internal/events"
+	"github.com/ercadev/lotsen/internal/upgrade"
+	"github.com/ercadev/lotsen/internal/version"
+	"github.com/ercadev/lotsen/store"
 )
 
 // Store is the persistence interface required by the API handlers.

--- a/api/internal/api/handler_auth.go
+++ b/api/internal/api/handler_auth.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ercadev/dirigent/auth"
+	"github.com/ercadev/lotsen/auth"
 )
 
 const (

--- a/api/internal/api/handler_auth_test.go
+++ b/api/internal/api/handler_auth_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/go-webauthn/webauthn/webauthn"
 
-	"github.com/ercadev/dirigent/auth"
-	"github.com/ercadev/dirigent/internal/api"
-	"github.com/ercadev/dirigent/internal/events"
+	"github.com/ercadev/lotsen/auth"
+	"github.com/ercadev/lotsen/internal/api"
+	"github.com/ercadev/lotsen/internal/events"
 )
 
 // stubAuthStore is an in-memory AuthUserStore for tests.

--- a/api/internal/api/handler_create_deployment.go
+++ b/api/internal/api/handler_create_deployment.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/dirigent/internal/events"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/internal/events"
+	"github.com/ercadev/lotsen/store"
 )
 
 func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_delete_deployment.go
+++ b/api/internal/api/handler_delete_deployment.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 func (h *Handler) deleteDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_deployment_logs.go
+++ b/api/internal/api/handler_deployment_logs.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 // deploymentLogs streams container log lines for a deployment as SSE.

--- a/api/internal/api/handler_deployment_recent_logs.go
+++ b/api/internal/api/handler_deployment_recent_logs.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 const (

--- a/api/internal/api/handler_get_deployment.go
+++ b/api/internal/api/handler_get_deployment.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 func (h *Handler) getDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_host_test.go
+++ b/api/internal/api/handler_host_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ercadev/dirigent/internal/api"
-	"github.com/ercadev/dirigent/internal/events"
+	"github.com/ercadev/lotsen/internal/api"
+	"github.com/ercadev/lotsen/internal/events"
 )
 
 func newTestServerWithHostProfileStore(t *testing.T, storePath string) *httptest.Server {

--- a/api/internal/api/handler_list_deployments.go
+++ b/api/internal/api/handler_list_deployments.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 type deploymentResponse struct {

--- a/api/internal/api/handler_passkey.go
+++ b/api/internal/api/handler_passkey.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 
-	"github.com/ercadev/dirigent/auth"
+	"github.com/ercadev/lotsen/auth"
 )
 
 const passkeySessionCookie = "lotsen_pk_session"

--- a/api/internal/api/handler_patch_deployment.go
+++ b/api/internal/api/handler_patch_deployment.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/dirigent/internal/events"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/internal/events"
+	"github.com/ercadev/lotsen/store"
 )
 
 func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_registries.go
+++ b/api/internal/api/handler_registries.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 type registryRequest struct {

--- a/api/internal/api/handler_restart_deployment.go
+++ b/api/internal/api/handler_restart_deployment.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/dirigent/internal/events"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/internal/events"
+	"github.com/ercadev/lotsen/store"
 )
 
 func (h *Handler) restartDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -17,9 +17,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/dirigent/internal/api"
-	"github.com/ercadev/dirigent/internal/events"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/internal/api"
+	"github.com/ercadev/lotsen/internal/events"
+	"github.com/ercadev/lotsen/store"
 )
 
 // memStore is an in-memory store used only in tests.

--- a/api/internal/api/handler_update_deployment.go
+++ b/api/internal/api/handler_update_deployment.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/dirigent/internal/events"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/internal/events"
+	"github.com/ercadev/lotsen/store"
 )
 
 func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_update_deployment_status.go
+++ b/api/internal/api/handler_update_deployment_status.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/dirigent/internal/events"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/internal/events"
+	"github.com/ercadev/lotsen/store"
 )
 
 func (h *Handler) updateDeploymentStatus(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_upgrade.go
+++ b/api/internal/api/handler_upgrade.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ercadev/dirigent/internal/upgrade"
+	"github.com/ercadev/lotsen/internal/upgrade"
 )
 
 func (h *Handler) startUpgrade(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_upgrade_version_test.go
+++ b/api/internal/api/handler_upgrade_version_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/dirigent/internal/api"
-	"github.com/ercadev/dirigent/internal/events"
-	"github.com/ercadev/dirigent/internal/upgrade"
-	"github.com/ercadev/dirigent/internal/version"
+	"github.com/ercadev/lotsen/internal/api"
+	"github.com/ercadev/lotsen/internal/events"
+	"github.com/ercadev/lotsen/internal/upgrade"
+	"github.com/ercadev/lotsen/internal/version"
 )
 
 type versionProviderStub struct {

--- a/api/internal/api/handler_users.go
+++ b/api/internal/api/handler_users.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ercadev/dirigent/auth"
+	"github.com/ercadev/lotsen/auth"
 )
 
 func (h *Handler) listUsers(w http.ResponseWriter, _ *http.Request) {

--- a/api/internal/api/handler_version.go
+++ b/api/internal/api/handler_version.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ercadev/dirigent/internal/version"
+	"github.com/ercadev/lotsen/internal/version"
 )
 
 type versionResponse struct {

--- a/api/internal/version/service.go
+++ b/api/internal/version/service.go
@@ -11,8 +11,8 @@ import (
 	"time"
 )
 
-var latestReleaseURL = "https://api.github.com/repos/ercadev/dirigent-releases/releases/latest"
-var releasesURL = "https://api.github.com/repos/ercadev/dirigent-releases/releases"
+var latestReleaseURL = "https://api.github.com/repos/ercadev/lotsen-releases/releases/latest"
+var releasesURL = "https://api.github.com/repos/ercadev/lotsen-releases/releases"
 
 const defaultCacheTTL = 5 * time.Minute
 

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -1,4 +1,4 @@
-module github.com/ercadev/dirigent/auth
+module github.com/ercadev/lotsen/auth
 
 go 1.25.0
 

--- a/cli/cmd/lotsen/main.go
+++ b/cli/cmd/lotsen/main.go
@@ -17,12 +17,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ercadev/dirigent/auth"
+	"github.com/ercadev/lotsen/auth"
 )
 
 const (
-	releaseBaseLatest = "https://github.com/ercadev/dirigent-releases/releases/latest/download"
-	releaseBaseTagFmt = "https://github.com/ercadev/dirigent-releases/releases/download/%s"
+	releaseBaseLatest = "https://github.com/ercadev/lotsen-releases/releases/latest/download"
+	releaseBaseTagFmt = "https://github.com/ercadev/lotsen-releases/releases/download/%s"
 )
 
 type versionSnapshot struct {

--- a/cli/cmd/lotsen/main_test.go
+++ b/cli/cmd/lotsen/main_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSha256File_ReturnsHashForKnownContent(t *testing.T) {
-	content := []byte("hello dirigent")
+	content := []byte("hello lotsen")
 	tmp, err := os.CreateTemp("", "sha256test-*")
 	if err != nil {
 		t.Fatal(err)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,7 +1,7 @@
-module github.com/ercadev/dirigent/cli
+module github.com/ercadev/lotsen/cli
 
 go 1.24.0
 
-require github.com/ercadev/dirigent/auth v0.0.0
+require github.com/ercadev/lotsen/auth v0.0.0
 
-replace github.com/ercadev/dirigent/auth => ../auth
+replace github.com/ercadev/lotsen/auth => ../auth

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "dirigent-dashboard",
+      "name": "lotsen-dashboard",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",

--- a/dashboard/src/pages/RegistriesPage.tsx
+++ b/dashboard/src/pages/RegistriesPage.tsx
@@ -70,7 +70,7 @@ export function RegistriesPage() {
         <div>
           <p className="text-[11px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">Registry credentials</p>
           <h2 className="mt-1 font-[family-name:var(--font-display)] text-xl font-semibold tracking-tight text-foreground">Private image access</h2>
-          <p className="mt-1 text-sm text-muted-foreground">Save registry prefixes once and Dirigent reuses credentials automatically for matching pulls.</p>
+          <p className="mt-1 text-sm text-muted-foreground">Save registry prefixes once and Lotsen reuses credentials automatically for matching pulls.</p>
         </div>
         <Badge variant="outline" className="rounded-md border-border/70 bg-background/70 px-2.5 py-1 font-mono text-[11px]">
           {(registriesQuery.data ?? []).length} configured

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Dirigent bootstrap installer
+# Lotsen bootstrap installer
 #
 # Usage:
-#   curl -fsSL https://github.com/ercadev/dirigent-releases/releases/latest/download/install.sh | sudo bash
+#   curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash
 #
-# This script only installs the Dirigent CLI binary. Run `lotsen setup`
+# This script only installs the Lotsen CLI binary. Run `lotsen setup`
 # afterwards to perform the full host setup.
 
 set -euo pipefail
@@ -26,7 +26,7 @@ fi
 
 step "Detecting operating system"
 if [ ! -f /etc/os-release ]; then
-    error "Cannot determine OS: /etc/os-release not found. Dirigent supports Ubuntu 22.04+ and Debian 11+."
+    error "Cannot determine OS: /etc/os-release not found. Lotsen supports Ubuntu 22.04+ and Debian 11+."
 fi
 
 # shellcheck source=/dev/null
@@ -48,7 +48,7 @@ case "${OS_ID}" in
         fi
         ;;
     *)
-        error "Unsupported operating system: ${OS_ID}. Dirigent supports Ubuntu 22.04+ and Debian 11+."
+        error "Unsupported operating system: ${OS_ID}. Lotsen supports Ubuntu 22.04+ and Debian 11+."
         ;;
 esac
 
@@ -59,15 +59,15 @@ case "${ARCH}" in
     *) error "Unsupported architecture: ${ARCH}. Supported: x86_64, aarch64." ;;
 esac
 
-DIRIGENT_VERSION="${DIRIGENT_VERSION:-latest}"
+LOTSEN_VERSION="${LOTSEN_VERSION:-latest}"
 
-if [ "${DIRIGENT_VERSION}" = "latest" ]; then
-    RELEASE_BASE="https://github.com/ercadev/dirigent-releases/releases/latest/download"
+if [ "${LOTSEN_VERSION}" = "latest" ]; then
+    RELEASE_BASE="https://github.com/ercadev/lotsen-releases/releases/latest/download"
 else
-    RELEASE_BASE="https://github.com/ercadev/dirigent-releases/releases/download/${DIRIGENT_VERSION}"
+    RELEASE_BASE="https://github.com/ercadev/lotsen-releases/releases/download/${LOTSEN_VERSION}"
 fi
 
-step "Installing Lotsen CLI (${DIRIGENT_VERSION}, linux/${ARCH})"
+step "Installing Lotsen CLI (${LOTSEN_VERSION}, linux/${ARCH})"
 curl -fsSL "${RELEASE_BASE}/lotsen-cli-linux-${ARCH}" -o /usr/local/bin/lotsen
 chmod 0755 /usr/local/bin/lotsen
 

--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -13,12 +13,12 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 
-	"github.com/ercadev/dirigent/orchestrator/internal/apiclient"
-	"github.com/ercadev/dirigent/orchestrator/internal/docker"
-	"github.com/ercadev/dirigent/orchestrator/internal/hostinfo"
-	"github.com/ercadev/dirigent/orchestrator/internal/hostmetrics"
-	"github.com/ercadev/dirigent/orchestrator/internal/reconciler"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/orchestrator/internal/apiclient"
+	"github.com/ercadev/lotsen/orchestrator/internal/docker"
+	"github.com/ercadev/lotsen/orchestrator/internal/hostinfo"
+	"github.com/ercadev/lotsen/orchestrator/internal/hostmetrics"
+	"github.com/ercadev/lotsen/orchestrator/internal/reconciler"
+	"github.com/ercadev/lotsen/store"
 )
 
 func dataPath() string {

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -1,15 +1,15 @@
-module github.com/ercadev/dirigent/orchestrator
+module github.com/ercadev/lotsen/orchestrator
 
 go 1.24.0
 
 require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/docker/go-connections v0.6.0
-	github.com/ercadev/dirigent/store v0.0.0
+	github.com/ercadev/lotsen/store v0.0.0
 	github.com/opencontainers/image-spec v1.1.1
 )
 
-replace github.com/ercadev/dirigent/store => ../store
+replace github.com/ercadev/lotsen/store => ../store
 
 require (
 	github.com/Microsoft/go-winio v0.4.21 // indirect

--- a/orchestrator/internal/apiclient/client.go
+++ b/orchestrator/internal/apiclient/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 // Client calls the Lotsen API to notify it of deployment status transitions.

--- a/orchestrator/internal/apiclient/client_test.go
+++ b/orchestrator/internal/apiclient/client_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 func TestClient_NotifyHeartbeat(t *testing.T) {

--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -27,7 +27,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 // ErrDockerUnavailable is returned when the Docker daemon cannot be reached.

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/ercadev/dirigent/orchestrator/internal/docker"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/orchestrator/internal/docker"
+	"github.com/ercadev/lotsen/store"
 )
 
 type mockClient struct {

--- a/orchestrator/internal/reconciler/reconciler.go
+++ b/orchestrator/internal/reconciler/reconciler.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ercadev/dirigent/orchestrator/internal/docker"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/orchestrator/internal/docker"
+	"github.com/ercadev/lotsen/store"
 )
 
 // Docker is the container management interface required by the reconciler.

--- a/orchestrator/internal/reconciler/reconciler_test.go
+++ b/orchestrator/internal/reconciler/reconciler_test.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ercadev/dirigent/orchestrator/internal/docker"
-	"github.com/ercadev/dirigent/orchestrator/internal/reconciler"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/orchestrator/internal/docker"
+	"github.com/ercadev/lotsen/orchestrator/internal/reconciler"
+	"github.com/ercadev/lotsen/store"
 )
 
 // mockNotifier records NotifyStatus calls and can be configured to fail.

--- a/prds/01-installer.md
+++ b/prds/01-installer.md
@@ -6,14 +6,14 @@ Setting up a container orchestration system on a VPS requires multiple manual st
 
 ## Solution
 
-A single shell script that fully installs and configures Dirigent and all its dependencies on a fresh Ubuntu/Debian VPS. After running one command, the user has a fully operational system and can immediately start deploying containers via the GUI.
+A single shell script that fully installs and configures Lotsen and all its dependencies on a fresh Ubuntu/Debian VPS. After running one command, the user has a fully operational system and can immediately start deploying containers via the GUI.
 
 ## User Stories
 
-1. As a solo developer, I want to install Dirigent with a single command, so that I can start deploying containers without manual setup steps.
+1. As a solo developer, I want to install Lotsen with a single command, so that I can start deploying containers without manual setup steps.
 2. As a developer, I want the installer to install Docker if it's not already present, so that I don't need to configure it separately before running the script.
-3. As a developer, I want the installer to set up Dirigent as a systemd service, so that it starts automatically on boot and survives VPS restarts.
-4. As a developer, I want the installer to create a dedicated Docker network for Dirigent, so that container networking is managed consistently.
+3. As a developer, I want the installer to set up Lotsen as a systemd service, so that it starts automatically on boot and survives VPS restarts.
+4. As a developer, I want the installer to create a dedicated Docker network for Lotsen, so that container networking is managed consistently.
 5. As a developer, I want the installer to set up and start the integrated reverse proxy, so that containers with domains are reachable from the internet immediately after deploy.
 6. As a developer, I want the installer to validate that it's running on a supported OS version, so that I get a clear error instead of a cryptic failure mid-install.
 7. As a developer, I want the installer to check that it's run as root or with sudo, so that permission errors don't interrupt the setup.
@@ -27,10 +27,10 @@ A single shell script that fully installs and configures Dirigent and all its de
 - Script checks for root/sudo at the start and exits with a clear message if not present
 - Script detects OS and version, exits with a clear error on unsupported systems
 - Docker installation follows the official Docker apt repository method
-- Dirigent binary is downloaded from GitHub releases
-- A dedicated Docker bridge network is created for Dirigent-managed containers
-- A systemd unit file is written and enabled for the Dirigent process
-- The reverse proxy is started as part of the Dirigent process (not a separate service)
+- Lotsen binary is downloaded from GitHub releases
+- A dedicated Docker bridge network is created for Lotsen-managed containers
+- A systemd unit file is written and enabled for the Lotsen process
+- The reverse proxy is started as part of the Lotsen process (not a separate service)
 - Script prints a summary on completion: GUI URL, status of each setup step
 
 ## Testing Decisions
@@ -38,7 +38,7 @@ A single shell script that fully installs and configures Dirigent and all its de
 - Good tests verify observable outcomes (service running, network exists, binary present), not internal script logic
 - Test: after running the script on a fresh Ubuntu 22.04 VM, the systemd service is active
 - Test: after install, the GUI is reachable on the expected port
-- Test: Docker network for Dirigent exists post-install
+- Test: Docker network for Lotsen exists post-install
 - Manual smoke test on Debian 11 and Ubuntu 24.04
 
 ## Out of Scope

--- a/prds/02-web-gui.md
+++ b/prds/02-web-gui.md
@@ -6,7 +6,7 @@ Managing Docker containers on a VPS today requires SSH access and CLI knowledge.
 
 ## Solution
 
-A browser-based GUI served by the Dirigent backend that gives the user full control over their deployments. Users can create, view, edit, and remove deployments, see real-time status and logs, and configure everything needed to run a container in production — all without touching the command line.
+A browser-based GUI served by the Lotsen backend that gives the user full control over their deployments. Users can create, view, edit, and remove deployments, see real-time status and logs, and configure everything needed to run a container in production — all without touching the command line.
 
 ## User Stories
 
@@ -28,13 +28,13 @@ A browser-based GUI served by the Dirigent backend that gives the user full cont
 
 ## Implementation Decisions
 
-- React frontend, served as a static build by the Dirigent Go server
+- React frontend, served as a static build by the Lotsen Go server
 - Go backend exposes a REST API for deployment CRUD operations
 - Deployment entity fields: id, name, image, envs (key-value pairs), ports (host:container mappings), volumes (host path:container path), domain (optional), status
 - Deployment statuses: `idle`, `deploying`, `healthy`, `failed`
 - Real-time log streaming via WebSocket or Server-Sent Events (SSE)
 - Real-time status updates via WebSocket or SSE
-- GUI is served on a well-known port (e.g. 3000 or 8080) by the Dirigent process
+- GUI is served on a well-known port (e.g. 3000 or 8080) by the Lotsen process
 - The backend is the single source of truth for deployment state — the GUI is stateless
 
 ## Testing Decisions
@@ -56,4 +56,4 @@ A browser-based GUI served by the Dirigent backend that gives the user full cont
 
 ## Further Notes
 
-The GUI should feel fast and minimal. Every interaction should be obvious to a developer who has used Docker before, even if they've never heard of Dirigent. Avoid introducing new terminology where Docker's own terms suffice.
+The GUI should feel fast and minimal. Every interaction should be obvious to a developer who has used Docker before, even if they've never heard of Lotsen. Avoid introducing new terminology where Docker's own terms suffice.

--- a/prds/03-zero-downtime-deployments.md
+++ b/prds/03-zero-downtime-deployments.md
@@ -6,14 +6,14 @@ Updating a Docker container in production — changing the image version, updati
 
 ## Solution
 
-When a deployment's configuration changes and the user saves, Dirigent starts the new container alongside the old one. Once the new container is confirmed healthy, the old one is stopped. If the new container never becomes healthy, the old one continues running uninterrupted. The user sees the deployment status update in real time throughout the process.
+When a deployment's configuration changes and the user saves, Lotsen starts the new container alongside the old one. Once the new container is confirmed healthy, the old one is stopped. If the new container never becomes healthy, the old one continues running uninterrupted. The user sees the deployment status update in real time throughout the process.
 
 ## User Stories
 
 1. As a developer, I want my service to remain available while I update a deployment, so that users don't experience downtime during routine changes.
-2. As a developer, I want Dirigent to start the new container before stopping the old one, so that there's always a healthy instance serving traffic.
-3. As a developer, I want Dirigent to use a Docker healthcheck if one is defined in the image, so that the new container is only considered healthy when it's actually ready to serve requests.
-4. As a developer, I want Dirigent to fall back to checking that the container stays running for a short period if no healthcheck is defined, so that basic stability is verified even for images without explicit healthchecks.
+2. As a developer, I want Lotsen to start the new container before stopping the old one, so that there's always a healthy instance serving traffic.
+3. As a developer, I want Lotsen to use a Docker healthcheck if one is defined in the image, so that the new container is only considered healthy when it's actually ready to serve requests.
+4. As a developer, I want Lotsen to fall back to checking that the container stays running for a short period if no healthcheck is defined, so that basic stability is verified even for images without explicit healthchecks.
 5. As a developer, I want the old container to keep running if the new one never becomes healthy, so that my service stays up even during a bad deployment.
 6. As a developer, I want to see the deployment status change to "deploying" when a save triggers a redeploy, so that I know the process has started.
 7. As a developer, I want to see the deployment status update to "healthy" or "failed" once the redeploy completes, so that I know the outcome without having to check manually.
@@ -52,4 +52,4 @@ When a deployment's configuration changes and the user saves, Dirigent starts th
 
 ## Further Notes
 
-The key invariant is: at no point during a redeploy should a request to the domain fail due to Dirigent's actions. The old container is the fallback and must stay alive until the new one is confirmed good. This should be treated as a safety-critical property of the orchestrator.
+The key invariant is: at no point during a redeploy should a request to the domain fail due to Lotsen's actions. The old container is the fallback and must stay alive until the new one is confirmed good. This should be treated as a safety-critical property of the orchestrator.

--- a/prds/04-reverse-proxy.md
+++ b/prds/04-reverse-proxy.md
@@ -6,7 +6,7 @@ Exposing a Docker container to the internet on a VPS requires manually configuri
 
 ## Solution
 
-Dirigent includes an integrated reverse proxy that automatically handles domain-based routing and TLS certificate provisioning. When a deployment has a domain configured, it becomes publicly reachable over HTTPS with no additional setup. The proxy configuration is updated automatically as deployments are created, updated, or removed.
+Lotsen includes an integrated reverse proxy that automatically handles domain-based routing and TLS certificate provisioning. When a deployment has a domain configured, it becomes publicly reachable over HTTPS with no additional setup. The proxy configuration is updated automatically as deployments are created, updated, or removed.
 
 ## User Stories
 
@@ -23,8 +23,8 @@ Dirigent includes an integrated reverse proxy that automatically handles domain-
 
 ## Implementation Decisions
 
-- Reverse proxy is embedded in the Dirigent Go process or managed as a controlled subprocess (e.g. Caddy)
-- Domain-to-deployment routing table is maintained in memory and persisted by Dirigent
+- Reverse proxy is embedded in the Lotsen Go process or managed as a controlled subprocess (e.g. Caddy)
+- Domain-to-deployment routing table is maintained in memory and persisted by Lotsen
 - TLS certificate provisioning uses the ACME protocol via Let's Encrypt
 - Certificates are stored on disk and reused across restarts
 - HTTP → HTTPS redirect is enabled by default for all domains

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -19,11 +19,11 @@ import (
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 
-	"github.com/ercadev/dirigent/proxy/internal/handler"
-	"github.com/ercadev/dirigent/proxy/internal/middleware"
-	"github.com/ercadev/dirigent/proxy/internal/poller"
-	"github.com/ercadev/dirigent/proxy/internal/routing"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/proxy/internal/handler"
+	"github.com/ercadev/lotsen/proxy/internal/middleware"
+	"github.com/ercadev/lotsen/proxy/internal/poller"
+	"github.com/ercadev/lotsen/proxy/internal/routing"
+	"github.com/ercadev/lotsen/store"
 )
 
 const (

--- a/proxy/cmd/proxy/main_test.go
+++ b/proxy/cmd/proxy/main_test.go
@@ -12,10 +12,10 @@ import (
 
 	"golang.org/x/crypto/acme/autocert"
 
-	"github.com/ercadev/dirigent/proxy/internal/handler"
-	"github.com/ercadev/dirigent/proxy/internal/middleware"
-	"github.com/ercadev/dirigent/proxy/internal/routing"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/proxy/internal/handler"
+	"github.com/ercadev/lotsen/proxy/internal/middleware"
+	"github.com/ercadev/lotsen/proxy/internal/routing"
+	"github.com/ercadev/lotsen/store"
 )
 
 type tableStub struct {

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,11 +1,11 @@
-module github.com/ercadev/dirigent/proxy
+module github.com/ercadev/lotsen/proxy
 
 go 1.25.0
 
 require (
 	github.com/corazawaf/coraza/v3 v3.3.3
-	github.com/ercadev/dirigent/auth v0.0.0
-	github.com/ercadev/dirigent/store v0.0.0
+	github.com/ercadev/lotsen/auth v0.0.0
+	github.com/ercadev/lotsen/store v0.0.0
 )
 
 require (
@@ -45,6 +45,6 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 )
 
-replace github.com/ercadev/dirigent/auth => ../auth
+replace github.com/ercadev/lotsen/auth => ../auth
 
-replace github.com/ercadev/dirigent/store => ../store
+replace github.com/ercadev/lotsen/store => ../store

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -16,9 +16,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ercadev/dirigent/proxy/internal/middleware"
-	"github.com/ercadev/dirigent/proxy/internal/routing"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/proxy/internal/middleware"
+	"github.com/ercadev/lotsen/proxy/internal/routing"
+	"github.com/ercadev/lotsen/store"
 )
 
 // RoutingTable is the interface the handler reads from when proxying requests

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -14,10 +14,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/dirigent/proxy/internal/handler"
-	"github.com/ercadev/dirigent/proxy/internal/middleware"
-	"github.com/ercadev/dirigent/proxy/internal/routing"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/proxy/internal/handler"
+	"github.com/ercadev/lotsen/proxy/internal/middleware"
+	"github.com/ercadev/lotsen/proxy/internal/routing"
+	"github.com/ercadev/lotsen/store"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/proxy/internal/handler/proxylogin.go
+++ b/proxy/internal/handler/proxylogin.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/ercadev/dirigent/auth"
+	"github.com/ercadev/lotsen/auth"
 )
 
 const tokenCookieName = "lotsen_token"

--- a/proxy/internal/middleware/basicauth.go
+++ b/proxy/internal/middleware/basicauth.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/proxy/internal/middleware/basicauth_test.go
+++ b/proxy/internal/middleware/basicauth_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ercadev/dirigent/proxy/internal/middleware"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/proxy/internal/middleware"
+	"github.com/ercadev/lotsen/store"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/proxy/internal/middleware/ipfilter.go
+++ b/proxy/internal/middleware/ipfilter.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 const (

--- a/proxy/internal/middleware/ipfilter_test.go
+++ b/proxy/internal/middleware/ipfilter_test.go
@@ -3,8 +3,8 @@ package middleware_test
 import (
 	"testing"
 
-	"github.com/ercadev/dirigent/proxy/internal/middleware"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/proxy/internal/middleware"
+	"github.com/ercadev/lotsen/store"
 )
 
 func TestIPFilter_EvaluateGlobal(t *testing.T) {

--- a/proxy/internal/middleware/uafilter_test.go
+++ b/proxy/internal/middleware/uafilter_test.go
@@ -3,7 +3,7 @@ package middleware_test
 import (
 	"testing"
 
-	"github.com/ercadev/dirigent/proxy/internal/middleware"
+	"github.com/ercadev/lotsen/proxy/internal/middleware"
 )
 
 func TestUAFilter_BlocksScannerAndHeadless(t *testing.T) {

--- a/proxy/internal/middleware/waf_test.go
+++ b/proxy/internal/middleware/waf_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ercadev/dirigent/proxy/internal/middleware"
+	"github.com/ercadev/lotsen/proxy/internal/middleware"
 )
 
 func TestWAF_EnforcementBlocksCustomRuleMatch(t *testing.T) {

--- a/proxy/internal/poller/poller.go
+++ b/proxy/internal/poller/poller.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 // Table is the routing table the poller updates as deployments change.

--- a/proxy/internal/poller/poller_test.go
+++ b/proxy/internal/poller/poller_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/dirigent/proxy/internal/poller"
-	"github.com/ercadev/dirigent/proxy/internal/routing"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/proxy/internal/poller"
+	"github.com/ercadev/lotsen/proxy/internal/routing"
+	"github.com/ercadev/lotsen/store"
 )
 
 // memStore is an in-memory store for tests.

--- a/proxy/internal/routing/table.go
+++ b/proxy/internal/routing/table.go
@@ -3,7 +3,7 @@ package routing
 import (
 	"sync"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 // Route stores upstream and optional per-deployment configuration.

--- a/proxy/internal/routing/table_test.go
+++ b/proxy/internal/routing/table_test.go
@@ -3,8 +3,8 @@ package routing_test
 import (
 	"testing"
 
-	"github.com/ercadev/dirigent/proxy/internal/routing"
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/proxy/internal/routing"
+	"github.com/ercadev/lotsen/store"
 )
 
 func TestTable_SetAndGet(t *testing.T) {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@
 #   sudo bash setup.sh
 #
 # To pin a specific version:
-#   sudo DIRIGENT_VERSION=v0.0.2 bash setup.sh
+#   sudo LOTSEN_VERSION=v0.0.2 bash setup.sh
 #
 # Supported operating systems:
 #   Ubuntu 22.04 (Jammy) and later
@@ -24,10 +24,10 @@
 
 set -euo pipefail
 
-ENV_FILE="/etc/dirigent/dirigent.env"
-UPGRADE_MODE="${DIRIGENT_UPGRADE:-${LOTSEN_UPGRADE:-0}}"
-NON_INTERACTIVE_MODE="${DIRIGENT_NON_INTERACTIVE:-${LOTSEN_NON_INTERACTIVE:-0}}"
-REQUESTED_SECURITY_PROFILE="${DIRIGENT_SECURITY_PROFILE:-${LOTSEN_SECURITY_PROFILE:-}}"
+ENV_FILE="/etc/lotsen/lotsen.env"
+UPGRADE_MODE="${LOTSEN_UPGRADE:-0}"
+NON_INTERACTIVE_MODE="${LOTSEN_NON_INTERACTIVE:-0}"
+REQUESTED_SECURITY_PROFILE="${LOTSEN_SECURITY_PROFILE:-}"
 
 # ─── output helpers ───────────────────────────────────────────────────────────
 
@@ -80,30 +80,23 @@ write_dashboard_env() {
     local rp_origin=""
     local tmp
 
-    install -m 700 -d /etc/dirigent
+    install -m 700 -d /etc/lotsen
     tmp=$(mktemp)
 
     if [ -f "${ENV_FILE}" ]; then
-        awk '!/^(DIRIGENT|LOTSEN)_(DASHBOARD_(DOMAIN|USER|PASSWORD|ACCESS_MODE)|AUTH_(USER|PASSWORD|COOKIE_DOMAIN)|JWT_SECRET|RP_ID|RP_ORIGINS)=/' "${ENV_FILE}" > "${tmp}"
+        awk '!/^LOTSEN_(DASHBOARD_(DOMAIN|USER|PASSWORD|ACCESS_MODE)|AUTH_(USER|PASSWORD|COOKIE_DOMAIN)|JWT_SECRET|RP_ID|RP_ORIGINS)=/' "${ENV_FILE}" > "${tmp}"
     fi
 
     if [ -n "${dashboard_domain}" ]; then
         rp_origin="https://${dashboard_domain}"
         {
-            echo "DIRIGENT_DASHBOARD_DOMAIN=${dashboard_domain}"
             echo "LOTSEN_DASHBOARD_DOMAIN=${dashboard_domain}"
-            echo "DIRIGENT_RP_ID=${dashboard_domain}"
-            echo "DIRIGENT_RP_ORIGINS=${rp_origin}"
             echo "LOTSEN_RP_ID=${dashboard_domain}"
             echo "LOTSEN_RP_ORIGINS=${rp_origin}"
         } >> "${tmp}"
     fi
 
     {
-        echo "DIRIGENT_JWT_SECRET=${jwt_secret}"
-        echo "DIRIGENT_AUTH_USER=${auth_user}"
-        echo "DIRIGENT_AUTH_PASSWORD=${auth_password}"
-        echo "DIRIGENT_DASHBOARD_ACCESS_MODE=${dashboard_access_mode}"
         echo "LOTSEN_JWT_SECRET=${jwt_secret}"
         echo "LOTSEN_AUTH_USER=${auth_user}"
         echo "LOTSEN_AUTH_PASSWORD=${auth_password}"
@@ -111,10 +104,7 @@ write_dashboard_env() {
     } >> "${tmp}"
 
     if [ -n "${auth_cookie_domain}" ]; then
-        {
-            echo "DIRIGENT_AUTH_COOKIE_DOMAIN=${auth_cookie_domain}"
-            echo "LOTSEN_AUTH_COOKIE_DOMAIN=${auth_cookie_domain}"
-        } >> "${tmp}"
+        echo "LOTSEN_AUTH_COOKIE_DOMAIN=${auth_cookie_domain}" >> "${tmp}"
     fi
 
     install -m 600 "${tmp}" "${ENV_FILE}"
@@ -205,7 +195,7 @@ apply_strict_ssh_hardening() {
         error "Strict profile requested but /etc/ssh/sshd_config is missing"
     fi
 
-    cp /etc/ssh/sshd_config /etc/ssh/sshd_config.dirigent.bak
+    cp /etc/ssh/sshd_config /etc/ssh/sshd_config.lotsen.bak
 
     if grep -qE '^\s*PasswordAuthentication\s+' /etc/ssh/sshd_config; then
         sed -i 's/^\s*PasswordAuthentication\s\+.*/PasswordAuthentication no/' /etc/ssh/sshd_config
@@ -253,10 +243,10 @@ configure_firewall() {
     ufw allow 80/tcp
     ufw allow 443/tcp
 
-    if [ "${DIRIGENT_OPEN_DASHBOARD_PORT:-0}" = "1" ]; then
+    if [ "${LOTSEN_OPEN_DASHBOARD_PORT:-0}" = "1" ]; then
         ufw allow 3000/tcp
     fi
-    if [ "${DIRIGENT_OPEN_API_PORT:-0}" = "1" ]; then
+    if [ "${LOTSEN_OPEN_API_PORT:-0}" = "1" ]; then
         ufw allow 8080/tcp
     fi
 
@@ -278,7 +268,7 @@ step "Detecting operating system"
 
 if [ ! -f /etc/os-release ]; then
     error "Cannot determine OS: /etc/os-release not found.
-       Dirigent supports Ubuntu 22.04+ and Debian 11+."
+       Lotsen supports Ubuntu 22.04+ and Debian 11+."
 fi
 
 # Source the file to get ID and VERSION_ID as shell variables.
@@ -305,7 +295,7 @@ case "${OS_ID}" in
         ;;
     *)
         error "Unsupported operating system: ${OS_ID}.
-       Dirigent supports Ubuntu 22.04+ and Debian 11+."
+       Lotsen supports Ubuntu 22.04+ and Debian 11+."
         ;;
 esac
 
@@ -327,7 +317,7 @@ case "${SECURITY_PROFILE}" in
     strict|standard|off)
         ;;
     *)
-        error "Invalid security profile '${SECURITY_PROFILE}'. Set DIRIGENT_SECURITY_PROFILE or LOTSEN_SECURITY_PROFILE to strict, standard, or off."
+        error "Invalid security profile '${SECURITY_PROFILE}'. Set LOTSEN_SECURITY_PROFILE to strict, standard, or off."
         ;;
 esac
 
@@ -341,15 +331,15 @@ fi
 
 # ─── version resolution ───────────────────────────────────────────────────────
 
-DIRIGENT_VERSION="${DIRIGENT_VERSION:-${LOTSEN_VERSION:-latest}}"
+LOTSEN_VERSION="${LOTSEN_VERSION:-latest}"
 
-if [ "${DIRIGENT_VERSION}" = "latest" ]; then
-    RELEASE_BASE="https://github.com/ercadev/dirigent-releases/releases/latest/download"
+if [ "${LOTSEN_VERSION}" = "latest" ]; then
+    RELEASE_BASE="https://github.com/ercadev/lotsen-releases/releases/latest/download"
 else
-    RELEASE_BASE="https://github.com/ercadev/dirigent-releases/releases/download/${DIRIGENT_VERSION}"
+    RELEASE_BASE="https://github.com/ercadev/lotsen-releases/releases/download/${LOTSEN_VERSION}"
 fi
 
-step "Using release: ${DIRIGENT_VERSION}"
+step "Using release: ${LOTSEN_VERSION}"
 
 # ─── Docker installation ──────────────────────────────────────────────────────
 
@@ -398,33 +388,13 @@ fi
 # out from under a running process. Also stop and disable the legacy monolithic
 # service from older installs so it does not hold port 8080.
 SERVICES="lotsen-api lotsen-orchestrator lotsen-proxy"
-LEGACY_SERVICES="dirigent-api dirigent-orchestrator dirigent-proxy"
 
-step "Stopping any running Dirigent services"
+step "Stopping any running Lotsen services"
 
-if systemctl is-active --quiet dirigent 2>/dev/null; then
-    step "Stopping legacy dirigent.service"
-    systemctl stop dirigent
-    systemctl disable dirigent 2>/dev/null || true
-fi
-
-if systemctl is-active --quiet dirigent-dashboard 2>/dev/null; then
-    step "Stopping legacy dirigent-dashboard"
-    systemctl stop dirigent-dashboard
-fi
-systemctl disable dirigent-dashboard 2>/dev/null || true
-
-for svc in ${SERVICES} ${LEGACY_SERVICES}; do
+for svc in ${SERVICES}; do
     if systemctl is-active --quiet "${svc}" 2>/dev/null; then
         step "Stopping ${svc}"
         systemctl stop "${svc}"
-    fi
-done
-
-for svc in ${LEGACY_SERVICES}; do
-    if systemctl is-enabled --quiet "${svc}" 2>/dev/null; then
-        step "Disabling legacy ${svc}"
-        systemctl disable "${svc}" 2>/dev/null || true
     fi
 done
 
@@ -444,7 +414,7 @@ download_binary "lotsen-proxy-linux-${ARCH}"            /usr/local/bin/lotsen-pr
 
 # ─── data directory ───────────────────────────────────────────────────────────
 
-DATA_DIR="/var/lib/dirigent"
+DATA_DIR="/var/lib/lotsen"
 
 if [ ! -d "${DATA_DIR}" ]; then
     step "Creating data directory ${DATA_DIR}"
@@ -455,12 +425,12 @@ fi
 
 # ─── dashboard public exposure setup ──────────────────────────────────────────
 
-DASHBOARD_DOMAIN="${DIRIGENT_DASHBOARD_DOMAIN:-}"
-AUTH_USER="${DIRIGENT_AUTH_USER:-${LOTSEN_AUTH_USER:-}}"
-AUTH_PASSWORD="${DIRIGENT_AUTH_PASSWORD:-${LOTSEN_AUTH_PASSWORD:-}}"
-JWT_SECRET="${DIRIGENT_JWT_SECRET:-${LOTSEN_JWT_SECRET:-}}"
-AUTH_COOKIE_DOMAIN="${DIRIGENT_AUTH_COOKIE_DOMAIN:-${LOTSEN_AUTH_COOKIE_DOMAIN:-}}"
-DASHBOARD_ACCESS_MODE="${DIRIGENT_DASHBOARD_ACCESS_MODE:-${LOTSEN_DASHBOARD_ACCESS_MODE:-}}"
+DASHBOARD_DOMAIN="${LOTSEN_DASHBOARD_DOMAIN:-}"
+AUTH_USER="${LOTSEN_AUTH_USER:-}"
+AUTH_PASSWORD="${LOTSEN_AUTH_PASSWORD:-}"
+JWT_SECRET="${LOTSEN_JWT_SECRET:-}"
+AUTH_COOKIE_DOMAIN="${LOTSEN_AUTH_COOKIE_DOMAIN:-}"
+DASHBOARD_ACCESS_MODE="${LOTSEN_DASHBOARD_ACCESS_MODE:-}"
 GENERATED_AUTH_PASSWORD=0
 GENERATED_JWT_SECRET=0
 EXISTING_DASHBOARD_DOMAIN=""
@@ -471,31 +441,12 @@ EXISTING_AUTH_COOKIE_DOMAIN=""
 EXISTING_DASHBOARD_ACCESS_MODE=""
 
 if [ -f "${ENV_FILE}" ]; then
-    EXISTING_DASHBOARD_DOMAIN=$(read_env_value "DIRIGENT_DASHBOARD_DOMAIN")
-    EXISTING_AUTH_USER=$(read_env_value "DIRIGENT_AUTH_USER")
-    EXISTING_AUTH_PASSWORD=$(read_env_value "DIRIGENT_AUTH_PASSWORD")
-    EXISTING_JWT_SECRET=$(read_env_value "DIRIGENT_JWT_SECRET")
-    EXISTING_AUTH_COOKIE_DOMAIN=$(read_env_value "DIRIGENT_AUTH_COOKIE_DOMAIN")
-    EXISTING_DASHBOARD_ACCESS_MODE=$(read_env_value "DIRIGENT_DASHBOARD_ACCESS_MODE")
-    if [ -z "${EXISTING_DASHBOARD_DOMAIN}" ]; then
-        EXISTING_DASHBOARD_DOMAIN=$(read_env_value "LOTSEN_DASHBOARD_DOMAIN")
-    fi
-    if [ -z "${EXISTING_AUTH_USER}" ]; then
-        EXISTING_AUTH_USER=$(read_env_value "LOTSEN_AUTH_USER")
-    fi
-    if [ -z "${EXISTING_AUTH_PASSWORD}" ]; then
-        EXISTING_AUTH_PASSWORD=$(read_env_value "LOTSEN_AUTH_PASSWORD")
-    fi
-    if [ -z "${EXISTING_JWT_SECRET}" ]; then
-        EXISTING_JWT_SECRET=$(read_env_value "LOTSEN_JWT_SECRET")
-    fi
-    if [ -z "${EXISTING_AUTH_COOKIE_DOMAIN}" ]; then
-        EXISTING_AUTH_COOKIE_DOMAIN=$(read_env_value "LOTSEN_AUTH_COOKIE_DOMAIN")
-    fi
-    if [ -z "${EXISTING_DASHBOARD_ACCESS_MODE}" ]; then
-        EXISTING_DASHBOARD_ACCESS_MODE=$(read_env_value "LOTSEN_DASHBOARD_ACCESS_MODE")
-    fi
-
+    EXISTING_DASHBOARD_DOMAIN=$(read_env_value "LOTSEN_DASHBOARD_DOMAIN")
+    EXISTING_AUTH_USER=$(read_env_value "LOTSEN_AUTH_USER")
+    EXISTING_AUTH_PASSWORD=$(read_env_value "LOTSEN_AUTH_PASSWORD")
+    EXISTING_JWT_SECRET=$(read_env_value "LOTSEN_JWT_SECRET")
+    EXISTING_AUTH_COOKIE_DOMAIN=$(read_env_value "LOTSEN_AUTH_COOKIE_DOMAIN")
+    EXISTING_DASHBOARD_ACCESS_MODE=$(read_env_value "LOTSEN_DASHBOARD_ACCESS_MODE")
     if [ -z "${DASHBOARD_DOMAIN}" ] && [ -n "${EXISTING_DASHBOARD_DOMAIN}" ]; then
         DASHBOARD_DOMAIN="${EXISTING_DASHBOARD_DOMAIN}"
     fi
@@ -618,12 +569,12 @@ fi
 
 if [ -n "${DASHBOARD_DOMAIN}" ]; then
     if ! validate_domain "${DASHBOARD_DOMAIN}"; then
-        error "DIRIGENT_DASHBOARD_DOMAIN is set but invalid. Example: dashboard.example.com"
+        error "LOTSEN_DASHBOARD_DOMAIN is set but invalid. Example: dashboard.example.com"
     fi
 fi
 
 if ! validate_dashboard_access_mode "${DASHBOARD_ACCESS_MODE}"; then
-    error "DIRIGENT_DASHBOARD_ACCESS_MODE must be one of: login_only, waf_only, waf_and_login"
+    error "LOTSEN_DASHBOARD_ACCESS_MODE must be one of: login_only, waf_only, waf_and_login"
 fi
 
 step "Writing shared environment file"
@@ -640,17 +591,17 @@ fi
 
 # ─── Docker network ───────────────────────────────────────────────────────────
 
-DIRIGENT_NETWORK="dirigent"
+LOTSEN_NETWORK="lotsen"
 
-step "Checking for Dirigent Docker network"
+step "Checking for Lotsen Docker network"
 
-if docker network inspect "${DIRIGENT_NETWORK}" > /dev/null 2>&1; then
-    step "Docker network '${DIRIGENT_NETWORK}' already exists; skipping"
+if docker network inspect "${LOTSEN_NETWORK}" > /dev/null 2>&1; then
+    step "Docker network '${LOTSEN_NETWORK}' already exists; skipping"
     STEP_NETWORK="already exists"
 else
-    step "Creating Docker bridge network '${DIRIGENT_NETWORK}'"
-    docker network create --driver bridge "${DIRIGENT_NETWORK}"
-    step "Docker network '${DIRIGENT_NETWORK}' created"
+    step "Creating Docker bridge network '${LOTSEN_NETWORK}'"
+    docker network create --driver bridge "${LOTSEN_NETWORK}"
+    step "Docker network '${LOTSEN_NETWORK}' created"
     STEP_NETWORK="created"
 fi
 
@@ -661,7 +612,7 @@ step "Writing systemd unit files"
 cat > /etc/systemd/system/lotsen-api.service << EOF
 [Unit]
 Description=Lotsen API
-Documentation=https://github.com/ercadev/dirigent
+Documentation=https://github.com/ercadev/lotsen
 After=network.target docker.service
 Requires=docker.service
 
@@ -669,7 +620,7 @@ Requires=docker.service
 Type=simple
 ExecStart=/usr/local/bin/lotsen-api
 EnvironmentFile=-${ENV_FILE}
-Environment=DIRIGENT_DATA=${DATA_DIR}/deployments.json
+Environment=LOTSEN_DATA=${DATA_DIR}/deployments.json
 Restart=on-failure
 RestartSec=5
 
@@ -680,7 +631,7 @@ EOF
 cat > /etc/systemd/system/lotsen-orchestrator.service << EOF
 [Unit]
 Description=Lotsen orchestrator
-Documentation=https://github.com/ercadev/dirigent
+Documentation=https://github.com/ercadev/lotsen
 After=network.target docker.service lotsen-api.service
 Requires=docker.service
 
@@ -688,8 +639,8 @@ Requires=docker.service
 Type=simple
 ExecStart=/usr/local/bin/lotsen-orchestrator
 EnvironmentFile=-${ENV_FILE}
-Environment=DIRIGENT_DATA=${DATA_DIR}/deployments.json
-Environment=DIRIGENT_API_URL=http://localhost:8080
+Environment=LOTSEN_DATA=${DATA_DIR}/deployments.json
+Environment=LOTSEN_API_URL=http://localhost:8080
 Restart=on-failure
 RestartSec=5
 
@@ -700,7 +651,7 @@ EOF
 cat > /etc/systemd/system/lotsen-proxy.service << EOF
 [Unit]
 Description=Lotsen reverse proxy
-Documentation=https://github.com/ercadev/dirigent
+Documentation=https://github.com/ercadev/lotsen
 After=network.target docker.service lotsen-api.service
 Requires=docker.service
 
@@ -708,17 +659,13 @@ Requires=docker.service
 Type=simple
 ExecStart=/usr/local/bin/lotsen-proxy
 EnvironmentFile=-${ENV_FILE}
-Environment=DIRIGENT_DATA=${DATA_DIR}/deployments.json
+Environment=LOTSEN_DATA=${DATA_DIR}/deployments.json
 Restart=on-failure
 RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
 EOF
-
-rm -f /etc/systemd/system/dirigent-api.service
-rm -f /etc/systemd/system/dirigent-orchestrator.service
-rm -f /etc/systemd/system/dirigent-proxy.service
 
 # ─── enable and start services ────────────────────────────────────────────────
 
@@ -750,7 +697,7 @@ fi
 
 echo ""
 echo "  ┌─────────────────────────────────────────────────────────────────────────┐"
-echo "  │  Dirigent is ready                                                      │"
+echo "  │  Lotsen is ready                                                      │"
 echo "  └─────────────────────────────────────────────────────────────────────────┘"
 echo ""
 echo "  Services:"
@@ -779,7 +726,7 @@ if [ -n "${DASHBOARD_DOMAIN}" ]; then
     echo "  and port 80 is open so certificates can be issued."
 else
     echo "  Note: The dashboard is served directly by lotsen-api on :8080."
-    echo "  Configure DIRIGENT_DASHBOARD_DOMAIN in setup to expose it through"
+    echo "  Configure LOTSEN_DASHBOARD_DOMAIN in setup to expose it through"
     echo "  the :80/:443 reverse proxy with TLS."
 fi
 echo ""
@@ -787,5 +734,5 @@ echo "  Setup summary:"
 echo "    Docker        ${STEP_DOCKER}"
 echo "    Network       ${STEP_NETWORK}"
 echo "    Data dir      ${DATA_DIR}"
-echo "    Version       ${DIRIGENT_VERSION}"
+echo "    Version       ${LOTSEN_VERSION}"
 echo ""

--- a/store/go.mod
+++ b/store/go.mod
@@ -1,3 +1,3 @@
-module github.com/ercadev/dirigent/store
+module github.com/ercadev/lotsen/store
 
 go 1.24.0

--- a/store/store.go
+++ b/store/store.go
@@ -532,7 +532,7 @@ func (s *JSONStore) secretKey() []byte {
 		keyMaterial = strings.TrimSpace(os.Getenv("LOTSEN_JWT_SECRET"))
 	}
 	if keyMaterial == "" {
-		keyMaterial = "dirigent-registry:" + s.path
+		keyMaterial = "lotsen-registry:" + s.path
 	}
 
 	sum := sha256.Sum256([]byte(keyMaterial))

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ercadev/dirigent/store"
+	"github.com/ercadev/lotsen/store"
 )
 
 // seedStore writes deployments directly to the JSON file, bypassing the store.

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "dirigent-website",
+      "name": "lotsen-website",
       "dependencies": {
         "lucide-react": "^0.575.0",
         "react": "^19.0.0",

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -50,7 +50,7 @@ export function Footer() {
           onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--clr-muted)')}
           onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--clr-subtle)')}
         >
-          ercadev/dirigent ↗
+          ercadev/lotsen ↗
         </a>
       </div>
     </footer>

--- a/website/src/constants.ts
+++ b/website/src/constants.ts
@@ -1,4 +1,4 @@
 export const INSTALL_COMMAND =
-  'curl -fsSL https://github.com/ercadev/dirigent-releases/releases/latest/download/install.sh | sudo bash'
+  'curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash'
 
-export const GITHUB_URL = 'https://github.com/ercadev/dirigent'
+export const GITHUB_URL = 'https://github.com/ercadev/lotsen'

--- a/website/src/content/docs/strict-mode-setup.md
+++ b/website/src/content/docs/strict-mode-setup.md
@@ -30,7 +30,7 @@ If you expose the dashboard on a domain, also prepare DNS:
 If Lotsen is not installed yet:
 
 ```bash
-curl -fsSL https://github.com/ercadev/dirigent-releases/releases/latest/download/install.sh | sudo bash
+curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash
 sudo lotsen setup --profile strict --proxy-hardening-profile strict
 ```
 


### PR DESCRIPTION
## Summary
- replace all `dirigent` module/import and product naming across backend, frontend, docs, and project config with `lotsen`
- hard-cut installer/runtime naming to Lotsen-only (`LOTSEN_*`, `/etc/lotsen/lotsen.env`, `/var/lib/lotsen`, `lotsen` network/services)
- update external release/repo/image references to `ercadev/lotsen`, `ercadev/lotsen-releases`, and `ercadevapps/lotsen`

## Validation
- `make test`
- `git grep -n -e dirigent -e Dirigent -e DIRIGENT -e ercadev/dirigent -e ercadev/dirigent-releases -e ercadevapps/dirigent`