### PR TITLE
fix(orchestrator): redeploy stopped deployments on config updates

### DIFF
--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
 	dockerclient "github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -263,12 +264,17 @@ func (d *Docker) StopAndRemove(ctx context.Context, containerID string) error {
 		if dockerclient.IsErrConnectionFailed(err) {
 			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
 		}
-		return fmt.Errorf("docker: stop container %s: %w", containerID, err)
+		if !errdefs.IsNotModified(err) && !errdefs.IsNotFound(err) {
+			return fmt.Errorf("docker: stop container %s: %w", containerID, err)
+		}
 	}
 
 	if err := d.client.ContainerRemove(ctx, containerID, container.RemoveOptions{}); err != nil {
 		if dockerclient.IsErrConnectionFailed(err) {
 			return fmt.Errorf("%w: %v", ErrDockerUnavailable, err)
+		}
+		if errdefs.IsNotFound(err) {
+			return nil
 		}
 		return fmt.Errorf("docker: remove container %s: %w", containerID, err)
 	}

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -365,6 +366,34 @@ func TestDocker_StopAndRemove(t *testing.T) {
 	}
 	if len(mock.removed) != 1 || mock.removed[0] != "c1" {
 		t.Errorf("want c1 removed, got %v", mock.removed)
+	}
+}
+
+func TestDocker_StopAndRemove_AlreadyStoppedStillRemoves(t *testing.T) {
+	mock := &mockClient{stopErr: errdefs.NotModified(errors.New("container already stopped"))}
+	d := docker.New(mock)
+	if err := d.StopAndRemove(context.Background(), "c1"); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if len(mock.stopped) != 1 || mock.stopped[0] != "c1" {
+		t.Errorf("want c1 stop attempted, got %v", mock.stopped)
+	}
+	if len(mock.removed) != 1 || mock.removed[0] != "c1" {
+		t.Errorf("want c1 removed, got %v", mock.removed)
+	}
+}
+
+func TestDocker_StopAndRemove_MissingContainerIgnored(t *testing.T) {
+	mock := &mockClient{removeErr: errdefs.NotFound(errors.New("no such container"))}
+	d := docker.New(mock)
+	if err := d.StopAndRemove(context.Background(), "c1"); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if len(mock.stopped) != 1 || mock.stopped[0] != "c1" {
+		t.Errorf("want c1 stop attempted, got %v", mock.stopped)
+	}
+	if len(mock.removed) != 1 || mock.removed[0] != "c1" {
+		t.Errorf("want c1 remove attempted, got %v", mock.removed)
 	}
 }
 

--- a/orchestrator/internal/reconciler/reconciler.go
+++ b/orchestrator/internal/reconciler/reconciler.go
@@ -154,8 +154,8 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 				} else {
 					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy, store.StatusReasonDeployStartSucceeded)
 				}
-			} else if c.Running {
-				// Container already running — this is a redeploy; apply start-then-stop.
+			} else {
+				// Any existing container means this is a redeploy; apply start-then-stop.
 				runtimePorts, err := r.docker.StartAndReplace(ctx, d, c.ID)
 				if err != nil {
 					log.Printf("reconciler: redeploy %s (%s): %v", d.ID, d.Name, err)
@@ -163,8 +163,6 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 				} else {
 					r.updatePortsAndStatus(d.ID, runtimePorts, store.StatusHealthy, store.StatusReasonRedeployStartSucceeded)
 				}
-			} else {
-				r.updateStatus(d.ID, store.StatusFailed, exitReason(c.ExitDetails), exitMessage(c.ExitDetails))
 			}
 
 		case store.StatusHealthy:

--- a/orchestrator/internal/reconciler/reconciler_test.go
+++ b/orchestrator/internal/reconciler/reconciler_test.go
@@ -366,7 +366,7 @@ func TestReconcile_Redeploy_FailedNewContainer_KeepsOldAndBecomesFailed(t *testi
 	}
 }
 
-func TestReconcile_DeployingWithStoppedContainer_BecomesFailed(t *testing.T) {
+func TestReconcile_DeployingWithStoppedContainer_RedeploysAndBecomesHealthy(t *testing.T) {
 	s := &mockStore{
 		deployments: []store.Deployment{
 			{ID: "d1", Name: "web", Status: store.StatusDeploying},
@@ -383,11 +383,40 @@ func TestReconcile_DeployingWithStoppedContainer_BecomesFailed(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 
+	if len(d.replaced) != 1 || d.replaced[0] != "c1" {
+		t.Fatalf("want StartAndReplace called with c1, got %v", d.replaced)
+	}
+	if s.getStatus("d1") != store.StatusHealthy {
+		t.Errorf("want status healthy, got %s", s.getStatus("d1"))
+	}
+	if s.getReason("d1") != store.StatusReasonRedeployStartSucceeded {
+		t.Errorf("want reason %q, got %q", store.StatusReasonRedeployStartSucceeded, s.getReason("d1"))
+	}
+}
+
+func TestReconcile_DeployingWithStoppedContainer_RedeployFails_BecomesFailed(t *testing.T) {
+	s := &mockStore{
+		deployments: []store.Deployment{
+			{ID: "d1", Name: "web", Status: store.StatusDeploying},
+		},
+	}
+	d := &mockDocker{
+		containers: []docker.ManagedContainer{
+			{ID: "c1", DeploymentID: "d1", Running: false},
+		},
+		startAndReplaceErr: errors.New("new container did not reach running state"),
+	}
+	r := reconciler.New(s, d, nil)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
 	if s.getStatus("d1") != store.StatusFailed {
 		t.Errorf("want status failed, got %s", s.getStatus("d1"))
 	}
-	if s.getReason("d1") != store.StatusReasonContainerNotRunning {
-		t.Errorf("want reason %q, got %q", store.StatusReasonContainerNotRunning, s.getReason("d1"))
+	if s.getReason("d1") != store.StatusReasonRedeployStartFailed {
+		t.Errorf("want reason %q, got %q", store.StatusReasonRedeployStartFailed, s.getReason("d1"))
 	}
 }
 
@@ -627,10 +656,10 @@ func TestReconcile_HealthyContainerGone_NotifiesFailed(t *testing.T) {
 	}
 }
 
-func TestReconcile_DeployingWithStoppedContainer_OOMKilled_ShowsOOMMessage(t *testing.T) {
+func TestReconcile_HealthyWithStoppedContainer_OOMKilled_ShowsOOMMessage(t *testing.T) {
 	s := &mockStore{
 		deployments: []store.Deployment{
-			{ID: "d1", Name: "web", Status: store.StatusDeploying},
+			{ID: "d1", Name: "web", Status: store.StatusHealthy},
 		},
 	}
 	d := &mockDocker{
@@ -658,10 +687,10 @@ func TestReconcile_DeployingWithStoppedContainer_OOMKilled_ShowsOOMMessage(t *te
 	}
 }
 
-func TestReconcile_DeployingWithStoppedContainer_NonZeroExit_ShowsExitMessage(t *testing.T) {
+func TestReconcile_HealthyWithStoppedContainer_NonZeroExit_ShowsExitMessage(t *testing.T) {
 	s := &mockStore{
 		deployments: []store.Deployment{
-			{ID: "d1", Name: "web", Status: store.StatusDeploying},
+			{ID: "d1", Name: "web", Status: store.StatusHealthy},
 		},
 	}
 	d := &mockDocker{


### PR DESCRIPTION
## Summary
- treat `deploying` deployments with an existing stopped container as a redeploy path (`StartAndReplace`) so env/config updates are applied instead of immediately failing
- harden `StopAndRemove` to tolerate already-stopped/missing containers, which keeps replace fallback paths reliable when old containers are exited
- add reconciler and docker unit coverage for stopped-container redeploy and idempotent stop/remove behavior

## Testing
- go test ./orchestrator/internal/reconciler ./orchestrator/internal/docker