### PR TITLE
feat(deployments): add managed config file mounts

### DIFF
--- a/api/cmd/lotsen/config.go
+++ b/api/cmd/lotsen/config.go
@@ -245,6 +245,7 @@ func exportConfigDocument() (configv1.Document, error) {
 		}
 
 		entry.VolumeMounts = exportVolumeMounts(deployment.ID, deployment.Volumes)
+		entry.FileMounts = exportFileMounts(deployment.FileMounts)
 		doc.Spec.Deployments = append(doc.Spec.Deployments, entry)
 	}
 
@@ -351,6 +352,28 @@ func exportVolumeMounts(deploymentID string, bindings []string) []configv1.Volum
 		}
 
 		mounts = append(mounts, configv1.VolumeMount{Mode: "bind", Source: source, Target: target})
+	}
+
+	return mounts
+}
+
+func exportFileMounts(fileMounts []store.FileMount) []configv1.FileMount {
+	if len(fileMounts) == 0 {
+		return nil
+	}
+
+	mounts := make([]configv1.FileMount, 0, len(fileMounts))
+	for _, mount := range fileMounts {
+		copied := configv1.FileMount{
+			Source:   strings.TrimSpace(mount.Source),
+			Target:   strings.TrimSpace(mount.Target),
+			Content:  mount.Content,
+			UID:      mount.UID,
+			GID:      mount.GID,
+			FileMode: strings.TrimSpace(mount.FileMode),
+			ReadOnly: mount.ReadOnly,
+		}
+		mounts = append(mounts, copied)
 	}
 
 	return mounts

--- a/api/cmd/lotsen/config.go
+++ b/api/cmd/lotsen/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	internalapi "github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/configplan"
 	"github.com/lotsendev/lotsen/internal/configv1"
 	"github.com/lotsendev/lotsen/store"
 )
@@ -23,7 +24,7 @@ var (
 
 func runConfig(args []string, stdout io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("usage: lotsen config <validate|fmt|export> [flags]")
+		return errors.New("usage: lotsen config <validate|fmt|export|plan> [flags]")
 	}
 
 	switch args[0] {
@@ -33,9 +34,55 @@ func runConfig(args []string, stdout io.Writer) error {
 		return runConfigFmt(args[1:], stdout)
 	case "export":
 		return runConfigExport(args[1:])
+	case "plan":
+		return runConfigPlan(args[1:])
 	default:
 		return fmt.Errorf("unknown config command %q", args[0])
 	}
+}
+
+func runConfigPlan(args []string) error {
+	fs := flag.NewFlagSet("config plan", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("f", "", "Path to config file")
+	outPath := fs.String("out", "", "Path to plan file")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("%w\n\nUsage: lotsen config plan -f <file> --out <plan-file>", err)
+	}
+
+	if strings.TrimSpace(*configPath) == "" || strings.TrimSpace(*outPath) == "" {
+		return errors.New("Usage: lotsen config plan -f <file> --out <plan-file>")
+	}
+
+	desired, err := readConfigFile(*configPath)
+	if err != nil {
+		return err
+	}
+
+	if err := configv1.Validate(desired); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+
+	live, err := exportConfigDocument()
+	if err != nil {
+		return fmt.Errorf("export live state: %w", err)
+	}
+
+	planDoc, err := configplan.Build(desired, live)
+	if err != nil {
+		return fmt.Errorf("build plan: %w", err)
+	}
+
+	formatted, err := configplan.MarshalCanonical(planDoc)
+	if err != nil {
+		return fmt.Errorf("marshal plan: %w", err)
+	}
+
+	if err := os.WriteFile(*outPath, formatted, 0o644); err != nil {
+		return fmt.Errorf("write plan file: %w", err)
+	}
+
+	return nil
 }
 
 func runConfigValidate(args []string, stdout io.Writer) error {

--- a/api/cmd/lotsen/config_test.go
+++ b/api/cmd/lotsen/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	internalapi "github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/configplan"
 	"github.com/lotsendev/lotsen/internal/configv1"
 	"github.com/lotsendev/lotsen/store"
 )
@@ -134,5 +136,142 @@ func TestRunConfigExport_DeterministicOutput(t *testing.T) {
 	}
 	if doc.Spec.Host == nil || doc.Spec.Host.DashboardAccessMode != "waf_and_login" {
 		t.Fatalf("want host settings in export, got %#v", doc.Spec.Host)
+	}
+}
+
+func TestRunConfigPlan_DeterministicOutputAndSections(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "deployments.json")
+	t.Setenv("LOTSEN_DATA", storePath)
+	t.Setenv("LOTSEN_MANAGED_VOLUMES_DIR", filepath.Join(filepath.Dir(storePath), "volumes"))
+
+	s, err := store.NewJSONStore(storePath)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	if _, err := s.Create(store.Deployment{ID: "dep-update", Name: "app", Image: "ghcr.io/acme/app:1", Domain: "old.example.com", Public: true, Status: store.StatusHealthy}); err != nil {
+		t.Fatalf("create update deployment: %v", err)
+	}
+	if _, err := s.Create(store.Deployment{ID: "dep-delete", Name: "legacy", Image: "ghcr.io/acme/legacy:1", Domain: "legacy.example.com", Public: true, Status: store.StatusHealthy}); err != nil {
+		t.Fatalf("create delete deployment: %v", err)
+	}
+
+	if _, err := s.CreateRegistry("r-keep", "a.example", "user-a", "token-a"); err != nil {
+		t.Fatalf("create keep registry: %v", err)
+	}
+	if _, err := s.CreateRegistry("r-delete", "c.example", "user-c", "token-c"); err != nil {
+		t.Fatalf("create delete registry: %v", err)
+	}
+
+	hostStore, err := internalapi.NewFileHostProfileStore(hostProfilePath(storePath))
+	if err != nil {
+		t.Fatalf("new host profile store: %v", err)
+	}
+	if _, err := hostStore.Update(internalapi.HostProfile{DisplayName: "old-host", DashboardAccessMode: internalapi.DashboardAccessModeLoginOnly}); err != nil {
+		t.Fatalf("update host profile: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "desired.json")
+	desired := `{
+  "apiVersion": "lotsen/v1",
+  "kind": "LotsenConfig",
+  "spec": {
+    "deployments": [
+      {
+        "name": "app",
+        "image": "ghcr.io/acme/app:2",
+        "domain": "app.example.com",
+        "public": true
+      },
+      {
+        "name": "new",
+        "image": "ghcr.io/acme/new:1",
+        "domain": "new.example.com",
+        "public": true
+      }
+    ],
+    "registries": [
+      {
+        "prefix": "a.example",
+        "username": "user-a",
+        "password": "${LOTSEN_SECRET_NEW_A}"
+      },
+      {
+        "prefix": "b.example",
+        "username": "user-b",
+        "password": "${LOTSEN_SECRET_B}"
+      }
+    ],
+    "host": {
+      "displayName": "prod-vps-1",
+      "dashboardAccessMode": "waf_and_login"
+    }
+  }
+}`
+
+	if err := os.WriteFile(configPath, []byte(desired), 0o644); err != nil {
+		t.Fatalf("write desired config: %v", err)
+	}
+
+	planPath1 := filepath.Join(t.TempDir(), "plan-1.json")
+	planPath2 := filepath.Join(t.TempDir(), "plan-2.json")
+
+	if err := runConfig([]string{"plan", "-f", configPath, "--out", planPath1}, io.Discard); err != nil {
+		t.Fatalf("first plan run: %v", err)
+	}
+	if err := runConfig([]string{"plan", "-f", configPath, "--out", planPath2}, io.Discard); err != nil {
+		t.Fatalf("second plan run: %v", err)
+	}
+
+	b1, err := os.ReadFile(planPath1)
+	if err != nil {
+		t.Fatalf("read first plan: %v", err)
+	}
+	b2, err := os.ReadFile(planPath2)
+	if err != nil {
+		t.Fatalf("read second plan: %v", err)
+	}
+
+	if string(b1) != string(b2) {
+		t.Fatal("want deterministic plan output")
+	}
+
+	var plan configplan.Document
+	if err := json.Unmarshal(b1, &plan); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+
+	if plan.Fingerprint == "" {
+		t.Fatal("want non-empty fingerprint")
+	}
+	if len(plan.Actions.Deployments.Create) != 1 || plan.Actions.Deployments.Create[0].Resource != "new" {
+		t.Fatalf("unexpected deployment create actions: %#v", plan.Actions.Deployments.Create)
+	}
+	if len(plan.Actions.Deployments.Update) != 1 || plan.Actions.Deployments.Update[0].Resource != "app" {
+		t.Fatalf("unexpected deployment update actions: %#v", plan.Actions.Deployments.Update)
+	}
+	if len(plan.Actions.Deployments.Delete) != 1 || plan.Actions.Deployments.Delete[0].Resource != "legacy" {
+		t.Fatalf("unexpected deployment delete actions: %#v", plan.Actions.Deployments.Delete)
+	}
+
+	if len(plan.Actions.Registries.Create) != 1 || plan.Actions.Registries.Create[0].Resource != "b.example" {
+		t.Fatalf("unexpected registry create actions: %#v", plan.Actions.Registries.Create)
+	}
+	if len(plan.Actions.Registries.Noop) != 1 || plan.Actions.Registries.Noop[0].Resource != "a.example" {
+		t.Fatalf("unexpected registry noop actions: %#v", plan.Actions.Registries.Noop)
+	}
+	if len(plan.Actions.Registries.Delete) != 1 || plan.Actions.Registries.Delete[0].Resource != "c.example" {
+		t.Fatalf("unexpected registry delete actions: %#v", plan.Actions.Registries.Delete)
+	}
+
+	if len(plan.Actions.Host.Update) != 1 || plan.Actions.Host.Update[0].Resource != "host" {
+		t.Fatalf("unexpected host actions: %#v", plan.Actions.Host)
+	}
+
+	if len(plan.Destructive.Deployments) != 1 || plan.Destructive.Deployments[0].Resource != "legacy" {
+		t.Fatalf("unexpected destructive deployment actions: %#v", plan.Destructive.Deployments)
+	}
+	if len(plan.Destructive.Registries) != 1 || plan.Destructive.Registries[0].Resource != "c.example" {
+		t.Fatalf("unexpected destructive registry actions: %#v", plan.Destructive.Registries)
 	}
 }

--- a/api/cmd/lotsen/config_test.go
+++ b/api/cmd/lotsen/config_test.go
@@ -51,6 +51,9 @@ func TestRunConfigExport_DeterministicOutput(t *testing.T) {
 		Domain:  "zeta.example.com",
 		Public:  true,
 		Volumes: []string{filepath.Join(filepath.Dir(storePath), "volumes", "dep-z", "db") + ":/var/lib/postgres"},
+		FileMounts: []store.FileMount{
+			{Source: "prometheus.yml", Target: "/etc/prometheus/prometheus.yml", Content: "global:\n", ReadOnly: true},
+		},
 		BasicAuth: &store.BasicAuthConfig{Users: []store.BasicAuthUser{
 			{Username: "zz", Password: "not-placeholder"},
 			{Username: "aa", Password: "${LOTSEN_SECRET_EXISTING}"},
@@ -129,6 +132,9 @@ func TestRunConfigExport_DeterministicOutput(t *testing.T) {
 	}
 	if !strings.HasPrefix(doc.Spec.Deployments[0].Env["DATABASE_URL"], "${LOTSEN_SECRET_") {
 		t.Fatalf("want DATABASE_URL exported as placeholder, got %q", doc.Spec.Deployments[0].Env["DATABASE_URL"])
+	}
+	if len(doc.Spec.Deployments[0].FileMounts) != 1 || doc.Spec.Deployments[0].FileMounts[0].Source != "prometheus.yml" {
+		t.Fatalf("want exported file mount, got %#v", doc.Spec.Deployments[0].FileMounts)
 	}
 
 	if len(doc.Spec.Registries) != 2 || doc.Spec.Registries[0].Prefix != "a.example" {

--- a/api/internal/api/handler.go
+++ b/api/internal/api/handler.go
@@ -114,6 +114,7 @@ type deploymentRequest struct {
 	ProxyPort    int                   `json:"proxy_port"`
 	Volumes      []string              `json:"volumes"`
 	VolumeMounts []volumeMountRequest  `json:"volume_mounts"`
+	FileMounts   []fileMountRequest    `json:"file_mounts"`
 	Domain       string                `json:"domain"`
 	Public       bool                  `json:"public"`
 	BasicAuth    *basicAuthRequest     `json:"basic_auth"`
@@ -127,6 +128,7 @@ type patchDeploymentRequest struct {
 	ProxyPort    *int                  `json:"proxy_port"`
 	Volumes      []string              `json:"volumes"`
 	VolumeMounts []volumeMountRequest  `json:"volume_mounts"`
+	FileMounts   []fileMountRequest    `json:"file_mounts"`
 	Domain       string                `json:"domain"`
 	Public       *bool                 `json:"public"`
 	BasicAuth    *basicAuthRequest     `json:"basic_auth"`
@@ -632,6 +634,7 @@ func updateRequiresRedeploy(existing store.Deployment, body deploymentRequest) b
 		!slices.Equal(existing.Ports, body.Ports) ||
 		existing.ProxyPort != body.ProxyPort ||
 		!slices.Equal(existing.Volumes, body.Volumes) ||
+		!equalFileMounts(existing.FileMounts, body.FileMounts) ||
 		!equalBasicAuthConfig(existing.BasicAuth, body.BasicAuth)
 }
 
@@ -649,6 +652,9 @@ func patchRequiresRedeploy(existing store.Deployment, body patchDeploymentReques
 		return true
 	}
 	if body.Volumes != nil && !slices.Equal(existing.Volumes, body.Volumes) {
+		return true
+	}
+	if body.FileMounts != nil && !equalFileMounts(existing.FileMounts, body.FileMounts) {
 		return true
 	}
 	if body.BasicAuth != nil && !equalBasicAuthConfig(existing.BasicAuth, body.BasicAuth) {
@@ -808,10 +814,38 @@ func updateRequestMatchesExisting(existing store.Deployment, body deploymentRequ
 		slices.Equal(existing.Ports, body.Ports) &&
 		existing.ProxyPort == body.ProxyPort &&
 		slices.Equal(existing.Volumes, body.Volumes) &&
+		equalFileMounts(existing.FileMounts, body.FileMounts) &&
 		existing.Domain == body.Domain &&
 		existing.Public == body.Public &&
 		equalStoredBasicAuthConfig(existing.BasicAuth, basicAuth) &&
 		equalSecurityConfig(existing.Security, body.Security)
+}
+
+func equalFileMounts(existing []store.FileMount, request []fileMountRequest) bool {
+	if len(existing) != len(request) {
+		return false
+	}
+	for i := range existing {
+		left := existing[i]
+		right := request[i]
+		if left.Source != strings.TrimSpace(right.Source) ||
+			left.Target != strings.TrimSpace(right.Target) ||
+			left.Content != right.Content ||
+			left.ReadOnly != right.ReadOnly ||
+			left.FileMode != strings.TrimSpace(right.FileMode) ||
+			!equalOptionalInt(left.UID, right.UID) ||
+			!equalOptionalInt(left.GID, right.GID) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalOptionalInt(left, right *int) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
 }
 
 func validateProxyPortSelection(domain string, proxyPort int, ports []string) error {

--- a/api/internal/api/handler_create_deployment.go
+++ b/api/internal/api/handler_create_deployment.go
@@ -51,6 +51,11 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	resolvedFileMounts, err := resolveFileMounts(id, body.FileMounts)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	body.Volumes = resolvedVolumes
 	body.Security = normalizeSecurityConfig(body.Security)
 
@@ -79,18 +84,19 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	d := store.Deployment{
-		ID:        id,
-		Name:      body.Name,
-		Image:     body.Image,
-		Envs:      body.Envs,
-		Ports:     assignedPorts,
-		ProxyPort: body.ProxyPort,
-		Volumes:   body.Volumes,
-		Domain:    body.Domain,
-		Public:    body.Public,
-		BasicAuth: basicAuth,
-		Security:  body.Security,
-		Status:    store.StatusDeploying,
+		ID:         id,
+		Name:       body.Name,
+		Image:      body.Image,
+		Envs:       body.Envs,
+		Ports:      assignedPorts,
+		ProxyPort:  body.ProxyPort,
+		Volumes:    body.Volumes,
+		FileMounts: resolvedFileMounts,
+		Domain:     body.Domain,
+		Public:     body.Public,
+		BasicAuth:  basicAuth,
+		Security:   body.Security,
+		Status:     store.StatusDeploying,
 	}
 
 	created, err := h.store.Create(d)

--- a/api/internal/api/handler_file_mounts.go
+++ b/api/internal/api/handler_file_mounts.go
@@ -1,0 +1,217 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/lotsendev/lotsen/store"
+)
+
+const (
+	defaultManagedFileMode = 0o644
+	maxFileMountContentLen = 64 * 1024
+	maxFileMountTotalLen   = 512 * 1024
+)
+
+type fileMountRequest struct {
+	Source   string `json:"source"`
+	Target   string `json:"target"`
+	Content  string `json:"content"`
+	UID      *int   `json:"uid,omitempty"`
+	GID      *int   `json:"gid,omitempty"`
+	FileMode string `json:"file_mode,omitempty"`
+	ReadOnly bool   `json:"read_only,omitempty"`
+}
+
+type managedFileSettings struct {
+	hasUID      bool
+	uid         int
+	hasGID      bool
+	gid         int
+	hasFileMode bool
+	fileMode    os.FileMode
+}
+
+func managedFilesBaseDirFromEnv() string {
+	if dir := strings.TrimSpace(os.Getenv("LOTSEN_MANAGED_FILES_DIR")); dir != "" {
+		return filepath.Clean(dir)
+	}
+	return "/var/lib/lotsen/files"
+}
+
+func resolveFileMounts(deploymentID string, mounts []fileMountRequest) ([]store.FileMount, error) {
+	if mounts == nil {
+		return []store.FileMount{}, nil
+	}
+
+	resolved := make([]store.FileMount, 0, len(mounts))
+	seenSources := make(map[string]struct{}, len(mounts))
+	seenTargets := make(map[string]struct{}, len(mounts))
+	totalBytes := 0
+
+	for _, mount := range mounts {
+		source := strings.TrimSpace(mount.Source)
+		if !managedVolumeNamePattern.MatchString(source) {
+			return nil, fmt.Errorf("file source names must match %q", managedVolumeNamePattern.String())
+		}
+		if _, exists := seenSources[source]; exists {
+			return nil, fmt.Errorf("file source %q is already used", source)
+		}
+		seenSources[source] = struct{}{}
+
+		target, err := cleanAbsolutePath(mount.Target)
+		if err != nil {
+			return nil, fmt.Errorf("file target must be an absolute path")
+		}
+		if _, exists := seenTargets[target]; exists {
+			return nil, fmt.Errorf("file target %q is already used", target)
+		}
+		seenTargets[target] = struct{}{}
+
+		if !utf8.ValidString(mount.Content) {
+			return nil, fmt.Errorf("file content for %q must be valid UTF-8 text", source)
+		}
+		contentBytes := len([]byte(mount.Content))
+		if contentBytes > maxFileMountContentLen {
+			return nil, fmt.Errorf("file content for %q exceeds %d bytes", source, maxFileMountContentLen)
+		}
+		totalBytes += contentBytes
+		if totalBytes > maxFileMountTotalLen {
+			return nil, fmt.Errorf("total file content exceeds %d bytes", maxFileMountTotalLen)
+		}
+
+		settings, err := managedFileSettingsFromRequest(mount)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := ensureManagedFileWithSettings(deploymentID, source, mount.Content, settings); err != nil {
+			return nil, err
+		}
+
+		resolved = append(resolved, store.FileMount{
+			Source:   source,
+			Target:   target,
+			Content:  mount.Content,
+			UID:      mount.UID,
+			GID:      mount.GID,
+			FileMode: strings.TrimSpace(mount.FileMode),
+			ReadOnly: mount.ReadOnly,
+		})
+	}
+
+	return resolved, nil
+}
+
+func managedFileSettingsFromRequest(mount fileMountRequest) (managedFileSettings, error) {
+	settings := managedFileSettings{}
+
+	if mount.UID != nil {
+		if *mount.UID < 0 {
+			return managedFileSettings{}, fmt.Errorf("uid must be >= 0")
+		}
+		settings.hasUID = true
+		settings.uid = *mount.UID
+	}
+
+	if mount.GID != nil {
+		if *mount.GID < 0 {
+			return managedFileSettings{}, fmt.Errorf("gid must be >= 0")
+		}
+		settings.hasGID = true
+		settings.gid = *mount.GID
+	}
+
+	rawFileMode := strings.TrimSpace(mount.FileMode)
+	if rawFileMode != "" {
+		parsed, err := strconv.ParseUint(rawFileMode, 8, 32)
+		if err != nil || parsed > 0o777 {
+			return managedFileSettings{}, fmt.Errorf("file_mode must be an octal permission between 0000 and 0777")
+		}
+		settings.hasFileMode = true
+		settings.fileMode = os.FileMode(parsed)
+	}
+
+	return settings, nil
+}
+
+func ensureManagedFileWithSettings(deploymentID, source, content string, settings managedFileSettings) (string, error) {
+	base := managedFilesBaseDirFromEnv()
+	if !filepath.IsAbs(base) {
+		return "", fmt.Errorf("managed files base path must be absolute")
+	}
+
+	cleanBase := filepath.Clean(base)
+	filePath := filepath.Join(cleanBase, deploymentID, source)
+	if !isPathWithinBase(cleanBase, filePath) {
+		return "", fmt.Errorf("managed file path escapes configured base directory")
+	}
+
+	parent := filepath.Dir(filePath)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", fmt.Errorf("create managed file parent directory: %w", err)
+	}
+
+	existed := true
+	if info, err := os.Lstat(filePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			existed = false
+		} else {
+			return "", fmt.Errorf("stat managed file: %w", err)
+		}
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("managed file path must not be a symlink")
+	}
+
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("open managed file: %w", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("write managed file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("close managed file: %w", err)
+	}
+
+	if err := applyManagedFileSettings(filePath, settings, existed); err != nil {
+		return "", err
+	}
+
+	return filePath, nil
+}
+
+func applyManagedFileSettings(filePath string, settings managedFileSettings, existed bool) error {
+	if !settings.hasFileMode && !existed {
+		settings.hasFileMode = true
+		settings.fileMode = defaultManagedFileMode
+	}
+
+	if settings.hasUID || settings.hasGID {
+		uid := -1
+		if settings.hasUID {
+			uid = settings.uid
+		}
+		gid := -1
+		if settings.hasGID {
+			gid = settings.gid
+		}
+		if err := os.Chown(filePath, uid, gid); err != nil {
+			return fmt.Errorf("set managed file ownership: %w", err)
+		}
+	}
+
+	if settings.hasFileMode {
+		if err := os.Chmod(filePath, settings.fileMode); err != nil {
+			return fmt.Errorf("set managed file permissions: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/api/internal/api/handler_file_mounts_test.go
+++ b/api/internal/api/handler_file_mounts_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveFileMounts_CreatesManagedFile(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("LOTSEN_MANAGED_FILES_DIR", base)
+
+	mounts, err := resolveFileMounts("dep-1", []fileMountRequest{
+		{Source: "prometheus.yml", Target: "/etc/prometheus/prometheus.yml", Content: "global:\n  scrape_interval: 15s\n", ReadOnly: true},
+	})
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("want one mount, got %d", len(mounts))
+	}
+
+	hostPath := filepath.Join(base, "dep-1", "prometheus.yml")
+	content, err := os.ReadFile(hostPath)
+	if err != nil {
+		t.Fatalf("read managed file: %v", err)
+	}
+	if string(content) != mounts[0].Content {
+		t.Fatalf("want file content %q, got %q", mounts[0].Content, string(content))
+	}
+
+	info, err := os.Stat(hostPath)
+	if err != nil {
+		t.Fatalf("stat managed file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("want managed file mode 0644 by default, got %04o", got)
+	}
+}
+
+func TestResolveFileMounts_RejectsDuplicateTarget(t *testing.T) {
+	t.Setenv("LOTSEN_MANAGED_FILES_DIR", t.TempDir())
+
+	_, err := resolveFileMounts("dep-1", []fileMountRequest{
+		{Source: "a.yml", Target: "/etc/app/config.yml", Content: "a"},
+		{Source: "b.yml", Target: "/etc/app/config.yml", Content: "b"},
+	})
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+
+func TestResolveFileMounts_RejectsLargeContent(t *testing.T) {
+	t.Setenv("LOTSEN_MANAGED_FILES_DIR", t.TempDir())
+
+	large := make([]byte, maxFileMountContentLen+1)
+	for i := range large {
+		large[i] = 'a'
+	}
+
+	_, err := resolveFileMounts("dep-1", []fileMountRequest{
+		{Source: "app.yml", Target: "/etc/app/app.yml", Content: string(large)},
+	})
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+}

--- a/api/internal/api/handler_managed_files_http_test.go
+++ b/api/internal/api/handler_managed_files_http_test.go
@@ -1,0 +1,65 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateDeployment_FileMount(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("LOTSEN_MANAGED_FILES_DIR", base)
+
+	srv := newTestServer(newMemStore())
+	defer srv.Close()
+
+	body := []byte(`{
+		"name":"prometheus",
+		"image":"prom/prometheus",
+		"ports":["9090"],
+		"envs":{},
+		"file_mounts":[{"source":"prometheus.yml","target":"/etc/prometheus/prometheus.yml","content":"global:\n  scrape_interval: 15s\n","read_only":true}]
+	}`)
+
+	resp, err := http.Post(srv.URL+"/api/deployments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/deployments: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("want 201, got %d", resp.StatusCode)
+	}
+
+	var created struct {
+		ID         string `json:"id"`
+		FileMounts []struct {
+			Source   string `json:"source"`
+			Target   string `json:"target"`
+			Content  string `json:"content"`
+			ReadOnly bool   `json:"read_only"`
+		} `json:"file_mounts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(created.FileMounts) != 1 {
+		t.Fatalf("want one file_mounts entry, got %d", len(created.FileMounts))
+	}
+	if created.FileMounts[0].Source != "prometheus.yml" || !created.FileMounts[0].ReadOnly {
+		t.Fatalf("unexpected file mount %#v", created.FileMounts[0])
+	}
+
+	managedPath := filepath.Join(base, created.ID, "prometheus.yml")
+	content, err := os.ReadFile(managedPath)
+	if err != nil {
+		t.Fatalf("read managed file: %v", err)
+	}
+	if string(content) != created.FileMounts[0].Content {
+		t.Fatalf("want managed content %q, got %q", created.FileMounts[0].Content, string(content))
+	}
+}

--- a/api/internal/api/handler_patch_deployment.go
+++ b/api/internal/api/handler_patch_deployment.go
@@ -30,6 +30,15 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 		}
 		body.Volumes = resolvedVolumes
 	}
+	resolvedFileMounts := []store.FileMount(nil)
+	if body.FileMounts != nil {
+		var err error
+		resolvedFileMounts, err = resolveFileMounts(id, body.FileMounts)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
 	body.Security = normalizeSecurityConfig(body.Security)
 
 	basicAuth, err := sanitizeAndHashBasicAuth(body.BasicAuth)
@@ -110,6 +119,7 @@ func (h *Handler) patchDeployment(w http.ResponseWriter, r *http.Request) {
 		ProxyPort:    effectiveProxyPort,
 		ProxyPortSet: body.ProxyPort != nil,
 		Volumes:      body.Volumes,
+		FileMounts:   resolvedFileMounts,
 		Domain:       body.Domain,
 		Public:       public,
 		PublicSet:    body.Public != nil,

--- a/api/internal/api/handler_update_deployment.go
+++ b/api/internal/api/handler_update_deployment.go
@@ -46,6 +46,11 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	resolvedFileMounts, err := resolveFileMounts(id, body.FileMounts)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	body.Volumes = resolvedVolumes
 	body.Security = normalizeSecurityConfig(body.Security)
 
@@ -95,18 +100,19 @@ func (h *Handler) updateDeployment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	d := store.Deployment{
-		ID:        id,
-		Name:      body.Name,
-		Image:     body.Image,
-		Envs:      body.Envs,
-		Ports:     body.Ports,
-		ProxyPort: body.ProxyPort,
-		Volumes:   body.Volumes,
-		Domain:    body.Domain,
-		Public:    body.Public,
-		BasicAuth: basicAuth,
-		Security:  body.Security,
-		Status:    nextStatus,
+		ID:         id,
+		Name:       body.Name,
+		Image:      body.Image,
+		Envs:       body.Envs,
+		Ports:      body.Ports,
+		ProxyPort:  body.ProxyPort,
+		Volumes:    body.Volumes,
+		FileMounts: resolvedFileMounts,
+		Domain:     body.Domain,
+		Public:     body.Public,
+		BasicAuth:  basicAuth,
+		Security:   body.Security,
+		Status:     nextStatus,
 	}
 
 	updated, err := h.store.Update(d)

--- a/api/internal/configplan/plan.go
+++ b/api/internal/configplan/plan.go
@@ -1,0 +1,633 @@
+package configplan
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/lotsendev/lotsen/internal/configv1"
+)
+
+const Kind = "LotsenPlan"
+
+var placeholderPattern = regexp.MustCompile(`^\$\{LOTSEN_SECRET_[A-Z0-9_]+\}$`)
+
+type Document struct {
+	APIVersion  string             `json:"apiVersion"`
+	Kind        string             `json:"kind"`
+	Fingerprint string             `json:"fingerprint"`
+	Summary     Summary            `json:"summary"`
+	Actions     Actions            `json:"actions"`
+	Drift       DriftSection       `json:"drift"`
+	Conflicts   ConflictSection    `json:"conflicts"`
+	Destructive DestructiveSection `json:"destructive"`
+}
+
+type Summary struct {
+	CreateCount      int `json:"createCount"`
+	UpdateCount      int `json:"updateCount"`
+	DeleteCount      int `json:"deleteCount"`
+	NoopCount        int `json:"noopCount"`
+	DriftCount       int `json:"driftCount"`
+	ConflictCount    int `json:"conflictCount"`
+	DestructiveCount int `json:"destructiveCount"`
+}
+
+type Actions struct {
+	Deployments ResourceActions `json:"deployments"`
+	Registries  ResourceActions `json:"registries"`
+	Host        HostActions     `json:"host"`
+}
+
+type ResourceActions struct {
+	Create []ResourceChange `json:"create"`
+	Update []ResourceChange `json:"update"`
+	Delete []ResourceChange `json:"delete"`
+	Noop   []ResourceChange `json:"noop"`
+}
+
+type HostActions struct {
+	Update []ResourceChange `json:"update"`
+	Noop   []ResourceChange `json:"noop"`
+}
+
+type ResourceChange struct {
+	Resource string   `json:"resource"`
+	Changes  []string `json:"changes,omitempty"`
+}
+
+type DriftSection struct {
+	Deployments []ResourceChange `json:"deployments"`
+	Registries  []ResourceChange `json:"registries"`
+	Host        []ResourceChange `json:"host"`
+}
+
+type ConflictSection struct {
+	Deployments []Conflict `json:"deployments"`
+	Registries  []Conflict `json:"registries"`
+	Host        []Conflict `json:"host"`
+}
+
+type Conflict struct {
+	Resource string `json:"resource"`
+	Reason   string `json:"reason"`
+}
+
+type DestructiveSection struct {
+	Deployments []ResourceChange `json:"deployments"`
+	Registries  []ResourceChange `json:"registries"`
+	Host        []ResourceChange `json:"host"`
+}
+
+func Build(desired, live configv1.Document) (Document, error) {
+	if desired.Spec == nil {
+		return Document{}, fmt.Errorf("desired config spec is required")
+	}
+	if live.Spec == nil {
+		return Document{}, fmt.Errorf("live config spec is required")
+	}
+
+	canonicalDesired := configv1.Canonicalize(desired)
+	canonicalLive := configv1.Canonicalize(live)
+
+	plan := Document{
+		APIVersion: configv1.APIVersion,
+		Kind:       Kind,
+		Actions: Actions{
+			Deployments: ResourceActions{Create: []ResourceChange{}, Update: []ResourceChange{}, Delete: []ResourceChange{}, Noop: []ResourceChange{}},
+			Registries:  ResourceActions{Create: []ResourceChange{}, Update: []ResourceChange{}, Delete: []ResourceChange{}, Noop: []ResourceChange{}},
+			Host:        HostActions{Update: []ResourceChange{}, Noop: []ResourceChange{}},
+		},
+		Drift:     DriftSection{Deployments: []ResourceChange{}, Registries: []ResourceChange{}, Host: []ResourceChange{}},
+		Conflicts: ConflictSection{Deployments: []Conflict{}, Registries: []Conflict{}, Host: []Conflict{}},
+		Destructive: DestructiveSection{
+			Deployments: []ResourceChange{},
+			Registries:  []ResourceChange{},
+			Host:        []ResourceChange{},
+		},
+	}
+
+	planningDeployments(&plan, canonicalDesired.Spec.Deployments, canonicalLive.Spec.Deployments)
+	planningRegistries(&plan, canonicalDesired.Spec.Registries, canonicalLive.Spec.Registries)
+	planningHost(&plan, canonicalDesired.Spec.Host, canonicalLive.Spec.Host)
+
+	plan.Summary = Summary{
+		CreateCount:      len(plan.Actions.Deployments.Create) + len(plan.Actions.Registries.Create),
+		UpdateCount:      len(plan.Actions.Deployments.Update) + len(plan.Actions.Registries.Update) + len(plan.Actions.Host.Update),
+		DeleteCount:      len(plan.Actions.Deployments.Delete) + len(plan.Actions.Registries.Delete),
+		NoopCount:        len(plan.Actions.Deployments.Noop) + len(plan.Actions.Registries.Noop) + len(plan.Actions.Host.Noop),
+		DriftCount:       len(plan.Drift.Deployments) + len(plan.Drift.Registries) + len(plan.Drift.Host),
+		ConflictCount:    len(plan.Conflicts.Deployments) + len(plan.Conflicts.Registries) + len(plan.Conflicts.Host),
+		DestructiveCount: len(plan.Destructive.Deployments) + len(plan.Destructive.Registries) + len(plan.Destructive.Host),
+	}
+
+	plan.Fingerprint = fingerprint(plan)
+
+	return plan, nil
+}
+
+func MarshalCanonical(plan Document) ([]byte, error) {
+	canonical := canonicalizePlan(plan)
+	out, err := json.MarshalIndent(canonical, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}
+
+func fingerprint(plan Document) string {
+	copy := canonicalizePlan(plan)
+	copy.Fingerprint = ""
+	payload, _ := json.Marshal(copy)
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func planningDeployments(plan *Document, desiredDeployments, liveDeployments []configv1.Deployment) {
+	desiredByName := make(map[string]configv1.Deployment, len(desiredDeployments))
+	for _, deployment := range desiredDeployments {
+		desiredByName[deployment.Name] = deployment
+	}
+
+	liveByName := make(map[string]configv1.Deployment, len(liveDeployments))
+	for _, deployment := range liveDeployments {
+		liveByName[deployment.Name] = deployment
+	}
+
+	desiredNames := sortedKeys(desiredByName)
+	for _, name := range desiredNames {
+		desired := desiredByName[name]
+		live, exists := liveByName[name]
+		if !exists {
+			plan.Actions.Deployments.Create = append(plan.Actions.Deployments.Create, ResourceChange{Resource: name})
+			continue
+		}
+
+		changes := diffDeployment(live, desired)
+		if len(changes) == 0 {
+			plan.Actions.Deployments.Noop = append(plan.Actions.Deployments.Noop, ResourceChange{Resource: name})
+			continue
+		}
+
+		change := ResourceChange{Resource: name, Changes: changes}
+		plan.Actions.Deployments.Update = append(plan.Actions.Deployments.Update, change)
+		plan.Drift.Deployments = append(plan.Drift.Deployments, change)
+	}
+
+	liveNames := sortedKeys(liveByName)
+	for _, name := range liveNames {
+		if _, exists := desiredByName[name]; exists {
+			continue
+		}
+		change := ResourceChange{Resource: name}
+		plan.Actions.Deployments.Delete = append(plan.Actions.Deployments.Delete, change)
+		plan.Drift.Deployments = append(plan.Drift.Deployments, change)
+		plan.Destructive.Deployments = append(plan.Destructive.Deployments, change)
+	}
+
+	plan.Conflicts.Deployments = deploymentConflicts(desiredByName, liveByName)
+}
+
+func planningRegistries(plan *Document, desiredRegistries, liveRegistries []configv1.Registry) {
+	desiredByPrefix := make(map[string]configv1.Registry, len(desiredRegistries))
+	for _, registry := range desiredRegistries {
+		desiredByPrefix[registry.Prefix] = registry
+	}
+
+	liveByPrefix := make(map[string]configv1.Registry, len(liveRegistries))
+	for _, registry := range liveRegistries {
+		liveByPrefix[registry.Prefix] = registry
+	}
+
+	desiredPrefixes := sortedKeys(desiredByPrefix)
+	for _, prefix := range desiredPrefixes {
+		desired := desiredByPrefix[prefix]
+		live, exists := liveByPrefix[prefix]
+		if !exists {
+			plan.Actions.Registries.Create = append(plan.Actions.Registries.Create, ResourceChange{Resource: prefix})
+			continue
+		}
+
+		changes := diffRegistry(live, desired)
+		if len(changes) == 0 {
+			plan.Actions.Registries.Noop = append(plan.Actions.Registries.Noop, ResourceChange{Resource: prefix})
+			continue
+		}
+
+		change := ResourceChange{Resource: prefix, Changes: changes}
+		plan.Actions.Registries.Update = append(plan.Actions.Registries.Update, change)
+		plan.Drift.Registries = append(plan.Drift.Registries, change)
+	}
+
+	livePrefixes := sortedKeys(liveByPrefix)
+	for _, prefix := range livePrefixes {
+		if _, exists := desiredByPrefix[prefix]; exists {
+			continue
+		}
+		change := ResourceChange{Resource: prefix}
+		plan.Actions.Registries.Delete = append(plan.Actions.Registries.Delete, change)
+		plan.Drift.Registries = append(plan.Drift.Registries, change)
+		plan.Destructive.Registries = append(plan.Destructive.Registries, change)
+	}
+}
+
+func planningHost(plan *Document, desiredHost, liveHost *configv1.Host) {
+	if desiredHost == nil {
+		plan.Actions.Host.Noop = append(plan.Actions.Host.Noop, ResourceChange{Resource: "host"})
+		return
+	}
+
+	if liveHost == nil {
+		liveHost = &configv1.Host{}
+	}
+
+	changes := diffHost(*liveHost, *desiredHost)
+	if len(changes) == 0 {
+		plan.Actions.Host.Noop = append(plan.Actions.Host.Noop, ResourceChange{Resource: "host"})
+		return
+	}
+
+	change := ResourceChange{Resource: "host", Changes: changes}
+	plan.Actions.Host.Update = append(plan.Actions.Host.Update, change)
+	plan.Drift.Host = append(plan.Drift.Host, change)
+}
+
+func deploymentConflicts(desiredByName, liveByName map[string]configv1.Deployment) []Conflict {
+	liveByDomain := make(map[string]string, len(liveByName))
+	for name, deployment := range liveByName {
+		domain := strings.TrimSpace(deployment.Domain)
+		if domain == "" {
+			continue
+		}
+		if _, exists := liveByDomain[domain]; !exists {
+			liveByDomain[domain] = name
+		}
+	}
+
+	conflicts := make([]Conflict, 0)
+	for name, deployment := range desiredByName {
+		domain := strings.TrimSpace(deployment.Domain)
+		if domain == "" {
+			continue
+		}
+
+		owner, exists := liveByDomain[domain]
+		if !exists || owner == name {
+			continue
+		}
+
+		if _, managed := desiredByName[owner]; !managed {
+			continue
+		}
+
+		conflicts = append(conflicts, Conflict{
+			Resource: name,
+			Reason:   fmt.Sprintf("domain %q is already claimed by deployment %q", domain, owner),
+		})
+	}
+
+	slices.SortFunc(conflicts, func(a, b Conflict) int {
+		return strings.Compare(a.Resource, b.Resource)
+	})
+	return conflicts
+}
+
+func diffDeployment(live, desired configv1.Deployment) []string {
+	changes := make([]string, 0)
+	if strings.TrimSpace(live.Image) != strings.TrimSpace(desired.Image) {
+		changes = append(changes, "image")
+	}
+	if strings.TrimSpace(live.Domain) != strings.TrimSpace(desired.Domain) {
+		changes = append(changes, "domain")
+	}
+	if !equalBoolPtr(live.Public, desired.Public) {
+		changes = append(changes, "public")
+	}
+	if !equalPorts(live.Ports, desired.Ports) {
+		changes = append(changes, "ports")
+	}
+	if !equalIntPtr(live.ProxyPort, desired.ProxyPort) {
+		changes = append(changes, "proxyPort")
+	}
+	if !equalEnv(live.Env, desired.Env) {
+		changes = append(changes, "env")
+	}
+	if !equalVolumeMounts(live.VolumeMounts, desired.VolumeMounts) {
+		changes = append(changes, "volumeMounts")
+	}
+	if !equalBasicAuth(live.BasicAuth, desired.BasicAuth) {
+		changes = append(changes, "basicAuth")
+	}
+	if !equalSecurity(live.Security, desired.Security) {
+		changes = append(changes, "security")
+	}
+
+	slices.Sort(changes)
+	return changes
+}
+
+func diffRegistry(live, desired configv1.Registry) []string {
+	changes := make([]string, 0)
+	if strings.TrimSpace(live.Username) != strings.TrimSpace(desired.Username) {
+		changes = append(changes, "username")
+	}
+	if !equalSecret(live.Password, desired.Password) {
+		changes = append(changes, "password")
+	}
+
+	slices.Sort(changes)
+	return changes
+}
+
+func diffHost(live, desired configv1.Host) []string {
+	changes := make([]string, 0)
+	if strings.TrimSpace(live.DisplayName) != strings.TrimSpace(desired.DisplayName) {
+		changes = append(changes, "displayName")
+	}
+	if normalizeDashboardAccessMode(live.DashboardAccessMode) != normalizeDashboardAccessMode(desired.DashboardAccessMode) {
+		changes = append(changes, "dashboardAccessMode")
+	}
+	if !equalDashboardWAF(live.DashboardWAF, desired.DashboardWAF) {
+		changes = append(changes, "dashboardWaf")
+	}
+
+	slices.Sort(changes)
+	return changes
+}
+
+func canonicalizePlan(plan Document) Document {
+	canonical := plan
+	canonical.Actions.Deployments = canonicalizeResourceActions(canonical.Actions.Deployments)
+	canonical.Actions.Registries = canonicalizeResourceActions(canonical.Actions.Registries)
+	canonical.Actions.Host.Update = canonicalizeChanges(canonical.Actions.Host.Update)
+	canonical.Actions.Host.Noop = canonicalizeChanges(canonical.Actions.Host.Noop)
+
+	canonical.Drift.Deployments = canonicalizeChanges(canonical.Drift.Deployments)
+	canonical.Drift.Registries = canonicalizeChanges(canonical.Drift.Registries)
+	canonical.Drift.Host = canonicalizeChanges(canonical.Drift.Host)
+
+	canonical.Conflicts.Deployments = slices.Clone(canonical.Conflicts.Deployments)
+	canonical.Conflicts.Registries = slices.Clone(canonical.Conflicts.Registries)
+	canonical.Conflicts.Host = slices.Clone(canonical.Conflicts.Host)
+	slices.SortFunc(canonical.Conflicts.Deployments, func(a, b Conflict) int { return strings.Compare(a.Resource, b.Resource) })
+	slices.SortFunc(canonical.Conflicts.Registries, func(a, b Conflict) int { return strings.Compare(a.Resource, b.Resource) })
+	slices.SortFunc(canonical.Conflicts.Host, func(a, b Conflict) int { return strings.Compare(a.Resource, b.Resource) })
+
+	canonical.Destructive.Deployments = canonicalizeChanges(canonical.Destructive.Deployments)
+	canonical.Destructive.Registries = canonicalizeChanges(canonical.Destructive.Registries)
+	canonical.Destructive.Host = canonicalizeChanges(canonical.Destructive.Host)
+
+	return canonical
+}
+
+func canonicalizeResourceActions(in ResourceActions) ResourceActions {
+	out := in
+	out.Create = canonicalizeChanges(in.Create)
+	out.Update = canonicalizeChanges(in.Update)
+	out.Delete = canonicalizeChanges(in.Delete)
+	out.Noop = canonicalizeChanges(in.Noop)
+	return out
+}
+
+func canonicalizeChanges(in []ResourceChange) []ResourceChange {
+	out := slices.Clone(in)
+	for i := range out {
+		if len(out[i].Changes) == 0 {
+			continue
+		}
+		out[i].Changes = slices.Clone(out[i].Changes)
+		slices.Sort(out[i].Changes)
+	}
+	slices.SortFunc(out, func(a, b ResourceChange) int {
+		return strings.Compare(a.Resource, b.Resource)
+	})
+	return out
+}
+
+func sortedKeys[T any](in map[string]T) []string {
+	keys := make([]string, 0, len(in))
+	for key := range in {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func equalBoolPtr(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func equalIntPtr(a, b *int) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func equalPorts(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if strings.TrimSpace(a[i]) != strings.TrimSpace(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalEnv(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, aValue := range a {
+		bValue, ok := b[key]
+		if !ok {
+			return false
+		}
+		if looksSensitiveEnvKey(key) {
+			if !equalSecret(aValue, bValue) {
+				return false
+			}
+			continue
+		}
+		if strings.TrimSpace(aValue) != strings.TrimSpace(bValue) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalVolumeMounts(a, b []configv1.VolumeMount) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if strings.TrimSpace(a[i].Mode) != strings.TrimSpace(b[i].Mode) {
+			return false
+		}
+		if strings.TrimSpace(a[i].Source) != strings.TrimSpace(b[i].Source) {
+			return false
+		}
+		if strings.TrimSpace(a[i].Target) != strings.TrimSpace(b[i].Target) {
+			return false
+		}
+		if !equalIntPtr(a[i].UID, b[i].UID) || !equalIntPtr(a[i].GID, b[i].GID) {
+			return false
+		}
+		if strings.TrimSpace(a[i].DirMode) != strings.TrimSpace(b[i].DirMode) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalBasicAuth(a, b *configv1.BasicAuth) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if len(a.Users) != len(b.Users) {
+		return false
+	}
+	for i := range a.Users {
+		if strings.TrimSpace(a.Users[i].Username) != strings.TrimSpace(b.Users[i].Username) {
+			return false
+		}
+		if !equalSecret(a.Users[i].Password, b.Users[i].Password) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalSecurity(a, b *configv1.Security) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.WAFEnabled != b.WAFEnabled {
+		return false
+	}
+	if strings.TrimSpace(a.WAFMode) != strings.TrimSpace(b.WAFMode) {
+		return false
+	}
+	if !equalStringSlices(a.IPDenylist, b.IPDenylist) {
+		return false
+	}
+	if !equalStringSlices(a.IPAllowlist, b.IPAllowlist) {
+		return false
+	}
+	if !equalStringSlices(a.CustomRules, b.CustomRules) {
+		return false
+	}
+	return true
+}
+
+func equalDashboardWAF(a, b *configv1.DashboardWAF) bool {
+	normalizedA := normalizeDashboardWAF(a)
+	normalizedB := normalizeDashboardWAF(b)
+	if normalizedA.Mode != normalizedB.Mode {
+		return false
+	}
+	if !equalStringSlices(normalizedA.IPAllowlist, normalizedB.IPAllowlist) {
+		return false
+	}
+	if !equalStringSlices(normalizedA.CustomRules, normalizedB.CustomRules) {
+		return false
+	}
+	return true
+}
+
+func normalizeDashboardWAF(cfg *configv1.DashboardWAF) configv1.DashboardWAF {
+	if cfg == nil {
+		return configv1.DashboardWAF{Mode: "detection", IPAllowlist: []string{}, CustomRules: []string{}}
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(cfg.Mode))
+	if mode != "enforcement" {
+		mode = "detection"
+	}
+
+	return configv1.DashboardWAF{
+		Mode:        mode,
+		IPAllowlist: normalizeStringList(cfg.IPAllowlist),
+		CustomRules: normalizeStringList(cfg.CustomRules),
+	}
+}
+
+func normalizeDashboardAccessMode(mode string) string {
+	normalized := strings.ToLower(strings.TrimSpace(mode))
+	switch normalized {
+	case "waf_only", "waf_and_login":
+		return normalized
+	default:
+		return "login_only"
+	}
+}
+
+func normalizeStringList(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, value := range in {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if strings.TrimSpace(a[i]) != strings.TrimSpace(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalSecret(a, b string) bool {
+	aTrimmed := strings.TrimSpace(a)
+	bTrimmed := strings.TrimSpace(b)
+	if placeholderPattern.MatchString(aTrimmed) && placeholderPattern.MatchString(bTrimmed) {
+		return true
+	}
+	return aTrimmed == bTrimmed
+}
+
+func looksSensitiveEnvKey(key string) bool {
+	normalized := strings.ToUpper(strings.TrimSpace(key))
+	if normalized == "" {
+		return false
+	}
+
+	keywords := []string{"SECRET", "TOKEN", "PASSWORD", "DATABASE_URL", "PRIVATE_KEY", "API_KEY", "ACCESS_KEY", "_KEY", "KEY_"}
+	for _, keyword := range keywords {
+		if strings.Contains(normalized, keyword) {
+			return true
+		}
+	}
+
+	return strings.HasSuffix(normalized, "KEY")
+}

--- a/api/internal/configplan/plan_test.go
+++ b/api/internal/configplan/plan_test.go
@@ -1,0 +1,186 @@
+package configplan
+
+import (
+	"testing"
+
+	"github.com/lotsendev/lotsen/internal/configv1"
+)
+
+func TestBuild_ActionGroupingAndSections(t *testing.T) {
+	public := true
+	desiredProxy := 8443
+
+	desired := configv1.Document{
+		APIVersion: configv1.APIVersion,
+		Kind:       configv1.Kind,
+		Spec: &configv1.Spec{
+			Deployments: []configv1.Deployment{
+				{Name: "app-create", Image: "ghcr.io/acme/new:1", Domain: "shared.example.com", Public: &public},
+				{Name: "app-noop", Image: "ghcr.io/acme/noop:1", Domain: "noop.example.com", Public: &public},
+				{Name: "app-update", Image: "ghcr.io/acme/app:2", Domain: "app.example.com", Public: &public, ProxyPort: &desiredProxy, Env: map[string]string{"DATABASE_URL": "${LOTSEN_SECRET_DESIRED_DB}"}},
+				{Name: "keeper", Image: "ghcr.io/acme/keeper:1", Domain: "shared.example.com", Public: &public},
+			},
+			Registries: []configv1.Registry{
+				{Prefix: "a.example", Username: "user-a", Password: "${LOTSEN_SECRET_A}"},
+				{Prefix: "b.example", Username: "user-b", Password: "${LOTSEN_SECRET_B}"},
+				{Prefix: "d.example", Username: "user-d-updated", Password: "${LOTSEN_SECRET_D}"},
+			},
+			Host: &configv1.Host{
+				DisplayName:         "prod-vps-1",
+				DashboardAccessMode: "waf_and_login",
+				DashboardWAF: &configv1.DashboardWAF{
+					Mode:        "enforcement",
+					IPAllowlist: []string{"203.0.113.0/24"},
+				},
+			},
+		},
+	}
+
+	liveProxy := 8080
+	live := configv1.Document{
+		APIVersion: configv1.APIVersion,
+		Kind:       configv1.Kind,
+		Spec: &configv1.Spec{
+			Deployments: []configv1.Deployment{
+				{Name: "app-noop", Image: "ghcr.io/acme/noop:1", Domain: "noop.example.com", Public: &public},
+				{Name: "app-update", Image: "ghcr.io/acme/app:1", Domain: "old.example.com", Public: &public, ProxyPort: &liveProxy, Env: map[string]string{"DATABASE_URL": "${LOTSEN_SECRET_LIVE_DB}"}},
+				{Name: "keeper", Image: "ghcr.io/acme/keeper:1", Domain: "shared.example.com", Public: &public},
+				{Name: "legacy-delete", Image: "ghcr.io/acme/legacy:1", Domain: "legacy.example.com", Public: &public},
+			},
+			Registries: []configv1.Registry{
+				{Prefix: "a.example", Username: "user-a", Password: "${LOTSEN_SECRET_LIVE_A}"},
+				{Prefix: "c.example", Username: "user-c", Password: "${LOTSEN_SECRET_C}"},
+				{Prefix: "d.example", Username: "user-d-old", Password: "${LOTSEN_SECRET_D_OLD}"},
+			},
+			Host: &configv1.Host{DisplayName: "old-host", DashboardAccessMode: "login_only"},
+		},
+	}
+
+	plan, err := Build(desired, live)
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+
+	if got, want := len(plan.Actions.Deployments.Create), 1; got != want {
+		t.Fatalf("want %d deployment creates, got %d", want, got)
+	}
+	if got := plan.Actions.Deployments.Create[0].Resource; got != "app-create" {
+		t.Fatalf("want app-create create action, got %q", got)
+	}
+
+	if got, want := len(plan.Actions.Deployments.Update), 1; got != want {
+		t.Fatalf("want %d deployment updates, got %d", want, got)
+	}
+	if got := plan.Actions.Deployments.Update[0].Resource; got != "app-update" {
+		t.Fatalf("want app-update update action, got %q", got)
+	}
+
+	if got, want := len(plan.Actions.Deployments.Delete), 1; got != want {
+		t.Fatalf("want %d deployment deletes, got %d", want, got)
+	}
+	if got := plan.Actions.Deployments.Delete[0].Resource; got != "legacy-delete" {
+		t.Fatalf("want legacy-delete delete action, got %q", got)
+	}
+
+	if got, want := len(plan.Actions.Deployments.Noop), 2; got != want {
+		t.Fatalf("want %d deployment noops, got %d", want, got)
+	}
+
+	if got, want := len(plan.Conflicts.Deployments), 1; got != want {
+		t.Fatalf("want %d deployment conflicts, got %d", want, got)
+	}
+	if got := plan.Conflicts.Deployments[0].Resource; got != "app-create" {
+		t.Fatalf("want app-create conflict, got %q", got)
+	}
+
+	if got, want := len(plan.Actions.Registries.Create), 1; got != want {
+		t.Fatalf("want %d registry creates, got %d", want, got)
+	}
+	if got := plan.Actions.Registries.Create[0].Resource; got != "b.example" {
+		t.Fatalf("want b.example create action, got %q", got)
+	}
+
+	if got, want := len(plan.Actions.Registries.Update), 1; got != want {
+		t.Fatalf("want %d registry updates, got %d", want, got)
+	}
+	if got := plan.Actions.Registries.Update[0].Resource; got != "d.example" {
+		t.Fatalf("want d.example update action, got %q", got)
+	}
+
+	if got, want := len(plan.Actions.Registries.Delete), 1; got != want {
+		t.Fatalf("want %d registry deletes, got %d", want, got)
+	}
+	if got := plan.Actions.Registries.Delete[0].Resource; got != "c.example" {
+		t.Fatalf("want c.example delete action, got %q", got)
+	}
+
+	if got, want := len(plan.Actions.Registries.Noop), 1; got != want {
+		t.Fatalf("want %d registry noops, got %d", want, got)
+	}
+	if got := plan.Actions.Registries.Noop[0].Resource; got != "a.example" {
+		t.Fatalf("want a.example noop action, got %q", got)
+	}
+
+	if got, want := len(plan.Actions.Host.Update), 1; got != want {
+		t.Fatalf("want %d host updates, got %d", want, got)
+	}
+
+	if got, want := len(plan.Drift.Deployments), 2; got != want {
+		t.Fatalf("want %d deployment drift entries, got %d", want, got)
+	}
+	if got, want := len(plan.Drift.Registries), 2; got != want {
+		t.Fatalf("want %d registry drift entries, got %d", want, got)
+	}
+	if got, want := len(plan.Drift.Host), 1; got != want {
+		t.Fatalf("want %d host drift entries, got %d", want, got)
+	}
+
+	if got, want := len(plan.Destructive.Deployments), 1; got != want {
+		t.Fatalf("want %d destructive deployment entries, got %d", want, got)
+	}
+	if got, want := len(plan.Destructive.Registries), 1; got != want {
+		t.Fatalf("want %d destructive registry entries, got %d", want, got)
+	}
+
+	if plan.Fingerprint == "" {
+		t.Fatal("want non-empty plan fingerprint")
+	}
+}
+
+func TestBuild_DeterministicFingerprint(t *testing.T) {
+	public := true
+	doc := configv1.Document{
+		APIVersion: configv1.APIVersion,
+		Kind:       configv1.Kind,
+		Spec: &configv1.Spec{
+			Deployments: []configv1.Deployment{{Name: "app", Image: "ghcr.io/acme/app:1", Domain: "app.example.com", Public: &public}},
+			Registries:  []configv1.Registry{{Prefix: "a.example", Username: "user", Password: "${LOTSEN_SECRET_A}"}},
+		},
+	}
+
+	first, err := Build(doc, doc)
+	if err != nil {
+		t.Fatalf("build first plan: %v", err)
+	}
+	second, err := Build(doc, doc)
+	if err != nil {
+		t.Fatalf("build second plan: %v", err)
+	}
+
+	if first.Fingerprint != second.Fingerprint {
+		t.Fatalf("want deterministic fingerprints, got %q and %q", first.Fingerprint, second.Fingerprint)
+	}
+
+	b1, err := MarshalCanonical(first)
+	if err != nil {
+		t.Fatalf("marshal first plan: %v", err)
+	}
+	b2, err := MarshalCanonical(second)
+	if err != nil {
+		t.Fatalf("marshal second plan: %v", err)
+	}
+
+	if string(b1) != string(b2) {
+		t.Fatal("want deterministic marshaled output across runs")
+	}
+}

--- a/api/internal/configv1/config.go
+++ b/api/internal/configv1/config.go
@@ -52,6 +52,7 @@ type Deployment struct {
 	Ports        []string          `json:"ports,omitempty"`
 	ProxyPort    *int              `json:"proxyPort,omitempty"`
 	VolumeMounts []VolumeMount     `json:"volumeMounts,omitempty"`
+	FileMounts   []FileMount       `json:"fileMounts,omitempty"`
 	BasicAuth    *BasicAuth        `json:"basicAuth,omitempty"`
 	Security     *Security         `json:"security,omitempty"`
 }
@@ -63,6 +64,16 @@ type VolumeMount struct {
 	UID     *int   `json:"uid,omitempty"`
 	GID     *int   `json:"gid,omitempty"`
 	DirMode string `json:"dirMode,omitempty"`
+}
+
+type FileMount struct {
+	Source   string `json:"source"`
+	Target   string `json:"target"`
+	Content  string `json:"content"`
+	UID      *int   `json:"uid,omitempty"`
+	GID      *int   `json:"gid,omitempty"`
+	FileMode string `json:"fileMode,omitempty"`
+	ReadOnly bool   `json:"readOnly,omitempty"`
 }
 
 type BasicAuth struct {
@@ -147,6 +158,9 @@ func Canonicalize(doc Document) Document {
 		}
 		if deployment.VolumeMounts != nil {
 			copied.VolumeMounts = slices.Clone(deployment.VolumeMounts)
+		}
+		if deployment.FileMounts != nil {
+			copied.FileMounts = slices.Clone(deployment.FileMounts)
 		}
 		if deployment.BasicAuth != nil {
 			users := slices.Clone(deployment.BasicAuth.Users)
@@ -314,6 +328,44 @@ func Validate(doc Document) error {
 					if mount.UID != nil || mount.GID != nil || strings.TrimSpace(mount.DirMode) != "" {
 						addErr(mountPath, "uid, gid, and dirMode are only supported for managed mounts")
 					}
+				}
+			}
+
+			seenFileSources := make(map[string]struct{}, len(deployment.FileMounts))
+			seenFileTargets := make(map[string]struct{}, len(deployment.FileMounts))
+			for mountIndex, mount := range deployment.FileMounts {
+				mountPath := fmt.Sprintf("%s.fileMounts[%d]", path, mountIndex)
+				source := strings.TrimSpace(mount.Source)
+				target := filepath.Clean(strings.TrimSpace(mount.Target))
+
+				if source == "" {
+					addErr(mountPath+".source", "is required")
+				} else if !managedVolumeNamePattern.MatchString(source) {
+					addErr(mountPath+".source", "must match managed file name pattern")
+				} else {
+					if _, exists := seenFileSources[source]; exists {
+						addErr(mountPath+".source", "must be unique")
+					}
+					seenFileSources[source] = struct{}{}
+				}
+
+				if target == "." || !filepath.IsAbs(target) {
+					addErr(mountPath+".target", "must be an absolute path")
+				} else {
+					if _, exists := seenFileTargets[target]; exists {
+						addErr(mountPath+".target", "must be unique")
+					}
+					seenFileTargets[target] = struct{}{}
+				}
+
+				if mount.UID != nil && *mount.UID < 0 {
+					addErr(mountPath+".uid", "must be >= 0")
+				}
+				if mount.GID != nil && *mount.GID < 0 {
+					addErr(mountPath+".gid", "must be >= 0")
+				}
+				if mount.FileMode != "" && !dirModePattern.MatchString(strings.TrimSpace(mount.FileMode)) {
+					addErr(mountPath+".fileMode", "must be an octal permission between 0000 and 0777")
 				}
 			}
 

--- a/dashboard/src/deployments/CreateDeploymentForm.tsx
+++ b/dashboard/src/deployments/CreateDeploymentForm.tsx
@@ -6,7 +6,7 @@ import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import { cn } from '../lib/utils'
 import { DynamicSection } from './DynamicSection'
-import { useCreateDeploymentForm, type BasicAuthUserRow, type EnvRow, type PortRow, type VolumeMountRow } from './useCreateDeploymentForm'
+import { useCreateDeploymentForm, type BasicAuthUserRow, type EnvRow, type FileMountRow, type PortRow, type VolumeMountRow } from './useCreateDeploymentForm'
 
 const fieldErrorCls = 'text-xs text-destructive'
 
@@ -21,7 +21,7 @@ export default function CreateDeploymentForm({ onSuccess, className, hideHeader 
     name, setName, image, setImage, domain, setDomain,
     isPublic, setIsPublic,
     selectedProxyRowId, setSelectedProxyRowId,
-    envRows, portRows, volumeRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
+    envRows, portRows, volumeRows, fileRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
     errors, handleSubmit, isPending,
   } = useCreateDeploymentForm({ onSuccess })
 
@@ -230,6 +230,54 @@ export default function CreateDeploymentForm({ onSuccess, className, hideHeader 
                   className="font-mono"
                 />
               </>
+            )}
+          />
+
+          <DynamicSection<FileMountRow>
+            title="Config files"
+            description="Create text config files on the VPS and mount them into the container. Useful for Prometheus, Nginx, and other services that require config files."
+            addLabel="Add config file"
+            removeLabel="Remove config file"
+            rows={fileRows.rows}
+            onAdd={fileRows.add}
+            onRemove={fileRows.remove}
+            errorFor={row => errors.files[row.id]}
+            renderRow={row => (
+              <div className="grid flex-1 gap-2">
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_auto_1fr_auto] md:items-center">
+                  <Input
+                    type="text"
+                    placeholder="prometheus.yml"
+                    value={row.source}
+                    onChange={e => fileRows.update(row.id, { source: e.target.value })}
+                    aria-invalid={Boolean(errors.files[row.id])}
+                    className="font-mono"
+                  />
+                  <span className="hidden text-sm text-muted-foreground md:inline">-&gt;</span>
+                  <Input
+                    type="text"
+                    placeholder="/etc/prometheus/prometheus.yml"
+                    value={row.target}
+                    onChange={e => fileRows.update(row.id, { target: e.target.value })}
+                    aria-invalid={Boolean(errors.files[row.id])}
+                    className="font-mono"
+                  />
+                  <label className="inline-flex items-center gap-2 rounded-md border border-border/60 px-2 py-1 text-xs text-foreground">
+                    <input
+                      type="checkbox"
+                      checked={row.readOnly}
+                      onChange={e => fileRows.update(row.id, { readOnly: e.target.checked })}
+                    />
+                    Read only
+                  </label>
+                </div>
+                <textarea
+                  value={row.content}
+                  onChange={e => fileRows.update(row.id, { content: e.target.value })}
+                  placeholder="Paste file content here"
+                  className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm"
+                />
+              </div>
             )}
           />
 

--- a/dashboard/src/deployments/EditDeploymentForm.tsx
+++ b/dashboard/src/deployments/EditDeploymentForm.tsx
@@ -6,7 +6,7 @@ import { DynamicSection } from './DynamicSection'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import { cn } from '../lib/utils'
-import type { BasicAuthUserRow, EnvRow, PortRow, VolumeMountRow } from './useCreateDeploymentForm'
+import type { BasicAuthUserRow, EnvRow, FileMountRow, PortRow, VolumeMountRow } from './useCreateDeploymentForm'
 
 const fieldErrorCls = 'text-xs text-destructive'
 
@@ -22,7 +22,7 @@ export default function EditDeploymentForm({ deployment, onClose, className, hid
     name, setName, image, setImage, domain, setDomain,
     isPublic, setIsPublic,
     selectedProxyRowId, setSelectedProxyRowId,
-    envRows, portRows, volumeRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
+    envRows, portRows, volumeRows, fileRows, basicAuthEnabled, setBasicAuthEnabled, basicAuthRows,
     errors, handleSubmit, isDirty, isPending,
   } = useEditDeploymentForm(deployment, onClose)
 
@@ -158,6 +158,54 @@ export default function EditDeploymentForm({ deployment, onClose, className, hid
               aria-invalid={Boolean(errors.volumes[row.id])}
               className="font-mono" />
           </>)}
+        />
+
+        <DynamicSection<FileMountRow>
+          title="Config files"
+          description="Create text config files on the VPS and mount them into the container. Useful for Prometheus, Nginx, and other services that require config files."
+          addLabel="Add config file"
+          removeLabel="Remove config file"
+          rows={fileRows.rows}
+          onAdd={fileRows.add}
+          onRemove={fileRows.remove}
+          errorFor={row => errors.files[row.id]}
+          renderRow={row => (
+            <div className="grid flex-1 gap-2">
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_auto_1fr_auto] md:items-center">
+                <Input
+                  type="text"
+                  placeholder="prometheus.yml"
+                  value={row.source}
+                  onChange={e => fileRows.update(row.id, { source: e.target.value })}
+                  aria-invalid={Boolean(errors.files[row.id])}
+                  className="font-mono"
+                />
+                <span className="hidden text-sm text-muted-foreground md:inline">-&gt;</span>
+                <Input
+                  type="text"
+                  placeholder="/etc/prometheus/prometheus.yml"
+                  value={row.target}
+                  onChange={e => fileRows.update(row.id, { target: e.target.value })}
+                  aria-invalid={Boolean(errors.files[row.id])}
+                  className="font-mono"
+                />
+                <label className="inline-flex items-center gap-2 rounded-md border border-border/60 px-2 py-1 text-xs text-foreground">
+                  <input
+                    type="checkbox"
+                    checked={row.readOnly}
+                    onChange={e => fileRows.update(row.id, { readOnly: e.target.checked })}
+                  />
+                  Read only
+                </label>
+              </div>
+              <textarea
+                value={row.content}
+                onChange={e => fileRows.update(row.id, { content: e.target.value })}
+                placeholder="Paste file content here"
+                className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm"
+              />
+            </div>
+          )}
         />
 
 

--- a/dashboard/src/deployments/useCreateDeploymentForm.ts
+++ b/dashboard/src/deployments/useCreateDeploymentForm.ts
@@ -7,6 +7,7 @@ import { useDynamicRows } from './useDynamicRows'
 
 export type EnvRow = { id: number; key: string; value: string }
 export type VolumeMountRow = { id: number; mode: 'managed' | 'bind'; source: string; target: string }
+export type FileMountRow = { id: number; source: string; target: string; content: string; readOnly: boolean }
 export type PortRow = { id: number; port: string }
 export type BasicAuthUserRow = { id: number; username: string; password: string }
 
@@ -16,11 +17,12 @@ export type FormErrors = {
   envs: Record<number, string>
   ports: Record<number, string>
   volumes: Record<number, string>
+  files: Record<number, string>
   basicAuth: Record<number, string>
   form?: string
 }
 
-const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {}, basicAuth: {} }
+const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {}, files: {}, basicAuth: {} }
 
 type UseCreateDeploymentFormOptions = {
   onSuccess?: () => void
@@ -40,6 +42,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
   const envRows = useDynamicRows<EnvRow>(id => ({ id, key: '', value: '' }))
   const portRows = useDynamicRows<PortRow>(id => ({ id, port: '' }))
   const volumeRows = useDynamicRows<VolumeMountRow>(id => ({ id, mode: 'managed', source: '', target: '' }))
+  const fileRows = useDynamicRows<FileMountRow>(id => ({ id, source: '', target: '', content: '', readOnly: true }))
   const basicAuthRows = useDynamicRows<BasicAuthUserRow>(id => ({ id, username: '', password: '' }))
 
   const mutation = useMutation({
@@ -55,6 +58,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
       envRows.reset()
       portRows.reset()
       volumeRows.reset()
+      fileRows.reset()
       basicAuthRows.reset()
       setErrors(EMPTY_ERRORS)
       options.onSuccess?.()
@@ -63,7 +67,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
   })
 
   function validate(): boolean {
-    const errs: FormErrors = { envs: {}, ports: {}, volumes: {}, basicAuth: {} }
+    const errs: FormErrors = { envs: {}, ports: {}, volumes: {}, files: {}, basicAuth: {} }
     if (!name.trim()) errs.name = 'Name is required'
     if (!image.trim()) errs.image = 'Image is required'
     for (const row of envRows.rows) {
@@ -96,6 +100,11 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
           : 'Host and container paths are required'
       }
     }
+    for (const row of fileRows.rows) {
+      if (!row.source.trim() || !row.target.trim()) {
+        errs.files[row.id] = 'File name and container path are required'
+      }
+    }
     if (basicAuthEnabled) {
       if (basicAuthRows.rows.length === 0) errs.form = 'Add at least one basic auth user'
       for (const row of basicAuthRows.rows) {
@@ -109,6 +118,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
       Object.keys(errs.envs).length === 0 &&
       Object.keys(errs.ports).length === 0 &&
       Object.keys(errs.volumes).length === 0 &&
+      Object.keys(errs.files).length === 0 &&
       Object.keys(errs.basicAuth).length === 0 &&
       !errs.form
     )
@@ -151,6 +161,12 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
         source: r.source.trim(),
         target: r.target.trim(),
       })),
+      file_mounts: fileRows.rows.map(r => ({
+        source: r.source.trim(),
+        target: r.target.trim(),
+        content: r.content,
+        read_only: r.readOnly,
+      })),
       domain: domain.trim(),
       public: isPublic,
       basic_auth: basicAuth,
@@ -167,6 +183,7 @@ export function useCreateDeploymentForm(options: UseCreateDeploymentFormOptions 
     envRows,
     portRows,
     volumeRows,
+    fileRows,
     basicAuthRows,
     errors,
     handleSubmit,

--- a/dashboard/src/deployments/useEditDeploymentForm.ts
+++ b/dashboard/src/deployments/useEditDeploymentForm.ts
@@ -1,12 +1,12 @@
 import { useMemo, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { updateDeployment, type BasicAuthConfig, type Deployment, type UpdateDeploymentInput, type VolumeMount } from '../lib/api'
+import { updateDeployment, type BasicAuthConfig, type Deployment, type FileMount, type UpdateDeploymentInput, type VolumeMount } from '../lib/api'
 import { hashPasswordIfNeeded } from '../lib/password'
 import { parsePortSpec } from './portSpec'
 import { useDynamicRows } from './useDynamicRows'
-import type { BasicAuthUserRow, EnvRow, FormErrors, PortRow, VolumeMountRow } from './useCreateDeploymentForm'
+import type { BasicAuthUserRow, EnvRow, FileMountRow, FormErrors, PortRow, VolumeMountRow } from './useCreateDeploymentForm'
 
-const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {}, basicAuth: {} }
+const EMPTY_ERRORS: FormErrors = { envs: {}, ports: {}, volumes: {}, files: {}, basicAuth: {} }
 
 function toEnvRows(envs: Record<string, string>): EnvRow[] {
   return Object.entries(envs).map(([key, value], i) => ({ id: i, key, value }))
@@ -35,6 +35,17 @@ function toPortRows(items: string[]): PortRow[] {
     const sep = item.indexOf(':')
     return { id: i, port: sep >= 0 ? item.slice(sep + 1) : item }
   })
+}
+
+function toFileMountRows(deployment: Deployment): FileMountRow[] {
+  const mounts: FileMount[] = deployment.file_mounts ?? []
+  return mounts.map((mount, i) => ({
+    id: i,
+    source: mount.source,
+    target: mount.target,
+    content: mount.content,
+    readOnly: mount.read_only ?? false,
+  }))
 }
 
 function findProxyRowId(rows: PortRow[], proxyPort?: number): number | null {
@@ -79,6 +90,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
   const envRows = useDynamicRows<EnvRow>(id => ({ id, key: '', value: '' }), toEnvRows(deployment.envs))
   const portRows = useDynamicRows<PortRow>(id => ({ id, port: '' }), toPortRows(deployment.ports))
   const volumeRows = useDynamicRows<VolumeMountRow>(id => ({ id, mode: 'managed', source: '', target: '' }), toVolumeMountRows(deployment))
+  const fileRows = useDynamicRows<FileMountRow>(id => ({ id, source: '', target: '', content: '', readOnly: true }), toFileMountRows(deployment))
   const basicAuthRows = useDynamicRows<BasicAuthUserRow>(id => ({ id, username: '', password: '' }), toBasicAuthRows(deployment))
   const [selectedProxyRowId, setSelectedProxyRowId] = useState<number | null>(() => findProxyRowId(toPortRows(deployment.ports), deployment.proxy_port))
 
@@ -108,6 +120,12 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
         source: r.source.trim(),
         target: r.target.trim(),
       })),
+      file_mounts: fileRows.rows.map(r => ({
+        source: r.source.trim(),
+        target: r.target.trim(),
+        content: r.content,
+        read_only: r.readOnly,
+      })),
       domain: domain.trim(),
       public: isPublic,
       basic_auth: basicAuthEnabled
@@ -120,7 +138,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
         : undefined,
       security: deployment.security,
     }
-  }, [name, image, domain, isPublic, envRows.rows, portRows.rows, selectedProxyRowId, volumeRows.rows, basicAuthEnabled, basicAuthRows.rows, deployment.security])
+  }, [name, image, domain, isPublic, envRows.rows, portRows.rows, selectedProxyRowId, volumeRows.rows, fileRows.rows, basicAuthEnabled, basicAuthRows.rows, deployment.security])
 
   const isDirty = useMemo(() => {
     const initial: UpdateDeploymentInput = {
@@ -140,6 +158,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
           target: separator >= 0 ? volume.slice(separator + 1) : '',
         }
       }),
+      file_mounts: deployment.file_mounts,
       domain: deployment.domain,
       public: deployment.public,
       basic_auth: deployment.basic_auth,
@@ -154,7 +173,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
       return true
     }
 
-    if (initial.ports.length !== normalizedInput.ports.length || initial.volume_mounts?.length !== normalizedInput.volume_mounts?.length) {
+    if (initial.ports.length !== normalizedInput.ports.length || initial.volume_mounts?.length !== normalizedInput.volume_mounts?.length || initial.file_mounts?.length !== normalizedInput.file_mounts?.length) {
       return true
     }
 
@@ -168,6 +187,18 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
       const current = normalizedInput.volume_mounts?.[i]
       const existing = initial.volume_mounts?.[i]
       if (!current || !existing || current.mode !== existing.mode || current.source !== existing.source || current.target !== existing.target) {
+        return true
+      }
+    }
+
+    for (let i = 0; i < (initial.file_mounts?.length ?? 0); i += 1) {
+      const current = normalizedInput.file_mounts?.[i]
+      const existing = initial.file_mounts?.[i]
+      if (!current || !existing ||
+        current.source !== existing.source ||
+        current.target !== existing.target ||
+        current.content !== existing.content ||
+        (current.read_only ?? false) !== (existing.read_only ?? false)) {
         return true
       }
     }
@@ -199,7 +230,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
   })
 
   function validate(): boolean {
-    const errs: FormErrors = { envs: {}, ports: {}, volumes: {}, basicAuth: {} }
+    const errs: FormErrors = { envs: {}, ports: {}, volumes: {}, files: {}, basicAuth: {} }
     if (!name.trim()) errs.name = 'Name is required'
     if (!image.trim()) errs.image = 'Image is required'
     for (const row of envRows.rows) {
@@ -232,6 +263,11 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
           : 'Host and container paths are required'
       }
     }
+    for (const row of fileRows.rows) {
+      if (!row.source.trim() || !row.target.trim()) {
+        errs.files[row.id] = 'File name and container path are required'
+      }
+    }
     if (basicAuthEnabled) {
       if (basicAuthRows.rows.length === 0) errs.form = 'Add at least one basic auth user'
       for (const row of basicAuthRows.rows) {
@@ -245,6 +281,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
       Object.keys(errs.envs).length === 0 &&
       Object.keys(errs.ports).length === 0 &&
       Object.keys(errs.volumes).length === 0 &&
+      Object.keys(errs.files).length === 0 &&
       Object.keys(errs.basicAuth).length === 0 &&
       !errs.form
     )
@@ -280,6 +317,7 @@ export function useEditDeploymentForm(deployment: Deployment, onClose: () => voi
     envRows,
     portRows,
     volumeRows,
+    fileRows,
     basicAuthRows,
     errors,
     handleSubmit,

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -239,6 +239,16 @@ export type VolumeMount = {
   target: string
 }
 
+export type FileMount = {
+  source: string
+  target: string
+  content: string
+  uid?: number
+  gid?: number
+  file_mode?: string
+  read_only?: boolean
+}
+
 export type Deployment = {
   id: string
   name: string
@@ -248,6 +258,7 @@ export type Deployment = {
   proxy_port?: number
   volumes: string[]
   volume_mounts?: VolumeMount[]
+  file_mounts?: FileMount[]
   domain: string
   public: boolean
   basic_auth?: BasicAuthConfig
@@ -451,6 +462,7 @@ export type CreateDeploymentInput = {
   proxy_port?: number
   volumes?: string[]
   volume_mounts?: VolumeMount[]
+  file_mounts?: FileMount[]
   domain: string
   public: boolean
   basic_auth?: BasicAuthConfig
@@ -474,6 +486,7 @@ export type UpdateDeploymentInput = {
   proxy_port?: number
   volumes?: string[]
   volume_mounts?: VolumeMount[]
+  file_mounts?: FileMount[]
   domain: string
   public: boolean
   basic_auth?: BasicAuthConfig
@@ -497,6 +510,7 @@ export type PatchDeploymentInput = {
   proxy_port?: number
   volumes?: string[]
   volume_mounts?: VolumeMount[]
+  file_mounts?: FileMount[]
   domain?: string
   public?: boolean
   basic_auth?: BasicAuthConfig

--- a/orchestrator/internal/docker/docker.go
+++ b/orchestrator/internal/docker/docker.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -128,7 +129,7 @@ func (d *Docker) Start(ctx context.Context, dep store.Deployment) ([]string, err
 
 	hostCfg := &container.HostConfig{
 		PortBindings: portBindings,
-		Binds:        dep.Volumes,
+		Binds:        deploymentBinds(dep),
 	}
 
 	resp, err := d.client.ContainerCreate(ctx, cfg, hostCfg, nil, nil, dep.Name)
@@ -325,7 +326,7 @@ func (d *Docker) StartAndReplace(ctx context.Context, dep store.Deployment, oldC
 	}
 	hostCfg := &container.HostConfig{
 		PortBindings: portBindings,
-		Binds:        dep.Volumes,
+		Binds:        deploymentBinds(dep),
 	}
 
 	nextName := dep.Name + "-next"
@@ -502,6 +503,36 @@ func parsePorts(ports []string) (nat.PortSet, nat.PortMap, error) {
 		return nil, nil, err
 	}
 	return nat.PortSet(exposed), bindings, nil
+}
+
+func deploymentBinds(dep store.Deployment) []string {
+	binds := make([]string, 0, len(dep.Volumes)+len(dep.FileMounts))
+	binds = append(binds, dep.Volumes...)
+	if len(dep.FileMounts) == 0 {
+		return binds
+	}
+
+	base := strings.TrimSpace(os.Getenv("LOTSEN_MANAGED_FILES_DIR"))
+	if base == "" {
+		base = "/var/lib/lotsen/files"
+	}
+	base = filepath.Clean(base)
+
+	for _, mount := range dep.FileMounts {
+		source := strings.TrimSpace(mount.Source)
+		target := strings.TrimSpace(mount.Target)
+		if source == "" || target == "" {
+			continue
+		}
+		hostPath := filepath.Join(base, dep.ID, source)
+		binding := hostPath + ":" + target
+		if mount.ReadOnly {
+			binding += ":ro"
+		}
+		binds = append(binds, binding)
+	}
+
+	return binds
 }
 
 func (d *Docker) resolvedPorts(ctx context.Context, containerID string) ([]string, error) {

--- a/orchestrator/internal/docker/docker_test.go
+++ b/orchestrator/internal/docker/docker_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -156,6 +157,42 @@ func TestDocker_Start_OK(t *testing.T) {
 	d := docker.New(mock)
 	if _, err := d.Start(context.Background(), deployment()); err != nil {
 		t.Fatalf("want nil, got %v", err)
+	}
+}
+
+func TestDocker_Start_IncludesManagedFileMounts(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("LOTSEN_MANAGED_FILES_DIR", base)
+
+	mock := &mockClient{
+		containerCreate:  container.CreateResponse{ID: "c1"},
+		inspectContainer: inspectWithPort("80/tcp", "80"),
+	}
+	d := docker.New(mock)
+
+	dep := deployment()
+	dep.FileMounts = []store.FileMount{
+		{Source: "prometheus.yml", Target: "/etc/prometheus/prometheus.yml", Content: "global:\n", ReadOnly: true},
+	}
+
+	if _, err := d.Start(context.Background(), dep); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+
+	if mock.createdHostCfg == nil {
+		t.Fatal("want ContainerCreate called with host config")
+	}
+
+	want := filepath.Join(base, dep.ID, "prometheus.yml") + ":/etc/prometheus/prometheus.yml:ro"
+	found := false
+	for _, bind := range mock.createdHostCfg.Binds {
+		if bind == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("want bind %q in %v", want, mock.createdHostCfg.Binds)
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -65,6 +65,7 @@ type Deployment struct {
 	Ports        []string          `json:"ports"`
 	ProxyPort    int               `json:"proxy_port,omitempty"`
 	Volumes      []string          `json:"volumes"`
+	FileMounts   []FileMount       `json:"file_mounts,omitempty"`
 	Domain       string            `json:"domain"`
 	Public       bool              `json:"public,omitempty"`
 	PublicSet    bool              `json:"-"`
@@ -91,6 +92,16 @@ type SecurityConfig struct {
 	IPDenylist  []string `json:"ip_denylist,omitempty"`
 	IPAllowlist []string `json:"ip_allowlist,omitempty"`
 	CustomRules []string `json:"custom_rules,omitempty"`
+}
+
+type FileMount struct {
+	Source   string `json:"source"`
+	Target   string `json:"target"`
+	Content  string `json:"content"`
+	UID      *int   `json:"uid,omitempty"`
+	GID      *int   `json:"gid,omitempty"`
+	FileMode string `json:"file_mode,omitempty"`
+	ReadOnly bool   `json:"read_only,omitempty"`
 }
 
 type Registry struct {
@@ -652,7 +663,8 @@ func (s *JSONStore) Update(d Deployment) (Deployment, error) {
 }
 
 // Patch merges the non-zero fields of patch into the stored deployment and persists atomically.
-// Only image, envs, ports, volumes, domain, basic auth config, status, and error are merged; id and name are immutable.
+// Only image, envs, ports, volumes, file mounts, domain, basic auth config,
+// status, and error are merged; id and name are immutable.
 // Returns ErrNotFound if no deployment with that ID exists.
 func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
 	var result Deployment
@@ -676,6 +688,9 @@ func (s *JSONStore) Patch(id string, patch Deployment) (Deployment, error) {
 		}
 		if patch.Volumes != nil {
 			d.Volumes = patch.Volumes
+		}
+		if patch.FileMounts != nil {
+			d.FileMounts = patch.FileMounts
 		}
 		if patch.ProxyPortSet {
 			d.ProxyPort = patch.ProxyPort

--- a/website/src/content/docs/deployment-configuration.md
+++ b/website/src/content/docs/deployment-configuration.md
@@ -10,6 +10,7 @@ A deployment is the central object in Lotsen. It describes a container you want 
 | image   | string   | Yes      | The Docker image to run, including tag. The orchestrator pulls this image before starting the container. Example: `nginx:1.27` or `ghcr.io/myorg/api:latest`. |
 | ports   | string[] | No       | Port mappings in `host:container` format. Each entry maps a port on the VPS host to a port inside the container. Example: `["80:80", "443:443"]`. |
 | volume_mounts | object[] | No | Volume mounts with explicit mode: managed or bind. Managed mounts are created automatically under `/var/lib/lotsen/volumes/<deployment>/<volume>`. Managed mounts also support optional `uid`, `gid`, and `dir_mode` ownership settings. Example: `[{"mode":"managed","source":"postgres-data","target":"/var/lib/postgresql/data","uid":5050,"gid":5050,"dir_mode":"0770"}]`. |
+| file_mounts | object[] | No | Managed text files created by Lotsen and mounted into the container. Useful for apps that need config files (for example Prometheus). Supports `source`, `target`, `content`, optional `uid`, `gid`, `file_mode`, and `read_only`. |
 | volumes | string[] | No | Backward-compatible raw bind format (`host-path:container-path`). Prefer `volume_mounts` for new deployments. |
 | envs    | object   | No       | Environment variables passed into the container as a key-value map. Values are stored in the Lotsen data file on disk. Example: `{"DATABASE_URL": "postgres://..."}`. |
 | domain  | string   | No       | A fully-qualified domain name to route to this container via the integrated reverse proxy. Point your DNS A record to the VPS IP, and Lotsen will forward HTTP traffic on port 80. Example: `api.example.com`. |
@@ -110,6 +111,29 @@ Use bind mounts when you need full host-path control:
   ]
 }
 ```
+
+## Config files (`file_mounts`)
+
+Some images need a real config file on disk. Use `file_mounts` to write file content from the dashboard and mount it into the container.
+
+```json
+"file_mounts": [
+  {
+    "source": "prometheus.yml",
+    "target": "/etc/prometheus/prometheus.yml",
+    "content": "global:\n  scrape_interval: 15s\n",
+    "read_only": true
+  }
+]
+```
+
+Managed files are created under:
+
+```text
+/var/lib/lotsen/files/<deployment-id>/<source>
+```
+
+This makes it possible to run services like Prometheus without SSH access just to create config files.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary
- add first-class `file_mounts` support across API, store, orchestrator, and dashboard so deployments can create and mount managed text config files without SSH
- validate and materialize managed files under `/var/lib/lotsen/files/<deployment-id>/<source>` (or `LOTSEN_MANAGED_FILES_DIR`) with path safety, ownership/mode options, UTF-8 checks, and content size limits
- extend config v1 export/validation/docs and add API/orchestrator/config tests covering file mount creation, persistence, and bind mounting (including read-only mounts)

## Verification
- `go test ./api/cmd/lotsen ./api/internal/api ./orchestrator/internal/docker ./api/internal/configv1 ./store`
- `bun run build` (in `dashboard/`)