### PR TITLE
feat(config): implement v1 validate, fmt, and export foundation

### DIFF
--- a/api/cmd/lotsen/config.go
+++ b/api/cmd/lotsen/config.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	internalapi "github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/configv1"
+	"github.com/lotsendev/lotsen/store"
+)
+
+var (
+	placeholderCleanupPattern = regexp.MustCompile(`[^A-Z0-9]+`)
+	placeholderPattern        = regexp.MustCompile(`^\$\{LOTSEN_SECRET_[A-Z0-9_]+\}$`)
+	managedVolumeNamePattern  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$`)
+)
+
+func runConfig(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return errors.New("usage: lotsen config <validate|fmt|export> [flags]")
+	}
+
+	switch args[0] {
+	case "validate":
+		return runConfigValidate(args[1:], stdout)
+	case "fmt":
+		return runConfigFmt(args[1:], stdout)
+	case "export":
+		return runConfigExport(args[1:])
+	default:
+		return fmt.Errorf("unknown config command %q", args[0])
+	}
+}
+
+func runConfigValidate(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("config validate", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("f", "", "Path to config file")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("%w\n\nUsage: lotsen config validate -f <file>", err)
+	}
+
+	if strings.TrimSpace(*path) == "" {
+		return errors.New("Usage: lotsen config validate -f <file>")
+	}
+
+	doc, err := readConfigFile(*path)
+	if err != nil {
+		return err
+	}
+
+	if err := configv1.Validate(doc); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+
+	if _, err := fmt.Fprintln(stdout, "config is valid"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runConfigFmt(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("config fmt", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("f", "", "Path to config file")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("%w\n\nUsage: lotsen config fmt -f <file>", err)
+	}
+
+	if strings.TrimSpace(*path) == "" {
+		return errors.New("Usage: lotsen config fmt -f <file>")
+	}
+
+	doc, err := readConfigFile(*path)
+	if err != nil {
+		return err
+	}
+
+	if err := configv1.Validate(doc); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+
+	formatted, err := configv1.MarshalCanonical(doc)
+	if err != nil {
+		return fmt.Errorf("format config: %w", err)
+	}
+
+	if _, err := stdout.Write(formatted); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runConfigExport(args []string) error {
+	fs := flag.NewFlagSet("config export", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("o", "", "Path to output file")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("%w\n\nUsage: lotsen config export -o <file>", err)
+	}
+
+	if strings.TrimSpace(*path) == "" {
+		return errors.New("Usage: lotsen config export -o <file>")
+	}
+
+	doc, err := exportConfigDocument()
+	if err != nil {
+		return err
+	}
+
+	formatted, err := configv1.MarshalCanonical(doc)
+	if err != nil {
+		return fmt.Errorf("marshal exported config: %w", err)
+	}
+
+	if err := os.WriteFile(*path, formatted, 0o644); err != nil {
+		return fmt.Errorf("write export file: %w", err)
+	}
+
+	return nil
+}
+
+func readConfigFile(path string) (configv1.Document, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return configv1.Document{}, fmt.Errorf("open config file: %w", err)
+	}
+	defer f.Close()
+
+	doc, err := configv1.DecodeStrict(f)
+	if err != nil {
+		return configv1.Document{}, fmt.Errorf("decode config file: %w", err)
+	}
+
+	return doc, nil
+}
+
+func exportConfigDocument() (configv1.Document, error) {
+	storePath := dataPath()
+	jsonStore, err := store.NewJSONStore(storePath)
+	if err != nil {
+		return configv1.Document{}, fmt.Errorf("open store: %w", err)
+	}
+
+	deployments, err := jsonStore.List()
+	if err != nil {
+		return configv1.Document{}, fmt.Errorf("list deployments: %w", err)
+	}
+
+	registryExports, err := jsonStore.ListRegistriesForExport()
+	if err != nil {
+		return configv1.Document{}, fmt.Errorf("list registries: %w", err)
+	}
+
+	hostProfileStore, err := internalapi.NewFileHostProfileStore(hostProfilePath(storePath))
+	if err != nil {
+		return configv1.Document{}, fmt.Errorf("open host profile store: %w", err)
+	}
+
+	hostProfile, err := hostProfileStore.Get()
+	if err != nil {
+		return configv1.Document{}, fmt.Errorf("get host profile: %w", err)
+	}
+
+	doc := configv1.Document{
+		APIVersion: configv1.APIVersion,
+		Kind:       configv1.Kind,
+		Spec: &configv1.Spec{
+			Deployments: make([]configv1.Deployment, 0, len(deployments)),
+			Registries:  make([]configv1.Registry, 0, len(registryExports)),
+		},
+	}
+
+	for _, deployment := range deployments {
+		public := deployment.Public
+		entry := configv1.Deployment{
+			Name:      deployment.Name,
+			Image:     deployment.Image,
+			Domain:    deployment.Domain,
+			Public:    &public,
+			Env:       exportEnvMap(deployment.Name, deployment.Envs),
+			Ports:     append([]string{}, deployment.Ports...),
+			Security:  exportSecurity(deployment.Security),
+			BasicAuth: exportBasicAuth(deployment.Name, deployment.BasicAuth),
+		}
+
+		if deployment.ProxyPort > 0 {
+			proxyPort := deployment.ProxyPort
+			entry.ProxyPort = &proxyPort
+		}
+
+		entry.VolumeMounts = exportVolumeMounts(deployment.ID, deployment.Volumes)
+		doc.Spec.Deployments = append(doc.Spec.Deployments, entry)
+	}
+
+	for _, registry := range registryExports {
+		password := registry.Password
+		if !isPlaceholder(password) {
+			password = placeholderFor("REGISTRY_" + registry.Prefix)
+		}
+		doc.Spec.Registries = append(doc.Spec.Registries, configv1.Registry{
+			Prefix:   registry.Prefix,
+			Username: registry.Username,
+			Password: password,
+		})
+	}
+
+	host := configv1.Host{
+		DisplayName:         strings.TrimSpace(hostProfile.DisplayName),
+		DashboardAccessMode: strings.TrimSpace(string(hostProfile.DashboardAccessMode)),
+	}
+
+	if waf := hostProfile.DashboardWAF; waf.Mode != "" || len(waf.IPAllowlist) > 0 || len(waf.CustomRules) > 0 {
+		host.DashboardWAF = &configv1.DashboardWAF{
+			Mode:        strings.TrimSpace(waf.Mode),
+			IPAllowlist: append([]string{}, waf.IPAllowlist...),
+			CustomRules: append([]string{}, waf.CustomRules...),
+		}
+	}
+
+	doc.Spec.Host = &host
+
+	if err := configv1.Validate(doc); err != nil {
+		return configv1.Document{}, fmt.Errorf("validate exported config: %w", err)
+	}
+
+	return doc, nil
+}
+
+func exportSecurity(security *store.SecurityConfig) *configv1.Security {
+	if security == nil {
+		return nil
+	}
+
+	return &configv1.Security{
+		WAFEnabled:  security.WAFEnabled,
+		WAFMode:     security.WAFMode,
+		IPDenylist:  append([]string{}, security.IPDenylist...),
+		IPAllowlist: append([]string{}, security.IPAllowlist...),
+		CustomRules: append([]string{}, security.CustomRules...),
+	}
+}
+
+func exportBasicAuth(deploymentName string, auth *store.BasicAuthConfig) *configv1.BasicAuth {
+	if auth == nil {
+		return nil
+	}
+
+	users := make([]configv1.BasicAuthUser, 0, len(auth.Users))
+	for _, user := range auth.Users {
+		password := user.Password
+		if !isPlaceholder(password) {
+			password = placeholderFor("BASIC_AUTH_" + deploymentName + "_" + user.Username)
+		}
+		users = append(users, configv1.BasicAuthUser{Username: user.Username, Password: password})
+	}
+
+	return &configv1.BasicAuth{Users: users}
+}
+
+func exportEnvMap(deploymentName string, in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		if looksSensitiveEnvKey(key) && !isPlaceholder(value) {
+			out[key] = placeholderFor("ENV_" + deploymentName + "_" + key)
+			continue
+		}
+		out[key] = value
+	}
+
+	return out
+}
+
+func exportVolumeMounts(deploymentID string, bindings []string) []configv1.VolumeMount {
+	if len(bindings) == 0 {
+		return nil
+	}
+
+	mounts := make([]configv1.VolumeMount, 0, len(bindings))
+	for _, binding := range bindings {
+		sep := strings.IndexByte(binding, ':')
+		if sep <= 0 {
+			continue
+		}
+
+		source := binding[:sep]
+		target := binding[sep+1:]
+
+		if managedName, ok := managedVolumeNameForDeployment(deploymentID, source); ok {
+			mounts = append(mounts, configv1.VolumeMount{Mode: "managed", Source: managedName, Target: target})
+			continue
+		}
+
+		mounts = append(mounts, configv1.VolumeMount{Mode: "bind", Source: source, Target: target})
+	}
+
+	return mounts
+}
+
+func managedVolumeNameForDeployment(deploymentID, source string) (string, bool) {
+	base := managedVolumesBaseDirFromEnv()
+	if !filepath.IsAbs(base) {
+		return "", false
+	}
+
+	prefix := filepath.Join(filepath.Clean(base), deploymentID) + string(filepath.Separator)
+	cleanSource := filepath.Clean(strings.TrimSpace(source))
+	if !strings.HasPrefix(cleanSource, prefix) {
+		return "", false
+	}
+
+	name := strings.TrimPrefix(cleanSource, prefix)
+	if strings.Contains(name, string(filepath.Separator)) {
+		return "", false
+	}
+	if !managedVolumeNamePattern.MatchString(name) {
+		return "", false
+	}
+
+	return name, true
+}
+
+func managedVolumesBaseDirFromEnv() string {
+	if dir := strings.TrimSpace(os.Getenv("LOTSEN_MANAGED_VOLUMES_DIR")); dir != "" {
+		return filepath.Clean(dir)
+	}
+	return "/var/lib/lotsen/volumes"
+}
+
+func looksSensitiveEnvKey(key string) bool {
+	normalized := strings.ToUpper(strings.TrimSpace(key))
+	if normalized == "" {
+		return false
+	}
+	keywords := []string{"SECRET", "TOKEN", "PASSWORD", "DATABASE_URL", "PRIVATE_KEY", "API_KEY", "ACCESS_KEY", "_KEY", "KEY_"}
+	for _, keyword := range keywords {
+		if strings.Contains(normalized, keyword) {
+			return true
+		}
+	}
+	return strings.HasSuffix(normalized, "KEY")
+}
+
+func isPlaceholder(value string) bool {
+	return placeholderPattern.MatchString(strings.TrimSpace(value))
+}
+
+func placeholderFor(raw string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(raw))
+	normalized = placeholderCleanupPattern.ReplaceAllString(normalized, "_")
+	normalized = strings.Trim(normalized, "_")
+	if normalized == "" {
+		normalized = "VALUE"
+	}
+	return "${LOTSEN_SECRET_" + normalized + "}"
+}

--- a/api/cmd/lotsen/config_test.go
+++ b/api/cmd/lotsen/config_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	internalapi "github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/configv1"
+	"github.com/lotsendev/lotsen/store"
+)
+
+func TestRunConfigValidate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lotsen.json")
+	err := os.WriteFile(path, []byte(`{"apiVersion":"lotsen/v1","kind":"LotsenConfig","spec":{"deployments":[],"registries":[],"host":{}}}`), 0o644)
+	if err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runConfig([]string{"validate", "-f", path}, &out); err != nil {
+		t.Fatalf("run config validate: %v", err)
+	}
+
+	if strings.TrimSpace(out.String()) != "config is valid" {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestRunConfigExport_DeterministicOutput(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "deployments.json")
+	t.Setenv("LOTSEN_DATA", storePath)
+	t.Setenv("LOTSEN_MANAGED_VOLUMES_DIR", filepath.Join(filepath.Dir(storePath), "volumes"))
+
+	s, err := store.NewJSONStore(storePath)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	created, err := s.Create(store.Deployment{
+		ID:      "dep-z",
+		Name:    "zeta",
+		Image:   "ghcr.io/acme/zeta:1",
+		Envs:    map[string]string{"DATABASE_URL": "postgres://live", "NODE_ENV": "production"},
+		Ports:   []string{"8080:8080", "8443:8443/tcp"},
+		Domain:  "zeta.example.com",
+		Public:  true,
+		Volumes: []string{filepath.Join(filepath.Dir(storePath), "volumes", "dep-z", "db") + ":/var/lib/postgres"},
+		BasicAuth: &store.BasicAuthConfig{Users: []store.BasicAuthUser{
+			{Username: "zz", Password: "not-placeholder"},
+			{Username: "aa", Password: "${LOTSEN_SECRET_EXISTING}"},
+		}},
+		Status: store.StatusHealthy,
+	})
+	if err != nil {
+		t.Fatalf("create deployment: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected created deployment id")
+	}
+
+	if _, err := s.CreateRegistry("r-z", "z.example", "z-user", "z-token"); err != nil {
+		t.Fatalf("create registry z: %v", err)
+	}
+	if _, err := s.CreateRegistry("r-a", "a.example", "a-user", "${LOTSEN_SECRET_ALREADY}"); err != nil {
+		t.Fatalf("create registry a: %v", err)
+	}
+
+	hostStore, err := internalapi.NewFileHostProfileStore(hostProfilePath(storePath))
+	if err != nil {
+		t.Fatalf("new host profile store: %v", err)
+	}
+	_, err = hostStore.Update(internalapi.HostProfile{
+		DisplayName:         "prod-vps-1",
+		DashboardAccessMode: internalapi.DashboardAccessModeWAFAndLogin,
+		DashboardWAF: internalapi.DashboardWAFConfig{
+			Mode:        "detection",
+			IPAllowlist: []string{"203.0.113.0/24"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("update host profile: %v", err)
+	}
+
+	outPath1 := filepath.Join(t.TempDir(), "export-1.json")
+	outPath2 := filepath.Join(t.TempDir(), "export-2.json")
+
+	if err := runConfig([]string{"export", "-o", outPath1}, io.Discard); err != nil {
+		t.Fatalf("first export: %v", err)
+	}
+	if err := runConfig([]string{"export", "-o", outPath2}, io.Discard); err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+
+	b1, err := os.ReadFile(outPath1)
+	if err != nil {
+		t.Fatalf("read first export: %v", err)
+	}
+	b2, err := os.ReadFile(outPath2)
+	if err != nil {
+		t.Fatalf("read second export: %v", err)
+	}
+
+	if string(b1) != string(b2) {
+		t.Fatal("want deterministic export output")
+	}
+
+	doc, err := configv1.DecodeStrict(bytes.NewReader(b1))
+	if err != nil {
+		t.Fatalf("decode export: %v", err)
+	}
+	if err := configv1.Validate(doc); err != nil {
+		t.Fatalf("validate export: %v", err)
+	}
+
+	if len(doc.Spec.Deployments) != 1 {
+		t.Fatalf("want 1 deployment, got %d", len(doc.Spec.Deployments))
+	}
+	if doc.Spec.Deployments[0].BasicAuth == nil || len(doc.Spec.Deployments[0].BasicAuth.Users) != 2 {
+		t.Fatalf("want exported basic auth users, got %#v", doc.Spec.Deployments[0].BasicAuth)
+	}
+	if doc.Spec.Deployments[0].BasicAuth.Users[0].Username != "aa" {
+		t.Fatalf("want sorted users by username, got %#v", doc.Spec.Deployments[0].BasicAuth.Users)
+	}
+	if !strings.HasPrefix(doc.Spec.Deployments[0].Env["DATABASE_URL"], "${LOTSEN_SECRET_") {
+		t.Fatalf("want DATABASE_URL exported as placeholder, got %q", doc.Spec.Deployments[0].Env["DATABASE_URL"])
+	}
+
+	if len(doc.Spec.Registries) != 2 || doc.Spec.Registries[0].Prefix != "a.example" {
+		t.Fatalf("want registries sorted by prefix, got %#v", doc.Spec.Registries)
+	}
+	if doc.Spec.Host == nil || doc.Spec.Host.DashboardAccessMode != "waf_and_login" {
+		t.Fatalf("want host settings in export, got %#v", doc.Spec.Host)
+	}
+}

--- a/api/cmd/lotsen/main.go
+++ b/api/cmd/lotsen/main.go
@@ -32,6 +32,14 @@ func dataPath() string {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "config" {
+		if err := runConfig(os.Args[2:], os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	s, err := store.NewJSONStore(dataPath())
 	if err != nil {
 		log.Fatalf("lotsen: open store: %v", err)

--- a/api/internal/configv1/config.go
+++ b/api/internal/configv1/config.go
@@ -1,0 +1,508 @@
+package configv1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const (
+	APIVersion = "lotsen/v1"
+	Kind       = "LotsenConfig"
+)
+
+var (
+	placeholderPattern       = regexp.MustCompile(`^\$\{LOTSEN_SECRET_[A-Z0-9_]+\}$`)
+	managedVolumeNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$`)
+	dirModePattern           = regexp.MustCompile(`^[0-7]{4}$`)
+)
+
+type Document struct {
+	APIVersion string    `json:"apiVersion"`
+	Kind       string    `json:"kind"`
+	Metadata   *Metadata `json:"metadata,omitempty"`
+	Spec       *Spec     `json:"spec"`
+}
+
+type Metadata struct {
+	Name        string            `json:"name,omitempty"`
+	Environment string            `json:"environment,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+}
+
+type Spec struct {
+	Deployments []Deployment `json:"deployments,omitempty"`
+	Registries  []Registry   `json:"registries,omitempty"`
+	Host        *Host        `json:"host,omitempty"`
+}
+
+type Deployment struct {
+	Name         string            `json:"name"`
+	Image        string            `json:"image"`
+	Domain       string            `json:"domain"`
+	Public       *bool             `json:"public"`
+	Env          map[string]string `json:"env,omitempty"`
+	Ports        []string          `json:"ports,omitempty"`
+	ProxyPort    *int              `json:"proxyPort,omitempty"`
+	VolumeMounts []VolumeMount     `json:"volumeMounts,omitempty"`
+	BasicAuth    *BasicAuth        `json:"basicAuth,omitempty"`
+	Security     *Security         `json:"security,omitempty"`
+}
+
+type VolumeMount struct {
+	Mode    string `json:"mode"`
+	Source  string `json:"source"`
+	Target  string `json:"target"`
+	UID     *int   `json:"uid,omitempty"`
+	GID     *int   `json:"gid,omitempty"`
+	DirMode string `json:"dirMode,omitempty"`
+}
+
+type BasicAuth struct {
+	Users []BasicAuthUser `json:"users"`
+}
+
+type BasicAuthUser struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type Security struct {
+	WAFEnabled  bool     `json:"wafEnabled"`
+	WAFMode     string   `json:"wafMode,omitempty"`
+	IPDenylist  []string `json:"ipDenylist,omitempty"`
+	IPAllowlist []string `json:"ipAllowlist,omitempty"`
+	CustomRules []string `json:"customRules,omitempty"`
+}
+
+type Registry struct {
+	Prefix   string `json:"prefix"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type Host struct {
+	DisplayName         string        `json:"displayName,omitempty"`
+	DashboardAccessMode string        `json:"dashboardAccessMode,omitempty"`
+	DashboardWAF        *DashboardWAF `json:"dashboardWaf,omitempty"`
+}
+
+type DashboardWAF struct {
+	Mode        string   `json:"mode,omitempty"`
+	IPAllowlist []string `json:"ipAllowlist,omitempty"`
+	CustomRules []string `json:"customRules,omitempty"`
+}
+
+func DecodeStrict(r io.Reader) (Document, error) {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+
+	var doc Document
+	if err := dec.Decode(&doc); err != nil {
+		return Document{}, err
+	}
+
+	var trailing any
+	if err := dec.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return Document{}, fmt.Errorf("expected a single JSON object")
+		}
+		return Document{}, err
+	}
+
+	return doc, nil
+}
+
+func MarshalCanonical(doc Document) ([]byte, error) {
+	canonical := Canonicalize(doc)
+	out, err := json.MarshalIndent(canonical, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}
+
+func Canonicalize(doc Document) Document {
+	canonical := doc
+
+	if canonical.Spec == nil {
+		return canonical
+	}
+
+	deployments := make([]Deployment, 0, len(canonical.Spec.Deployments))
+	for _, deployment := range canonical.Spec.Deployments {
+		copied := deployment
+		if deployment.Env != nil {
+			copied.Env = cloneMap(deployment.Env)
+		}
+		if deployment.Ports != nil {
+			copied.Ports = slices.Clone(deployment.Ports)
+		}
+		if deployment.VolumeMounts != nil {
+			copied.VolumeMounts = slices.Clone(deployment.VolumeMounts)
+		}
+		if deployment.BasicAuth != nil {
+			users := slices.Clone(deployment.BasicAuth.Users)
+			slices.SortFunc(users, func(a, b BasicAuthUser) int {
+				return strings.Compare(a.Username, b.Username)
+			})
+			copied.BasicAuth = &BasicAuth{Users: users}
+		}
+		if deployment.Security != nil {
+			sec := *deployment.Security
+			sec.IPDenylist = slices.Clone(sec.IPDenylist)
+			sec.IPAllowlist = slices.Clone(sec.IPAllowlist)
+			sec.CustomRules = slices.Clone(sec.CustomRules)
+			copied.Security = &sec
+		}
+		deployments = append(deployments, copied)
+	}
+	slices.SortFunc(deployments, func(a, b Deployment) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	registries := slices.Clone(canonical.Spec.Registries)
+	slices.SortFunc(registries, func(a, b Registry) int {
+		return strings.Compare(a.Prefix, b.Prefix)
+	})
+
+	var host *Host
+	if canonical.Spec.Host != nil {
+		copied := *canonical.Spec.Host
+		if canonical.Spec.Host.DashboardWAF != nil {
+			waf := *canonical.Spec.Host.DashboardWAF
+			waf.IPAllowlist = slices.Clone(waf.IPAllowlist)
+			waf.CustomRules = slices.Clone(waf.CustomRules)
+			copied.DashboardWAF = &waf
+		}
+		host = &copied
+	}
+
+	canonical.Spec = &Spec{Deployments: deployments, Registries: registries, Host: host}
+
+	if canonical.Metadata != nil {
+		metadata := *canonical.Metadata
+		metadata.Labels = cloneMap(metadata.Labels)
+		canonical.Metadata = &metadata
+	}
+
+	return canonical
+}
+
+func Validate(doc Document) error {
+	errList := make([]string, 0)
+	addErr := func(path string, message string) {
+		errList = append(errList, fmt.Sprintf("%s: %s", path, message))
+	}
+
+	if doc.APIVersion != APIVersion {
+		addErr("apiVersion", fmt.Sprintf("must equal %q", APIVersion))
+	}
+	if doc.Kind != Kind {
+		addErr("kind", fmt.Sprintf("must equal %q", Kind))
+	}
+	if doc.Spec == nil {
+		addErr("spec", "is required")
+	}
+
+	if doc.Metadata != nil {
+		if doc.Metadata.Name != "" && len(doc.Metadata.Name) > 63 {
+			addErr("metadata.name", "must be 1..63 characters")
+		}
+		for key, value := range doc.Metadata.Labels {
+			if strings.TrimSpace(key) == "" {
+				addErr("metadata.labels", "keys must be non-empty")
+			}
+			if strings.TrimSpace(value) == "" {
+				addErr("metadata.labels."+key, "value must be non-empty")
+			}
+		}
+	}
+
+	if doc.Spec != nil {
+		deploymentNames := make(map[string]struct{}, len(doc.Spec.Deployments))
+		for i, deployment := range doc.Spec.Deployments {
+			path := fmt.Sprintf("spec.deployments[%d]", i)
+			if strings.TrimSpace(deployment.Name) == "" {
+				addErr(path+".name", "is required")
+			} else {
+				if _, exists := deploymentNames[deployment.Name]; exists {
+					addErr(path+".name", "must be unique")
+				}
+				deploymentNames[deployment.Name] = struct{}{}
+			}
+			if strings.TrimSpace(deployment.Image) == "" {
+				addErr(path+".image", "is required")
+			}
+			if strings.TrimSpace(deployment.Domain) == "" {
+				addErr(path+".domain", "is required")
+			}
+			if deployment.Public == nil {
+				addErr(path+".public", "is required")
+			}
+
+			containerTCPPorts := make(map[int]struct{})
+			for portIndex, rawPort := range deployment.Ports {
+				spec, err := parsePortSpec(rawPort)
+				if err != nil {
+					addErr(fmt.Sprintf("%s.ports[%d]", path, portIndex), err.Error())
+					continue
+				}
+				if spec.Protocol == "tcp" {
+					containerTCPPorts[spec.ContainerPort] = struct{}{}
+				}
+			}
+
+			if deployment.ProxyPort != nil {
+				if *deployment.ProxyPort < 1 || *deployment.ProxyPort > 65535 {
+					addErr(path+".proxyPort", "must be between 1 and 65535")
+				} else if _, ok := containerTCPPorts[*deployment.ProxyPort]; !ok {
+					addErr(path+".proxyPort", "must match a TCP container port in ports")
+				}
+			}
+
+			for key, value := range deployment.Env {
+				if strings.TrimSpace(key) == "" {
+					addErr(path+".env", "keys must be non-empty")
+					continue
+				}
+				if looksSensitiveEnvKey(key) && !isPlaceholder(value) {
+					addErr(path+".env."+key, "must use a ${LOTSEN_SECRET_*} placeholder")
+				}
+			}
+
+			for mountIndex, mount := range deployment.VolumeMounts {
+				mountPath := fmt.Sprintf("%s.volumeMounts[%d]", path, mountIndex)
+				mode := strings.ToLower(strings.TrimSpace(mount.Mode))
+				target := filepath.Clean(strings.TrimSpace(mount.Target))
+				if mode != "managed" && mode != "bind" {
+					addErr(mountPath+".mode", "must be managed or bind")
+				}
+				if strings.TrimSpace(mount.Source) == "" {
+					addErr(mountPath+".source", "is required")
+				}
+				if target == "." || !filepath.IsAbs(target) {
+					addErr(mountPath+".target", "must be an absolute path")
+				}
+
+				if mode == "managed" {
+					if !managedVolumeNamePattern.MatchString(strings.TrimSpace(mount.Source)) {
+						addErr(mountPath+".source", "must match managed volume name pattern")
+					}
+					if mount.UID != nil && *mount.UID < 0 {
+						addErr(mountPath+".uid", "must be >= 0")
+					}
+					if mount.GID != nil && *mount.GID < 0 {
+						addErr(mountPath+".gid", "must be >= 0")
+					}
+					if mount.DirMode != "" && !dirModePattern.MatchString(strings.TrimSpace(mount.DirMode)) {
+						addErr(mountPath+".dirMode", "must be an octal permission between 0000 and 0777")
+					}
+				}
+
+				if mode == "bind" {
+					if source := filepath.Clean(strings.TrimSpace(mount.Source)); source == "." || !filepath.IsAbs(source) {
+						addErr(mountPath+".source", "must be an absolute path for bind mounts")
+					}
+					if mount.UID != nil || mount.GID != nil || strings.TrimSpace(mount.DirMode) != "" {
+						addErr(mountPath, "uid, gid, and dirMode are only supported for managed mounts")
+					}
+				}
+			}
+
+			if deployment.BasicAuth != nil {
+				if len(deployment.BasicAuth.Users) == 0 {
+					addErr(path+".basicAuth.users", "must not be empty")
+				}
+				usernames := make(map[string]struct{}, len(deployment.BasicAuth.Users))
+				for userIndex, user := range deployment.BasicAuth.Users {
+					userPath := fmt.Sprintf("%s.basicAuth.users[%d]", path, userIndex)
+					if strings.TrimSpace(user.Username) == "" {
+						addErr(userPath+".username", "is required")
+					} else {
+						if _, exists := usernames[user.Username]; exists {
+							addErr(userPath+".username", "must be unique")
+						}
+						usernames[user.Username] = struct{}{}
+					}
+					if !isPlaceholder(user.Password) {
+						addErr(userPath+".password", "must use a ${LOTSEN_SECRET_*} placeholder")
+					}
+				}
+			}
+
+			if deployment.Security != nil {
+				if deployment.Security.WAFMode != "" {
+					mode := strings.ToLower(strings.TrimSpace(deployment.Security.WAFMode))
+					if mode != "detection" && mode != "enforcement" {
+						addErr(path+".security.wafMode", "must be detection or enforcement")
+					}
+				}
+
+				for idx, entry := range deployment.Security.IPDenylist {
+					if !isValidCIDRorIP(entry) {
+						addErr(fmt.Sprintf("%s.security.ipDenylist[%d]", path, idx), "must be a valid CIDR or IP")
+					}
+				}
+				for idx, entry := range deployment.Security.IPAllowlist {
+					if !isValidCIDRorIP(entry) {
+						addErr(fmt.Sprintf("%s.security.ipAllowlist[%d]", path, idx), "must be a valid CIDR or IP")
+					}
+				}
+			}
+		}
+
+		registryPrefixes := make(map[string]struct{}, len(doc.Spec.Registries))
+		for i, registry := range doc.Spec.Registries {
+			path := fmt.Sprintf("spec.registries[%d]", i)
+			if strings.TrimSpace(registry.Prefix) == "" {
+				addErr(path+".prefix", "is required")
+			} else {
+				if _, exists := registryPrefixes[registry.Prefix]; exists {
+					addErr(path+".prefix", "must be unique")
+				}
+				registryPrefixes[registry.Prefix] = struct{}{}
+			}
+			if strings.TrimSpace(registry.Username) == "" {
+				addErr(path+".username", "is required")
+			}
+			if !isPlaceholder(registry.Password) {
+				addErr(path+".password", "must use a ${LOTSEN_SECRET_*} placeholder")
+			}
+		}
+
+		if doc.Spec.Host != nil {
+			host := doc.Spec.Host
+			if host.DashboardAccessMode != "" {
+				mode := strings.ToLower(strings.TrimSpace(host.DashboardAccessMode))
+				if mode != "login_only" && mode != "waf_only" && mode != "waf_and_login" {
+					addErr("spec.host.dashboardAccessMode", "must be login_only, waf_only, or waf_and_login")
+				}
+			}
+			if host.DashboardWAF != nil {
+				if host.DashboardWAF.Mode != "" {
+					mode := strings.ToLower(strings.TrimSpace(host.DashboardWAF.Mode))
+					if mode != "detection" && mode != "enforcement" {
+						addErr("spec.host.dashboardWaf.mode", "must be detection or enforcement")
+					}
+				}
+				for i, entry := range host.DashboardWAF.IPAllowlist {
+					if !isValidCIDRorIP(entry) {
+						addErr(fmt.Sprintf("spec.host.dashboardWaf.ipAllowlist[%d]", i), "must be a valid CIDR or IP")
+					}
+				}
+			}
+		}
+	}
+
+	if len(errList) > 0 {
+		return errors.New(strings.Join(errList, "; "))
+	}
+	return nil
+}
+
+type portSpec struct {
+	HostPort      int
+	ContainerPort int
+	Protocol      string
+}
+
+func parsePortSpec(raw string) (portSpec, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return portSpec{}, fmt.Errorf("port mapping must not be empty")
+	}
+
+	mainPart, protocol, hasProtocol := strings.Cut(raw, "/")
+	if hasProtocol {
+		protocol = strings.ToLower(strings.TrimSpace(protocol))
+		if protocol != "tcp" && protocol != "udp" {
+			return portSpec{}, fmt.Errorf("invalid protocol %q", protocol)
+		}
+	} else {
+		protocol = "tcp"
+	}
+
+	parts := strings.Split(mainPart, ":")
+	if len(parts) > 2 {
+		return portSpec{}, fmt.Errorf("invalid port mapping %q", raw)
+	}
+
+	containerPort, err := parseValidPortNumber(parts[len(parts)-1])
+	if err != nil {
+		return portSpec{}, err
+	}
+
+	spec := portSpec{ContainerPort: containerPort, Protocol: protocol}
+	if len(parts) == 1 {
+		return spec, nil
+	}
+
+	hostPort, err := parseValidPortNumber(parts[0])
+	if err != nil {
+		return portSpec{}, err
+	}
+	spec.HostPort = hostPort
+
+	return spec, nil
+}
+
+func parseValidPortNumber(raw string) (int, error) {
+	port, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("port must be numeric")
+	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("port must be between 1 and 65535")
+	}
+	return port, nil
+}
+
+func looksSensitiveEnvKey(key string) bool {
+	normalized := strings.ToUpper(strings.TrimSpace(key))
+	if normalized == "" {
+		return false
+	}
+
+	keywords := []string{"SECRET", "TOKEN", "PASSWORD", "DATABASE_URL", "PRIVATE_KEY", "API_KEY", "ACCESS_KEY", "_KEY", "KEY_"}
+	for _, keyword := range keywords {
+		if strings.Contains(normalized, keyword) {
+			return true
+		}
+	}
+
+	return strings.HasSuffix(normalized, "KEY")
+}
+
+func isPlaceholder(value string) bool {
+	return placeholderPattern.MatchString(strings.TrimSpace(value))
+}
+
+func isValidCIDRorIP(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if _, _, err := net.ParseCIDR(value); err == nil {
+		return true
+	}
+	return net.ParseIP(value) != nil
+}
+
+func cloneMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/api/internal/configv1/config_test.go
+++ b/api/internal/configv1/config_test.go
@@ -1,0 +1,95 @@
+package configv1
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeStrict_RejectsUnknownFields(t *testing.T) {
+	_, err := DecodeStrict(strings.NewReader(`{"apiVersion":"lotsen/v1","kind":"LotsenConfig","spec":{},"extra":true}`))
+	if err == nil {
+		t.Fatal("want strict decoding error for unknown top-level field")
+	}
+}
+
+func TestValidate_ReportsSemanticErrors(t *testing.T) {
+	public := true
+	proxyPort := 8443
+
+	doc := Document{
+		APIVersion: APIVersion,
+		Kind:       Kind,
+		Spec: &Spec{Deployments: []Deployment{{
+			Name:      "web",
+			Image:     "ghcr.io/acme/web:1.2.3",
+			Domain:    "app.example.com",
+			Public:    &public,
+			Ports:     []string{"8080:8080"},
+			ProxyPort: &proxyPort,
+		}}},
+	}
+
+	err := Validate(doc)
+	if err == nil {
+		t.Fatal("want validation error")
+	}
+	if !strings.Contains(err.Error(), "proxyPort") {
+		t.Fatalf("want proxyPort validation error, got %v", err)
+	}
+}
+
+func TestMarshalCanonical_SortsListsDeterministically(t *testing.T) {
+	public := true
+	doc := Document{
+		APIVersion: APIVersion,
+		Kind:       Kind,
+		Spec: &Spec{
+			Deployments: []Deployment{
+				{
+					Name:   "zeta",
+					Image:  "ghcr.io/acme/zeta:1.0",
+					Domain: "zeta.example.com",
+					Public: &public,
+					BasicAuth: &BasicAuth{Users: []BasicAuthUser{
+						{Username: "zz", Password: "${LOTSEN_SECRET_ZZ}"},
+						{Username: "aa", Password: "${LOTSEN_SECRET_AA}"},
+					}},
+				},
+				{
+					Name:   "alpha",
+					Image:  "ghcr.io/acme/alpha:1.0",
+					Domain: "alpha.example.com",
+					Public: &public,
+				},
+			},
+			Registries: []Registry{
+				{Prefix: "z.example", Username: "z", Password: "${LOTSEN_SECRET_Z}"},
+				{Prefix: "a.example", Username: "a", Password: "${LOTSEN_SECRET_A}"},
+			},
+		},
+	}
+
+	first, err := MarshalCanonical(doc)
+	if err != nil {
+		t.Fatalf("marshal canonical: %v", err)
+	}
+	second, err := MarshalCanonical(doc)
+	if err != nil {
+		t.Fatalf("marshal canonical second run: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Fatal("want deterministic canonical output across runs")
+	}
+
+	out := string(first)
+	if strings.Index(out, `"name": "alpha"`) > strings.Index(out, `"name": "zeta"`) {
+		t.Fatalf("want deployments sorted by name, got %s", out)
+	}
+	if strings.Index(out, `"prefix": "a.example"`) > strings.Index(out, `"prefix": "z.example"`) {
+		t.Fatalf("want registries sorted by prefix, got %s", out)
+	}
+	if strings.Index(out, `"username": "aa"`) > strings.Index(out, `"username": "zz"`) {
+		t.Fatalf("want nested users sorted by username, got %s", out)
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -111,6 +111,12 @@ type RegistryAuth struct {
 	Password string
 }
 
+type RegistryExport struct {
+	Prefix   string
+	Username string
+	Password string
+}
+
 type persistedState struct {
 	Deployments []Deployment `json:"deployments"`
 	Registries  []Registry   `json:"registries,omitempty"`
@@ -451,6 +457,32 @@ func (s *JSONStore) ResolveRegistryAuth(imageRef string) (*RegistryAuth, error) 
 	}
 
 	return &RegistryAuth{Username: match.Username, Password: password}, nil
+}
+
+func (s *JSONStore) ListRegistriesForExport() ([]RegistryExport, error) {
+	var result []RegistryExport
+	err := s.withRLock(func() error {
+		state, err := s.readState()
+		if err != nil {
+			return err
+		}
+
+		result = make([]RegistryExport, 0, len(state.Registries))
+		for _, entry := range state.Registries {
+			password, err := s.decryptSecret(entry.Secret)
+			if err != nil {
+				return err
+			}
+			result = append(result, RegistryExport{Prefix: entry.Prefix, Username: entry.Username, Password: password})
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 func normalizeRegistryPrefix(prefix string) string {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -592,3 +592,35 @@ func TestJSONStore_ResolveRegistryAuth_LongestPrefixWins(t *testing.T) {
 		t.Fatalf("want nil for public image, got %#v", auth)
 	}
 }
+
+func TestJSONStore_ListRegistriesForExport(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deployments.json")
+	s, err := store.NewJSONStore(path)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	_, err = s.CreateRegistry("r1", "ghcr.io", "alice", "token-a")
+	if err != nil {
+		t.Fatalf("create registry r1: %v", err)
+	}
+	_, err = s.CreateRegistry("r2", "docker.io/myorg", "bob", "token-b")
+	if err != nil {
+		t.Fatalf("create registry r2: %v", err)
+	}
+
+	registries, err := s.ListRegistriesForExport()
+	if err != nil {
+		t.Fatalf("list registries for export: %v", err)
+	}
+	if len(registries) != 2 {
+		t.Fatalf("want 2 registries, got %d", len(registries))
+	}
+
+	if registries[0].Prefix != "ghcr.io" || registries[0].Username != "alice" || registries[0].Password != "token-a" {
+		t.Fatalf("unexpected first registry export: %#v", registries[0])
+	}
+	if registries[1].Prefix != "docker.io/myorg" || registries[1].Username != "bob" || registries[1].Password != "token-b" {
+		t.Fatalf("unexpected second registry export: %#v", registries[1])
+	}
+}


### PR DESCRIPTION
## Summary
- Add a new `configv1` module with strict JSON decoding, schema/semantic validation, and canonical JSON formatting with deterministic ordering.
- Add `lotsen config validate`, `lotsen config fmt`, and `lotsen config export` commands to the API binary CLI entrypoint.
- Export live deployments, registries, and host settings into canonical `lotsen/v1` config, converting protected plaintext values to deterministic `${LOTSEN_SECRET_*}` placeholders.
- Extend store capabilities with registry export (decrypted for export pipeline use) and add behavior-focused tests for validation, canonicalization, export determinism, and store export behavior.

## Testing
- `go test ./...` (in `api`)
- `go test ./...` (in `store`)

Closes #240.