### PR TITLE
chore(repo): migrate references to lotsendev/lotsen

### DIFF
--- a/.claude/skills/go-engineer/SKILL.md
+++ b/.claude/skills/go-engineer/SKILL.md
@@ -9,7 +9,7 @@ description: Senior Go engineer that reads GitHub issues, plans architecture, an
 
 ### 1. Read the issue
 
-Fetch the issue with `mcp__github__get_issue` (`owner=ercadev`, `repo=lotsen`). Read all comments via `mcp__github__get_issue_comments`. Internalize:
+Fetch the issue with `mcp__github__get_issue` (`owner=lotsendev`, `repo=lotsen`). Read all comments via `mcp__github__get_issue_comments`. Internalize:
 
 - What problem is being solved (not just what to build)
 - Acceptance criteria

--- a/.claude/skills/pickup-issue/SKILL.md
+++ b/.claude/skills/pickup-issue/SKILL.md
@@ -9,7 +9,7 @@ description: Reads a GitHub issue, determines whether it is frontend (React) or 
 
 ### 1. Read the issue
 
-Use `mcp__github__get_issue` with `owner=ercadev`, `repo=lotsen`, and the issue number.
+Use `mcp__github__get_issue` with `owner=lotsendev`, `repo=lotsen`, and the issue number.
 Also call `mcp__github__get_issue_comments` to read any discussion.
 
 Read the full body, acceptance criteria, and any comments.

--- a/.claude/skills/react-engineer/SKILL.md
+++ b/.claude/skills/react-engineer/SKILL.md
@@ -21,7 +21,7 @@ description: Senior React engineer that reads GitHub issues, plans UI architectu
 
 ### 1. Read the issue
 
-Fetch the issue with `mcp__github__get_issue` (`owner=ercadev`, `repo=lotsen`). Read all comments via `mcp__github__get_issue_comments`. Internalize:
+Fetch the issue with `mcp__github__get_issue` (`owner=lotsendev`, `repo=lotsen`). Read all comments via `mcp__github__get_issue_comments`. Internalize:
 
 - What user problem is being solved (not just what to build)
 - Acceptance criteria

--- a/.claude/skills/refine-issue/SKILL.md
+++ b/.claude/skills/refine-issue/SKILL.md
@@ -36,7 +36,7 @@ Iterate until the user approves.
 
 ```bash
 gh issue create \
-  --repo ercadev/lotsen \
+  --repo lotsendev/lotsen \
   --title "<title>" \
   --body "<body>"
 ```

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -35,7 +35,7 @@ description: Reviews GitHub pull requests by fetching PR diffs, summarizing chan
 
 ## Posting to GitHub
 
-Use `mcp__github__create_pull_request_review` with `owner=ercadev`, `repo=lotsen`, and the PR number.
+Use `mcp__github__create_pull_request_review` with `owner=lotsendev`, `repo=lotsen`, and the PR number.
 
 ### Approve
 Set `event=APPROVE` and `body="<summary>"`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,11 +186,11 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASES_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release delete ${{ env.RELEASE_TAG }} --repo ercadev/lotsen-releases --yes || true
+          gh release delete ${{ env.RELEASE_TAG }} --repo lotsendev/lotsen --yes || true
           gh release create ${{ env.RELEASE_TAG }} \
-            --repo ercadev/lotsen-releases \
+            --repo lotsendev/lotsen \
             --title "${{ env.RELEASE_TAG }}" \
             --notes-file release-notes.md \
             --latest \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Context
 Docker orchestration for solo devs/VPS. Lightweight K8s alternative.
-- **Repo:** `ercadev/lotsen` (Always use for `gh` commands).
+- **Repo:** `lotsendev/lotsen` (Always use for `gh` commands).
 - **Stack:** Go (Backend/Orchestrator), Bun + React + Vite (Frontend).
 - **Data Flow:** Dashboard → API → JSON Store ← Orchestrator → Docker.
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -15,7 +15,7 @@ This guide covers two paths: running Lotsen on a VPS (production) and running it
 ### Install
 
 ```bash
-curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash
+curl -fsSL https://github.com/lotsendev/lotsen/releases/latest/download/install.sh | sudo bash
 sudo lotsen setup
 ```
 
@@ -54,7 +54,7 @@ This command updates `/etc/lotsen/lotsen.env` and restarts `lotsen-proxy`.
 ### Pin a specific version
 
 ```bash
-LOTSEN_VERSION=v0.1.0 curl -fsSL https://github.com/ercadev/lotsen-releases/releases/download/v0.1.0/install.sh | sudo bash
+LOTSEN_VERSION=v0.1.0 curl -fsSL https://github.com/lotsendev/lotsen/releases/download/v0.1.0/install.sh | sudo bash
 sudo LOTSEN_VERSION=v0.1.0 lotsen setup
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ dev-website:
 
 # Trigger a release via conventional-commit analysis (requires gh CLI).
 release:
-	gh workflow run auto-tag.yml --repo ercadev/lotsen
+	gh workflow run auto-tag.yml --repo lotsendev/lotsen
 
 # Remove build artifacts.
 clean:

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ A lightweight Docker orchestration tool for solo developers and small teams runn
 Run the following command on a fresh Ubuntu 22.04+ or Debian 11+ VPS as root (or with `sudo`):
 
 ```bash
-curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash
+curl -fsSL https://github.com/lotsendev/lotsen/releases/latest/download/install.sh | sudo bash
 sudo lotsen setup
 ```
 
 To pin a specific version:
 
 ```bash
-LOTSEN_VERSION=v0.0.2 curl -fsSL https://github.com/ercadev/lotsen-releases/releases/download/v0.0.2/install.sh | sudo bash
+LOTSEN_VERSION=v0.0.2 curl -fsSL https://github.com/lotsendev/lotsen/releases/download/v0.0.2/install.sh | sudo bash
 sudo LOTSEN_VERSION=v0.0.2 lotsen setup
 ```
 

--- a/api/README.md
+++ b/api/README.md
@@ -76,4 +76,4 @@ api/
     └── api/          HTTP handlers and Store interface
 ```
 
-Deployment persistence is provided by the shared `store/` module at the repo root (`github.com/ercadev/lotsen/store`).
+Deployment persistence is provided by the shared `store/` module at the repo root (`github.com/lotsendev/lotsen/store`).

--- a/api/cmd/lotsen/main.go
+++ b/api/cmd/lotsen/main.go
@@ -12,12 +12,12 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 
-	"github.com/ercadev/lotsen/auth"
-	internalapi "github.com/ercadev/lotsen/internal/api"
-	"github.com/ercadev/lotsen/internal/dashboard"
-	"github.com/ercadev/lotsen/internal/docker"
-	"github.com/ercadev/lotsen/internal/events"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/auth"
+	internalapi "github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/dashboard"
+	"github.com/lotsendev/lotsen/internal/docker"
+	"github.com/lotsendev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/store"
 )
 
 const addr = ":8080"

--- a/api/cmd/lotsen/main_test.go
+++ b/api/cmd/lotsen/main_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	internalapi "github.com/ercadev/lotsen/internal/api"
+	internalapi "github.com/lotsendev/lotsen/internal/api"
 )
 
 func TestAuthFromEnv_NoSecret(t *testing.T) {

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,11 +1,11 @@
-module github.com/ercadev/lotsen
+module github.com/lotsendev/lotsen
 
 go 1.25.0
 
 require (
 	github.com/docker/docker v27.5.1+incompatible
-	github.com/ercadev/lotsen/auth v0.0.0
-	github.com/ercadev/lotsen/store v0.0.0
+	github.com/lotsendev/lotsen/auth v0.0.0
+	github.com/lotsendev/lotsen/store v0.0.0
 	github.com/go-webauthn/webauthn v0.16.0
 	golang.org/x/crypto v0.48.0
 )
@@ -57,6 +57,6 @@ require (
 	modernc.org/sqlite v1.37.0 // indirect
 )
 
-replace github.com/ercadev/lotsen/auth => ../auth
+replace github.com/lotsendev/lotsen/auth => ../auth
 
-replace github.com/ercadev/lotsen/store => ../store
+replace github.com/lotsendev/lotsen/store => ../store

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/go-webauthn/webauthn/webauthn"
 
-	"github.com/ercadev/lotsen/auth"
-	"github.com/ercadev/lotsen/internal/events"
-	"github.com/ercadev/lotsen/internal/upgrade"
-	"github.com/ercadev/lotsen/internal/version"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/auth"
+	"github.com/lotsendev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/internal/upgrade"
+	"github.com/lotsendev/lotsen/internal/version"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // Store is the persistence interface required by the API handlers.

--- a/api/internal/api/handler_auth.go
+++ b/api/internal/api/handler_auth.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ercadev/lotsen/auth"
+	"github.com/lotsendev/lotsen/auth"
 )
 
 const (

--- a/api/internal/api/handler_auth_test.go
+++ b/api/internal/api/handler_auth_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/go-webauthn/webauthn/webauthn"
 
-	"github.com/ercadev/lotsen/auth"
-	"github.com/ercadev/lotsen/internal/api"
-	"github.com/ercadev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/auth"
+	"github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/events"
 )
 
 // stubAuthStore is an in-memory AuthUserStore for tests.

--- a/api/internal/api/handler_create_deployment.go
+++ b/api/internal/api/handler_create_deployment.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/lotsen/internal/events"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_delete_deployment.go
+++ b/api/internal/api/handler_delete_deployment.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func (h *Handler) deleteDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_deployment_logs.go
+++ b/api/internal/api/handler_deployment_logs.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // deploymentLogs streams container log lines for a deployment as SSE.

--- a/api/internal/api/handler_deployment_recent_logs.go
+++ b/api/internal/api/handler_deployment_recent_logs.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 const (

--- a/api/internal/api/handler_get_deployment.go
+++ b/api/internal/api/handler_get_deployment.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func (h *Handler) getDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_host_test.go
+++ b/api/internal/api/handler_host_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ercadev/lotsen/internal/api"
-	"github.com/ercadev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/events"
 )
 
 func newTestServerWithHostProfileStore(t *testing.T, storePath string) *httptest.Server {

--- a/api/internal/api/handler_list_deployments.go
+++ b/api/internal/api/handler_list_deployments.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 type deploymentResponse struct {

--- a/api/internal/api/handler_passkey.go
+++ b/api/internal/api/handler_passkey.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 
-	"github.com/ercadev/lotsen/auth"
+	"github.com/lotsendev/lotsen/auth"
 )
 
 const passkeySessionCookie = "lotsen_pk_session"

--- a/api/internal/api/handler_patch_deployment.go
+++ b/api/internal/api/handler_patch_deployment.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/lotsen/internal/events"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_registries.go
+++ b/api/internal/api/handler_registries.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 type registryRequest struct {

--- a/api/internal/api/handler_restart_deployment.go
+++ b/api/internal/api/handler_restart_deployment.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/lotsen/internal/events"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func (h *Handler) restartDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_test.go
+++ b/api/internal/api/handler_test.go
@@ -17,9 +17,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/lotsen/internal/api"
-	"github.com/ercadev/lotsen/internal/events"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // memStore is an in-memory store used only in tests.

--- a/api/internal/api/handler_update_deployment.go
+++ b/api/internal/api/handler_update_deployment.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/lotsen/internal/events"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_update_deployment_status.go
+++ b/api/internal/api/handler_update_deployment_status.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ercadev/lotsen/internal/events"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func (h *Handler) updateDeploymentStatus(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_upgrade.go
+++ b/api/internal/api/handler_upgrade.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ercadev/lotsen/internal/upgrade"
+	"github.com/lotsendev/lotsen/internal/upgrade"
 )
 
 func (h *Handler) startUpgrade(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/api/handler_upgrade_version_test.go
+++ b/api/internal/api/handler_upgrade_version_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/lotsen/internal/api"
-	"github.com/ercadev/lotsen/internal/events"
-	"github.com/ercadev/lotsen/internal/upgrade"
-	"github.com/ercadev/lotsen/internal/version"
+	"github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/events"
+	"github.com/lotsendev/lotsen/internal/upgrade"
+	"github.com/lotsendev/lotsen/internal/version"
 )
 
 type versionProviderStub struct {

--- a/api/internal/api/handler_users.go
+++ b/api/internal/api/handler_users.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ercadev/lotsen/auth"
+	"github.com/lotsendev/lotsen/auth"
 )
 
 func (h *Handler) listUsers(w http.ResponseWriter, _ *http.Request) {

--- a/api/internal/api/handler_version.go
+++ b/api/internal/api/handler_version.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ercadev/lotsen/internal/version"
+	"github.com/lotsendev/lotsen/internal/version"
 )
 
 type versionResponse struct {

--- a/api/internal/version/service.go
+++ b/api/internal/version/service.go
@@ -11,8 +11,8 @@ import (
 	"time"
 )
 
-var latestReleaseURL = "https://api.github.com/repos/ercadev/lotsen-releases/releases/latest"
-var releasesURL = "https://api.github.com/repos/ercadev/lotsen-releases/releases"
+var latestReleaseURL = "https://api.github.com/repos/lotsendev/lotsen/releases/latest"
+var releasesURL = "https://api.github.com/repos/lotsendev/lotsen/releases"
 
 const defaultCacheTTL = 5 * time.Minute
 

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -1,4 +1,4 @@
-module github.com/ercadev/lotsen/auth
+module github.com/lotsendev/lotsen/auth
 
 go 1.25.0
 

--- a/cli/cmd/lotsen/main.go
+++ b/cli/cmd/lotsen/main.go
@@ -17,12 +17,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ercadev/lotsen/auth"
+	"github.com/lotsendev/lotsen/auth"
 )
 
 const (
-	releaseBaseLatest = "https://github.com/ercadev/lotsen-releases/releases/latest/download"
-	releaseBaseTagFmt = "https://github.com/ercadev/lotsen-releases/releases/download/%s"
+	releaseBaseLatest = "https://github.com/lotsendev/lotsen/releases/latest/download"
+	releaseBaseTagFmt = "https://github.com/lotsendev/lotsen/releases/download/%s"
 )
 
 type versionSnapshot struct {

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,7 +1,7 @@
-module github.com/ercadev/lotsen/cli
+module github.com/lotsendev/lotsen/cli
 
 go 1.24.0
 
-require github.com/ercadev/lotsen/auth v0.0.0
+require github.com/lotsendev/lotsen/auth v0.0.0
 
-replace github.com/ercadev/lotsen/auth => ../auth
+replace github.com/lotsendev/lotsen/auth => ../auth

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # Lotsen bootstrap installer
 #
 # Usage:
-#   curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash
+#   curl -fsSL https://github.com/lotsendev/lotsen/releases/latest/download/install.sh | sudo bash
 #
 # This script only installs the Lotsen CLI binary. Run `lotsen setup`
 # afterwards to perform the full host setup.
@@ -62,9 +62,9 @@ esac
 LOTSEN_VERSION="${LOTSEN_VERSION:-latest}"
 
 if [ "${LOTSEN_VERSION}" = "latest" ]; then
-    RELEASE_BASE="https://github.com/ercadev/lotsen-releases/releases/latest/download"
+    RELEASE_BASE="https://github.com/lotsendev/lotsen/releases/latest/download"
 else
-    RELEASE_BASE="https://github.com/ercadev/lotsen-releases/releases/download/${LOTSEN_VERSION}"
+    RELEASE_BASE="https://github.com/lotsendev/lotsen/releases/download/${LOTSEN_VERSION}"
 fi
 
 step "Installing Lotsen CLI (${LOTSEN_VERSION}, linux/${ARCH})"

--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -13,12 +13,12 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 
-	"github.com/ercadev/lotsen/orchestrator/internal/apiclient"
-	"github.com/ercadev/lotsen/orchestrator/internal/docker"
-	"github.com/ercadev/lotsen/orchestrator/internal/hostinfo"
-	"github.com/ercadev/lotsen/orchestrator/internal/hostmetrics"
-	"github.com/ercadev/lotsen/orchestrator/internal/reconciler"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/orchestrator/internal/apiclient"
+	"github.com/lotsendev/lotsen/orchestrator/internal/docker"
+	"github.com/lotsendev/lotsen/orchestrator/internal/hostinfo"
+	"github.com/lotsendev/lotsen/orchestrator/internal/hostmetrics"
+	"github.com/lotsendev/lotsen/orchestrator/internal/reconciler"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func dataPath() string {

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -1,15 +1,15 @@
-module github.com/ercadev/lotsen/orchestrator
+module github.com/lotsendev/lotsen/orchestrator
 
 go 1.24.0
 
 require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/docker/go-connections v0.6.0
-	github.com/ercadev/lotsen/store v0.0.0
+	github.com/lotsendev/lotsen/store v0.0.0
 	github.com/opencontainers/image-spec v1.1.1
 )
 
-replace github.com/ercadev/lotsen/store => ../store
+replace github.com/lotsendev/lotsen/store => ../store
 
 require (
 	github.com/Microsoft/go-winio v0.4.21 // indirect

--- a/orchestrator/internal/apiclient/client.go
+++ b/orchestrator/internal/apiclient/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // Client calls the Lotsen API to notify it of deployment status transitions.

--- a/orchestrator/internal/apiclient/client_test.go
+++ b/orchestrator/internal/apiclient/client_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func TestClient_NotifyHeartbeat(t *testing.T) {

--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -27,7 +27,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // ErrDockerUnavailable is returned when the Docker daemon cannot be reached.

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/ercadev/lotsen/orchestrator/internal/docker"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/orchestrator/internal/docker"
+	"github.com/lotsendev/lotsen/store"
 )
 
 type mockClient struct {

--- a/orchestrator/internal/reconciler/reconciler.go
+++ b/orchestrator/internal/reconciler/reconciler.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ercadev/lotsen/orchestrator/internal/docker"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/orchestrator/internal/docker"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // Docker is the container management interface required by the reconciler.

--- a/orchestrator/internal/reconciler/reconciler_test.go
+++ b/orchestrator/internal/reconciler/reconciler_test.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ercadev/lotsen/orchestrator/internal/docker"
-	"github.com/ercadev/lotsen/orchestrator/internal/reconciler"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/orchestrator/internal/docker"
+	"github.com/lotsendev/lotsen/orchestrator/internal/reconciler"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // mockNotifier records NotifyStatus calls and can be configured to fail.

--- a/proxy/cmd/proxy/main.go
+++ b/proxy/cmd/proxy/main.go
@@ -19,11 +19,11 @@ import (
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 
-	"github.com/ercadev/lotsen/proxy/internal/handler"
-	"github.com/ercadev/lotsen/proxy/internal/middleware"
-	"github.com/ercadev/lotsen/proxy/internal/poller"
-	"github.com/ercadev/lotsen/proxy/internal/routing"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/proxy/internal/handler"
+	"github.com/lotsendev/lotsen/proxy/internal/middleware"
+	"github.com/lotsendev/lotsen/proxy/internal/poller"
+	"github.com/lotsendev/lotsen/proxy/internal/routing"
+	"github.com/lotsendev/lotsen/store"
 )
 
 const (

--- a/proxy/cmd/proxy/main_test.go
+++ b/proxy/cmd/proxy/main_test.go
@@ -12,10 +12,10 @@ import (
 
 	"golang.org/x/crypto/acme/autocert"
 
-	"github.com/ercadev/lotsen/proxy/internal/handler"
-	"github.com/ercadev/lotsen/proxy/internal/middleware"
-	"github.com/ercadev/lotsen/proxy/internal/routing"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/proxy/internal/handler"
+	"github.com/lotsendev/lotsen/proxy/internal/middleware"
+	"github.com/lotsendev/lotsen/proxy/internal/routing"
+	"github.com/lotsendev/lotsen/store"
 )
 
 type tableStub struct {

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,11 +1,11 @@
-module github.com/ercadev/lotsen/proxy
+module github.com/lotsendev/lotsen/proxy
 
 go 1.25.0
 
 require (
 	github.com/corazawaf/coraza/v3 v3.3.3
-	github.com/ercadev/lotsen/auth v0.0.0
-	github.com/ercadev/lotsen/store v0.0.0
+	github.com/lotsendev/lotsen/auth v0.0.0
+	github.com/lotsendev/lotsen/store v0.0.0
 )
 
 require (
@@ -45,6 +45,6 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 )
 
-replace github.com/ercadev/lotsen/auth => ../auth
+replace github.com/lotsendev/lotsen/auth => ../auth
 
-replace github.com/ercadev/lotsen/store => ../store
+replace github.com/lotsendev/lotsen/store => ../store

--- a/proxy/internal/handler/handler.go
+++ b/proxy/internal/handler/handler.go
@@ -16,9 +16,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ercadev/lotsen/proxy/internal/middleware"
-	"github.com/ercadev/lotsen/proxy/internal/routing"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/proxy/internal/middleware"
+	"github.com/lotsendev/lotsen/proxy/internal/routing"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // RoutingTable is the interface the handler reads from when proxying requests

--- a/proxy/internal/handler/handler_test.go
+++ b/proxy/internal/handler/handler_test.go
@@ -14,10 +14,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/lotsen/proxy/internal/handler"
-	"github.com/ercadev/lotsen/proxy/internal/middleware"
-	"github.com/ercadev/lotsen/proxy/internal/routing"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/proxy/internal/handler"
+	"github.com/lotsendev/lotsen/proxy/internal/middleware"
+	"github.com/lotsendev/lotsen/proxy/internal/routing"
+	"github.com/lotsendev/lotsen/store"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/proxy/internal/handler/proxylogin.go
+++ b/proxy/internal/handler/proxylogin.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/ercadev/lotsen/auth"
+	"github.com/lotsendev/lotsen/auth"
 )
 
 const tokenCookieName = "lotsen_token"

--- a/proxy/internal/middleware/basicauth.go
+++ b/proxy/internal/middleware/basicauth.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/proxy/internal/middleware/basicauth_test.go
+++ b/proxy/internal/middleware/basicauth_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ercadev/lotsen/proxy/internal/middleware"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/proxy/internal/middleware"
+	"github.com/lotsendev/lotsen/store"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/proxy/internal/middleware/ipfilter.go
+++ b/proxy/internal/middleware/ipfilter.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 const (

--- a/proxy/internal/middleware/ipfilter_test.go
+++ b/proxy/internal/middleware/ipfilter_test.go
@@ -3,8 +3,8 @@ package middleware_test
 import (
 	"testing"
 
-	"github.com/ercadev/lotsen/proxy/internal/middleware"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/proxy/internal/middleware"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func TestIPFilter_EvaluateGlobal(t *testing.T) {

--- a/proxy/internal/middleware/uafilter_test.go
+++ b/proxy/internal/middleware/uafilter_test.go
@@ -3,7 +3,7 @@ package middleware_test
 import (
 	"testing"
 
-	"github.com/ercadev/lotsen/proxy/internal/middleware"
+	"github.com/lotsendev/lotsen/proxy/internal/middleware"
 )
 
 func TestUAFilter_BlocksScannerAndHeadless(t *testing.T) {

--- a/proxy/internal/middleware/waf_test.go
+++ b/proxy/internal/middleware/waf_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ercadev/lotsen/proxy/internal/middleware"
+	"github.com/lotsendev/lotsen/proxy/internal/middleware"
 )
 
 func TestWAF_EnforcementBlocksCustomRuleMatch(t *testing.T) {

--- a/proxy/internal/poller/poller.go
+++ b/proxy/internal/poller/poller.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // Table is the routing table the poller updates as deployments change.

--- a/proxy/internal/poller/poller_test.go
+++ b/proxy/internal/poller/poller_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ercadev/lotsen/proxy/internal/poller"
-	"github.com/ercadev/lotsen/proxy/internal/routing"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/proxy/internal/poller"
+	"github.com/lotsendev/lotsen/proxy/internal/routing"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // memStore is an in-memory store for tests.

--- a/proxy/internal/routing/table.go
+++ b/proxy/internal/routing/table.go
@@ -3,7 +3,7 @@ package routing
 import (
 	"sync"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // Route stores upstream and optional per-deployment configuration.

--- a/proxy/internal/routing/table_test.go
+++ b/proxy/internal/routing/table_test.go
@@ -3,8 +3,8 @@ package routing_test
 import (
 	"testing"
 
-	"github.com/ercadev/lotsen/proxy/internal/routing"
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/proxy/internal/routing"
+	"github.com/lotsendev/lotsen/store"
 )
 
 func TestTable_SetAndGet(t *testing.T) {

--- a/setup.sh
+++ b/setup.sh
@@ -334,9 +334,9 @@ fi
 LOTSEN_VERSION="${LOTSEN_VERSION:-latest}"
 
 if [ "${LOTSEN_VERSION}" = "latest" ]; then
-    RELEASE_BASE="https://github.com/ercadev/lotsen-releases/releases/latest/download"
+    RELEASE_BASE="https://github.com/lotsendev/lotsen/releases/latest/download"
 else
-    RELEASE_BASE="https://github.com/ercadev/lotsen-releases/releases/download/${LOTSEN_VERSION}"
+    RELEASE_BASE="https://github.com/lotsendev/lotsen/releases/download/${LOTSEN_VERSION}"
 fi
 
 step "Using release: ${LOTSEN_VERSION}"
@@ -612,7 +612,7 @@ step "Writing systemd unit files"
 cat > /etc/systemd/system/lotsen-api.service << EOF
 [Unit]
 Description=Lotsen API
-Documentation=https://github.com/ercadev/lotsen
+Documentation=https://github.com/lotsendev/lotsen
 After=network.target docker.service
 Requires=docker.service
 
@@ -631,7 +631,7 @@ EOF
 cat > /etc/systemd/system/lotsen-orchestrator.service << EOF
 [Unit]
 Description=Lotsen orchestrator
-Documentation=https://github.com/ercadev/lotsen
+Documentation=https://github.com/lotsendev/lotsen
 After=network.target docker.service lotsen-api.service
 Requires=docker.service
 
@@ -651,7 +651,7 @@ EOF
 cat > /etc/systemd/system/lotsen-proxy.service << EOF
 [Unit]
 Description=Lotsen reverse proxy
-Documentation=https://github.com/ercadev/lotsen
+Documentation=https://github.com/lotsendev/lotsen
 After=network.target docker.service lotsen-api.service
 Requires=docker.service
 

--- a/store/go.mod
+++ b/store/go.mod
@@ -1,3 +1,3 @@
-module github.com/ercadev/lotsen/store
+module github.com/lotsendev/lotsen/store
 
 go 1.24.0

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ercadev/lotsen/store"
+	"github.com/lotsendev/lotsen/store"
 )
 
 // seedStore writes deployments directly to the JSON file, bypassing the store.

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -50,7 +50,7 @@ export function Footer() {
           onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--clr-muted)')}
           onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--clr-subtle)')}
         >
-          ercadev/lotsen ↗
+          lotsendev/lotsen ↗
         </a>
       </div>
     </footer>

--- a/website/src/constants.ts
+++ b/website/src/constants.ts
@@ -1,4 +1,4 @@
 export const INSTALL_COMMAND =
-  'curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash'
+  'curl -fsSL https://github.com/lotsendev/lotsen/releases/latest/download/install.sh | sudo bash'
 
-export const GITHUB_URL = 'https://github.com/ercadev/lotsen'
+export const GITHUB_URL = 'https://github.com/lotsendev/lotsen'

--- a/website/src/content/docs/strict-mode-setup.md
+++ b/website/src/content/docs/strict-mode-setup.md
@@ -30,7 +30,7 @@ If you expose the dashboard on a domain, also prepare DNS:
 If Lotsen is not installed yet:
 
 ```bash
-curl -fsSL https://github.com/ercadev/lotsen-releases/releases/latest/download/install.sh | sudo bash
+curl -fsSL https://github.com/lotsendev/lotsen/releases/latest/download/install.sh | sudo bash
 sudo lotsen setup --profile strict --proxy-hardening-profile strict
 ```
 


### PR DESCRIPTION
## Summary
- migrate all repository and artifact URLs from `ercadev/lotsen` and `lotsen-releases` to `lotsendev/lotsen`
- update release automation to publish GitHub Releases and downloadable artifacts in the main repo
- rename Go module paths/imports across api/auth/cli/orchestrator/proxy/store to `github.com/lotsendev/lotsen/...`

## Verification
- ran `go test ./...` in `api`, `auth`, `cli`, `orchestrator`, `proxy`, and `store`
- website build still fails due to pre-existing TypeScript test globals configuration (`describe`/`it`/`expect`/`vi`)