### PR TITLE
fix(volumes): support managed mount ownership for non-root containers

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -53,7 +53,7 @@ LOTSEN_DATA=/tmp/lotsen.json go run ./cmd/lotsen
   "ports":   ["80:80"],
   "volumes": ["/data:/data"],
   "volume_mounts": [
-    { "mode": "managed", "source": "app-data", "target": "/data" }
+    { "mode": "managed", "source": "app-data", "target": "/data", "uid": 1000, "gid": 1000, "dir_mode": "0770" }
   ],
   "domain":  "example.com",
   "status":  "idle"
@@ -67,7 +67,7 @@ LOTSEN_DATA=/tmp/lotsen.json go run ./cmd/lotsen
 ```bash
 curl -X POST http://localhost:8080/api/deployments \
   -H "Content-Type: application/json" \
-  -d '{"name":"web","image":"nginx:latest","ports":["80:80"],"volume_mounts":[{"mode":"managed","source":"web-data","target":"/data"}]}'
+  -d '{"name":"web","image":"nginx:latest","ports":["80:80"],"volume_mounts":[{"mode":"managed","source":"web-data","target":"/data","uid":1000,"gid":1000,"dir_mode":"0770"}]}'
 ```
 
 ## Package structure

--- a/api/internal/api/handler_managed_volumes_http_test.go
+++ b/api/internal/api/handler_managed_volumes_http_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -84,5 +85,47 @@ func TestCreateDeployment_ManagedVolumeMountRejectsTraversalName(t *testing.T) {
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateDeployment_ManagedVolumeMountAppliesDirMode(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("LOTSEN_MANAGED_VOLUMES_DIR", base)
+
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	body := []byte(`{
+		"name":"pgadmin",
+		"image":"dpage/pgadmin4",
+		"ports":["80"],
+		"envs":{},
+		"volume_mounts":[{"mode":"managed","source":"data","target":"/var/lib/pgadmin","dir_mode":"0770"}]
+	}`)
+
+	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/deployments: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("want 201, got %d", resp.StatusCode)
+	}
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	managedPath := filepath.Join(base, created.ID, "data")
+	info, statErr := os.Stat(managedPath)
+	if statErr != nil {
+		t.Fatalf("stat managed path: %v", statErr)
+	}
+	if got := info.Mode().Perm(); got != 0o770 {
+		t.Fatalf("want managed dir mode 0770, got %04o", got)
 	}
 }

--- a/api/internal/api/handler_volumes.go
+++ b/api/internal/api/handler_volumes.go
@@ -1,30 +1,45 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
 const (
 	volumeMountModeManaged = "managed"
 	volumeMountModeBind    = "bind"
+	defaultManagedDirMode  = 0o777
 )
 
 var managedVolumeNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$`)
 
 type volumeMountRequest struct {
-	Mode   string `json:"mode"`
-	Source string `json:"source"`
-	Target string `json:"target"`
+	Mode    string `json:"mode"`
+	Source  string `json:"source"`
+	Target  string `json:"target"`
+	UID     *int   `json:"uid,omitempty"`
+	GID     *int   `json:"gid,omitempty"`
+	DirMode string `json:"dir_mode,omitempty"`
 }
 
 type volumeMountResponse struct {
 	Mode   string `json:"mode"`
 	Source string `json:"source"`
 	Target string `json:"target"`
+}
+
+type managedVolumeSettings struct {
+	hasUID     bool
+	uid        int
+	hasGID     bool
+	gid        int
+	hasDirMode bool
+	dirMode    os.FileMode
 }
 
 func managedVolumesBaseDirFromEnv() string {
@@ -65,7 +80,12 @@ func resolveVolumeBindings(deploymentID string, volumes []string, mounts []volum
 				return nil, fmt.Errorf("managed volume names must match %q", managedVolumeNamePattern.String())
 			}
 
-			hostPath, pathErr := ensureManagedVolumeDirectory(deploymentID, source)
+			settings, settingsErr := managedVolumeSettingsFromRequest(mount)
+			if settingsErr != nil {
+				return nil, settingsErr
+			}
+
+			hostPath, pathErr := ensureManagedVolumeDirectoryWithSettings(deploymentID, source, settings)
 			if pathErr != nil {
 				return nil, pathErr
 			}
@@ -76,6 +96,10 @@ func resolveVolumeBindings(deploymentID string, volumes []string, mounts []volum
 			seenSources[hostPath] = struct{}{}
 			bindings = append(bindings, hostPath+":"+target)
 		case volumeMountModeBind:
+			if mount.UID != nil || mount.GID != nil || strings.TrimSpace(mount.DirMode) != "" {
+				return nil, fmt.Errorf("uid, gid, and dir_mode are only supported for managed volume mounts")
+			}
+
 			hostPath, hostErr := cleanAbsolutePath(source)
 			if hostErr != nil {
 				return nil, fmt.Errorf("bind source must be an absolute path")
@@ -94,6 +118,10 @@ func resolveVolumeBindings(deploymentID string, volumes []string, mounts []volum
 }
 
 func ensureManagedVolumeDirectory(deploymentID, volumeName string) (string, error) {
+	return ensureManagedVolumeDirectoryWithSettings(deploymentID, volumeName, managedVolumeSettings{})
+}
+
+func ensureManagedVolumeDirectoryWithSettings(deploymentID, volumeName string, settings managedVolumeSettings) (string, error) {
 	base := managedVolumesBaseDirFromEnv()
 	if !filepath.IsAbs(base) {
 		return "", fmt.Errorf("managed volumes base path must be absolute")
@@ -105,11 +133,85 @@ func ensureManagedVolumeDirectory(deploymentID, volumeName string) (string, erro
 		return "", fmt.Errorf("managed volume path escapes configured base directory")
 	}
 
+	existed := true
+	if _, err := os.Stat(volumeDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			existed = false
+		} else {
+			return "", fmt.Errorf("stat managed volume directory: %w", err)
+		}
+	}
+
 	if err := os.MkdirAll(volumeDir, 0o755); err != nil {
 		return "", fmt.Errorf("create managed volume directory: %w", err)
 	}
 
+	if err := applyManagedVolumeSettings(volumeDir, settings, existed); err != nil {
+		return "", err
+	}
+
 	return volumeDir, nil
+}
+
+func managedVolumeSettingsFromRequest(mount volumeMountRequest) (managedVolumeSettings, error) {
+	settings := managedVolumeSettings{}
+
+	if mount.UID != nil {
+		if *mount.UID < 0 {
+			return managedVolumeSettings{}, fmt.Errorf("uid must be >= 0")
+		}
+		settings.hasUID = true
+		settings.uid = *mount.UID
+	}
+
+	if mount.GID != nil {
+		if *mount.GID < 0 {
+			return managedVolumeSettings{}, fmt.Errorf("gid must be >= 0")
+		}
+		settings.hasGID = true
+		settings.gid = *mount.GID
+	}
+
+	rawDirMode := strings.TrimSpace(mount.DirMode)
+	if rawDirMode != "" {
+		parsed, err := strconv.ParseUint(rawDirMode, 8, 32)
+		if err != nil || parsed > 0o777 {
+			return managedVolumeSettings{}, fmt.Errorf("dir_mode must be an octal permission between 0000 and 0777")
+		}
+		settings.hasDirMode = true
+		settings.dirMode = os.FileMode(parsed)
+	}
+
+	return settings, nil
+}
+
+func applyManagedVolumeSettings(volumeDir string, settings managedVolumeSettings, existed bool) error {
+	if !settings.hasDirMode && !existed {
+		settings.hasDirMode = true
+		settings.dirMode = defaultManagedDirMode
+	}
+
+	if settings.hasUID || settings.hasGID {
+		uid := -1
+		if settings.hasUID {
+			uid = settings.uid
+		}
+		gid := -1
+		if settings.hasGID {
+			gid = settings.gid
+		}
+		if err := os.Chown(volumeDir, uid, gid); err != nil {
+			return fmt.Errorf("set managed volume ownership: %w", err)
+		}
+	}
+
+	if settings.hasDirMode {
+		if err := os.Chmod(volumeDir, settings.dirMode); err != nil {
+			return fmt.Errorf("set managed volume permissions: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func cleanAbsolutePath(raw string) (string, error) {

--- a/api/internal/api/handler_volumes.go
+++ b/api/internal/api/handler_volumes.go
@@ -117,10 +117,6 @@ func resolveVolumeBindings(deploymentID string, volumes []string, mounts []volum
 	return bindings, nil
 }
 
-func ensureManagedVolumeDirectory(deploymentID, volumeName string) (string, error) {
-	return ensureManagedVolumeDirectoryWithSettings(deploymentID, volumeName, managedVolumeSettings{})
-}
-
 func ensureManagedVolumeDirectoryWithSettings(deploymentID, volumeName string, settings managedVolumeSettings) (string, error) {
 	base := managedVolumesBaseDirFromEnv()
 	if !filepath.IsAbs(base) {

--- a/api/internal/api/handler_volumes_test.go
+++ b/api/internal/api/handler_volumes_test.go
@@ -26,6 +26,14 @@ func TestResolveVolumeBindings_ManagedCreatesDirectory(t *testing.T) {
 	if _, statErr := os.Stat(wantSource); statErr != nil {
 		t.Fatalf("want managed path to exist: %v", statErr)
 	}
+
+	info, err := os.Stat(wantSource)
+	if err != nil {
+		t.Fatalf("stat managed path: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o777 {
+		t.Fatalf("want managed dir mode 0777 by default, got %04o", got)
+	}
 }
 
 func TestResolveVolumeBindings_RejectsInvalidManagedName(t *testing.T) {
@@ -48,6 +56,50 @@ func TestResolveVolumeBindings_RejectsDuplicateTarget(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("want error, got nil")
+	}
+}
+
+func TestResolveVolumeBindings_RejectsBindOwnershipSettings(t *testing.T) {
+	t.Setenv("LOTSEN_MANAGED_VOLUMES_DIR", t.TempDir())
+
+	uid := 1000
+	_, err := resolveVolumeBindings("dep-1", nil, []volumeMountRequest{
+		{Mode: volumeMountModeBind, Source: "/srv/data", Target: "/data", UID: &uid},
+	})
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+
+func TestResolveVolumeBindings_RejectsInvalidDirMode(t *testing.T) {
+	t.Setenv("LOTSEN_MANAGED_VOLUMES_DIR", t.TempDir())
+
+	_, err := resolveVolumeBindings("dep-1", nil, []volumeMountRequest{
+		{Mode: volumeMountModeManaged, Source: "data", Target: "/data", DirMode: "0999"},
+	})
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+
+func TestResolveVolumeBindings_AppliesManagedDirModeOverride(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("LOTSEN_MANAGED_VOLUMES_DIR", base)
+
+	_, err := resolveVolumeBindings("dep-1", nil, []volumeMountRequest{
+		{Mode: volumeMountModeManaged, Source: "data", Target: "/data", DirMode: "0700"},
+	})
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+
+	path := filepath.Join(base, "dep-1", "data")
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		t.Fatalf("stat managed path: %v", statErr)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("want managed dir mode 0700, got %04o", got)
 	}
 }
 

--- a/website/src/content/docs/deployment-configuration.md
+++ b/website/src/content/docs/deployment-configuration.md
@@ -9,7 +9,7 @@ A deployment is the central object in Lotsen. It describes a container you want 
 | name    | string   | Yes      | A human-readable identifier for the deployment. Used as the container name in Docker. Must be unique across all deployments. |
 | image   | string   | Yes      | The Docker image to run, including tag. The orchestrator pulls this image before starting the container. Example: `nginx:1.27` or `ghcr.io/myorg/api:latest`. |
 | ports   | string[] | No       | Port mappings in `host:container` format. Each entry maps a port on the VPS host to a port inside the container. Example: `["80:80", "443:443"]`. |
-| volume_mounts | object[] | No | Volume mounts with explicit mode: managed or bind. Managed mounts are created automatically under `/var/lib/lotsen/volumes/<deployment>/<volume>`. Example: `[{"mode":"managed","source":"postgres-data","target":"/var/lib/postgresql/data"}]`. |
+| volume_mounts | object[] | No | Volume mounts with explicit mode: managed or bind. Managed mounts are created automatically under `/var/lib/lotsen/volumes/<deployment>/<volume>`. Managed mounts also support optional `uid`, `gid`, and `dir_mode` ownership settings. Example: `[{"mode":"managed","source":"postgres-data","target":"/var/lib/postgresql/data","uid":5050,"gid":5050,"dir_mode":"0770"}]`. |
 | volumes | string[] | No | Backward-compatible raw bind format (`host-path:container-path`). Prefer `volume_mounts` for new deployments. |
 | envs    | object   | No       | Environment variables passed into the container as a key-value map. Values are stored in the Lotsen data file on disk. Example: `{"DATABASE_URL": "postgres://..."}`. |
 | domain  | string   | No       | A fully-qualified domain name to route to this container via the integrated reverse proxy. Point your DNS A record to the VPS IP, and Lotsen will forward HTTP traffic on port 80. Example: `api.example.com`. |
@@ -59,6 +59,21 @@ The first deploy creates:
 ```
 
 This path is remounted automatically on redeploy.
+
+For non-root images (for example pgAdmin), managed mounts are created with writable permissions by default (`0777`) so first boot can succeed without manual host `chown`. You can also override ownership explicitly:
+
+```json
+"volume_mounts": [
+  {
+    "mode": "managed",
+    "source": "pgadmin-data",
+    "target": "/var/lib/pgadmin",
+    "uid": 5050,
+    "gid": 5050,
+    "dir_mode": "0770"
+  }
+]
+```
 
 ### Advanced bind mount mode
 


### PR DESCRIPTION
## Summary
- add optional `uid`, `gid`, and `dir_mode` support for managed `volume_mounts` to explicitly set writable ownership/permissions for non-root containers
- apply safe default managed-volume directory permissions (`0777`) on first create so fresh non-root workloads like pgAdmin can start without manual host `chown`
- add API/unit coverage for new validation and behavior, and update deployment docs with non-root examples

## Testing
- `go test ./internal/api/...`

Closes #235