### PR TITLE
chore(repo): migrate lotsendev references and harden dashboard WAF UI

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -3,6 +3,9 @@ name: Auto Tag
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   version:
     name: Determine version
@@ -11,7 +14,7 @@ jobs:
       actions: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   go:
     name: Go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -54,13 +58,13 @@ jobs:
       run:
         working-directory: dashboard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: dashboard/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('dashboard/bun.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,14 @@ on:
 
 env:
   RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   ci-go:
     name: CI / Go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -67,13 +68,13 @@ jobs:
       run:
         working-directory: dashboard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: dashboard/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('dashboard/bun.lock') }}
@@ -90,7 +91,7 @@ jobs:
     needs: [ci-go, ci-react]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -105,7 +106,7 @@ jobs:
         with:
           bun-version: latest
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: dashboard/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('dashboard/bun.lock') }}
@@ -210,7 +211,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: docker/setup-qemu-action@v3
 

--- a/dashboard/src/components/ui/button.tsx
+++ b/dashboard/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps } from 'react'
 import { cn } from '../../lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=size-])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+  'inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=size-])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
   {
     variants: {
       variant: {

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -295,10 +295,11 @@ export function SettingsPage() {
     onSuccess: profile => {
       queryClient.setQueryData(['hostProfile'], profile)
       setDashboardWAFError(null)
-      setDashboardWAFModeDraft(profile.dashboardWaf.mode)
-      setDashboardWAFAllowlistDraft(profile.dashboardWaf.ipAllowlist)
+      const nextDashboardWAF = profile.dashboardWaf ?? { mode: 'detection', ipAllowlist: [], customRules: [] }
+      setDashboardWAFModeDraft(nextDashboardWAF.mode)
+      setDashboardWAFAllowlistDraft(Array.isArray(nextDashboardWAF.ipAllowlist) ? nextDashboardWAF.ipAllowlist : [])
       setDashboardWAFAllowlistInput('')
-      setDashboardWAFRulesDraft(profile.dashboardWaf.customRules.join('\n'))
+      setDashboardWAFRulesDraft(Array.isArray(nextDashboardWAF.customRules) ? nextDashboardWAF.customRules.join('\n') : '')
     },
     onError: error => {
       setDashboardWAFError(error instanceof Error ? error.message : 'Failed to update dashboard WAF settings')

--- a/dashboard/src/pages/TrafficPage.tsx
+++ b/dashboard/src/pages/TrafficPage.tsx
@@ -335,14 +335,14 @@ export function TrafficPage() {
                       <td className="px-3 py-2 whitespace-nowrap">{formatTimestamp(entry.timestamp)}</td>
                       <td className="px-3 py-2 font-mono text-[11px]">{entry.clientIp || '-'}</td>
                       <td className="px-3 py-2">
-                        <div className="text-foreground">
+                        <div className="text-foreground [overflow-wrap:anywhere]">
                           {entry.method} {entry.path}
                           {entry.query ? `?${entry.query}` : ''}
                         </div>
                         {entry.headers && Object.keys(entry.headers).length > 0 && (
                           <details className="mt-1 text-[11px] text-muted-foreground">
                             <summary className="cursor-pointer select-none">Headers</summary>
-                            <pre className="mt-1 whitespace-pre-wrap rounded border border-border/50 bg-background p-2 text-[10px] text-foreground">
+                            <pre className="mt-1 whitespace-pre-wrap rounded border border-border/50 bg-background p-2 text-[10px] text-foreground [overflow-wrap:anywhere]">
                               {JSON.stringify(entry.headers, null, 2)}
                             </pre>
                           </details>


### PR DESCRIPTION
## Summary
- migrate repository, module, release, and docs references from `ercadev/*` to `lotsendev/lotsen`, including CI/release workflow targets
- upgrade GitHub Actions workflow dependencies to v5 and force Node 24 runtime compatibility for JavaScript actions
- harden dashboard settings UI by guarding missing `dashboardWaf` arrays to prevent save-time `join` crashes, and improve long traffic log wrapping