### PR TITLE
feat(config): add v1 config plan/apply workflow

### DIFF
--- a/api/cmd/lotsen/config.go
+++ b/api/cmd/lotsen/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	internalapi "github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/configapply"
 	"github.com/lotsendev/lotsen/internal/configplan"
 	"github.com/lotsendev/lotsen/internal/configv1"
 	"github.com/lotsendev/lotsen/store"
@@ -24,7 +26,7 @@ var (
 
 func runConfig(args []string, stdout io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("usage: lotsen config <validate|fmt|export|plan> [flags]")
+		return errors.New("usage: lotsen config <validate|fmt|export|plan|apply> [flags]")
 	}
 
 	switch args[0] {
@@ -36,9 +38,82 @@ func runConfig(args []string, stdout io.Writer) error {
 		return runConfigExport(args[1:])
 	case "plan":
 		return runConfigPlan(args[1:])
+	case "apply":
+		return runConfigApply(args[1:], stdout)
 	default:
 		return fmt.Errorf("unknown config command %q", args[0])
 	}
+}
+
+func runConfigApply(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("config apply", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("f", "", "Path to config file")
+	planPath := fs.String("plan", "", "Path to plan file")
+	approve := fs.String("approve", "", "Approved plan fingerprint")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("%w\n\nUsage: lotsen config apply -f <file> --plan <plan-file> --approve <fingerprint>", err)
+	}
+
+	if strings.TrimSpace(*configPath) == "" || strings.TrimSpace(*planPath) == "" || strings.TrimSpace(*approve) == "" {
+		return errors.New("Usage: lotsen config apply -f <file> --plan <plan-file> --approve <fingerprint>")
+	}
+
+	desired, err := readConfigFile(*configPath)
+	if err != nil {
+		return err
+	}
+	if err := configv1.Validate(desired); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+
+	planDoc, err := readPlanFile(*planPath)
+	if err != nil {
+		return err
+	}
+
+	approvedFingerprint := strings.TrimSpace(*approve)
+	if planDoc.Fingerprint != approvedFingerprint {
+		return errors.New("approval fingerprint does not match plan fingerprint")
+	}
+
+	live, err := exportConfigDocument()
+	if err != nil {
+		return fmt.Errorf("export live state: %w", err)
+	}
+
+	currentPlan, err := configplan.Build(desired, live)
+	if err != nil {
+		return fmt.Errorf("build plan: %w", err)
+	}
+	if currentPlan.Fingerprint != approvedFingerprint {
+		return fmt.Errorf("stale approval fingerprint: expected %s, got %s", currentPlan.Fingerprint, approvedFingerprint)
+	}
+
+	storePath := dataPath()
+	jsonStore, err := store.NewJSONStore(storePath)
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	hostProfileStore, err := internalapi.NewFileHostProfileStore(hostProfilePath(storePath))
+	if err != nil {
+		return fmt.Errorf("open host profile store: %w", err)
+	}
+
+	result, applyErr := configapply.Execute(desired, currentPlan, jsonStore, hostProfileStore)
+	encoded, marshalErr := json.MarshalIndent(result, "", "  ")
+	if marshalErr != nil {
+		return fmt.Errorf("marshal apply outcome: %w", marshalErr)
+	}
+	if _, writeErr := stdout.Write(append(encoded, '\n')); writeErr != nil {
+		return writeErr
+	}
+
+	if applyErr != nil {
+		return applyErr
+	}
+
+	return nil
 }
 
 func runConfigPlan(args []string) error {
@@ -173,6 +248,31 @@ func runConfigExport(args []string) error {
 	}
 
 	return nil
+}
+
+func readPlanFile(path string) (configplan.Document, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return configplan.Document{}, fmt.Errorf("open plan file: %w", err)
+	}
+	defer f.Close()
+
+	var plan configplan.Document
+	if err := json.NewDecoder(f).Decode(&plan); err != nil {
+		return configplan.Document{}, fmt.Errorf("decode plan file: %w", err)
+	}
+
+	if strings.TrimSpace(plan.APIVersion) != configv1.APIVersion {
+		return configplan.Document{}, fmt.Errorf("invalid plan apiVersion %q", plan.APIVersion)
+	}
+	if strings.TrimSpace(plan.Kind) != configplan.Kind {
+		return configplan.Document{}, fmt.Errorf("invalid plan kind %q", plan.Kind)
+	}
+	if strings.TrimSpace(plan.Fingerprint) == "" {
+		return configplan.Document{}, errors.New("plan fingerprint is required")
+	}
+
+	return plan, nil
 }
 
 func readConfigFile(path string) (configv1.Document, error) {

--- a/api/cmd/lotsen/config_test.go
+++ b/api/cmd/lotsen/config_test.go
@@ -281,3 +281,248 @@ func TestRunConfigPlan_DeterministicOutputAndSections(t *testing.T) {
 		t.Fatalf("unexpected destructive registry actions: %#v", plan.Destructive.Registries)
 	}
 }
+
+func TestRunConfigApply_EndToEndAndIdempotentRerun(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "deployments.json")
+	t.Setenv("LOTSEN_DATA", storePath)
+	t.Setenv("LOTSEN_MANAGED_VOLUMES_DIR", filepath.Join(filepath.Dir(storePath), "volumes"))
+
+	s, err := store.NewJSONStore(storePath)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	if _, err := s.Create(store.Deployment{ID: "dep-update", Name: "app", Image: "ghcr.io/acme/app:1", Domain: "old.example.com", Public: true, Status: store.StatusHealthy}); err != nil {
+		t.Fatalf("create update deployment: %v", err)
+	}
+	if _, err := s.Create(store.Deployment{ID: "dep-delete", Name: "legacy", Image: "ghcr.io/acme/legacy:1", Domain: "legacy.example.com", Public: true, Status: store.StatusHealthy}); err != nil {
+		t.Fatalf("create delete deployment: %v", err)
+	}
+
+	if _, err := s.CreateRegistry("r-keep", "a.example", "user-a", "token-a"); err != nil {
+		t.Fatalf("create keep registry: %v", err)
+	}
+	if _, err := s.CreateRegistry("r-delete", "c.example", "user-c", "token-c"); err != nil {
+		t.Fatalf("create delete registry: %v", err)
+	}
+
+	hostStore, err := internalapi.NewFileHostProfileStore(hostProfilePath(storePath))
+	if err != nil {
+		t.Fatalf("new host profile store: %v", err)
+	}
+	if _, err := hostStore.Update(internalapi.HostProfile{DisplayName: "old-host", DashboardAccessMode: internalapi.DashboardAccessModeLoginOnly}); err != nil {
+		t.Fatalf("seed host profile: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "desired.json")
+	desired := `{
+  "apiVersion": "lotsen/v1",
+  "kind": "LotsenConfig",
+  "spec": {
+    "deployments": [
+      {
+        "name": "app",
+        "image": "ghcr.io/acme/app:2",
+        "domain": "app.example.com",
+        "public": true
+      },
+      {
+        "name": "new",
+        "image": "ghcr.io/acme/new:1",
+        "domain": "new.example.com",
+        "public": true
+      }
+    ],
+    "registries": [
+      {
+        "prefix": "a.example",
+        "username": "user-a",
+        "password": "${LOTSEN_SECRET_NEW_A}"
+      },
+      {
+        "prefix": "b.example",
+        "username": "user-b",
+        "password": "${LOTSEN_SECRET_B}"
+      }
+    ],
+    "host": {
+      "displayName": "prod-vps-1",
+      "dashboardAccessMode": "waf_and_login"
+    }
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(desired), 0o644); err != nil {
+		t.Fatalf("write desired config: %v", err)
+	}
+
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	if err := runConfig([]string{"plan", "-f", configPath, "--out", planPath}, io.Discard); err != nil {
+		t.Fatalf("plan run: %v", err)
+	}
+
+	planBytes, err := os.ReadFile(planPath)
+	if err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	var plan configplan.Document
+	if err := json.Unmarshal(planBytes, &plan); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runConfig([]string{"apply", "-f", configPath, "--plan", planPath, "--approve", plan.Fingerprint}, &out); err != nil {
+		t.Fatalf("apply run: %v", err)
+	}
+
+	var applyResult struct {
+		Summary struct {
+			Applied int `json:"applied"`
+			Noop    int `json:"noop"`
+			Failed  int `json:"failed"`
+		} `json:"summary"`
+		PartialFailed bool `json:"partialFailed"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &applyResult); err != nil {
+		t.Fatalf("decode apply output: %v", err)
+	}
+	if applyResult.PartialFailed {
+		t.Fatalf("want successful apply, got partial failure: %s", out.String())
+	}
+	if applyResult.Summary.Failed != 0 {
+		t.Fatalf("want 0 failed outcomes, got %d", applyResult.Summary.Failed)
+	}
+
+	deployments, err := s.List()
+	if err != nil {
+		t.Fatalf("list deployments after apply: %v", err)
+	}
+	byName := map[string]store.Deployment{}
+	for _, deployment := range deployments {
+		byName[deployment.Name] = deployment
+	}
+	if _, exists := byName["legacy"]; exists {
+		t.Fatalf("want legacy deployment deleted, got %#v", byName["legacy"])
+	}
+	if byName["app"].Image != "ghcr.io/acme/app:2" {
+		t.Fatalf("want app image updated, got %q", byName["app"].Image)
+	}
+	if _, exists := byName["new"]; !exists {
+		t.Fatal("want new deployment created")
+	}
+
+	registries, err := s.ListRegistries()
+	if err != nil {
+		t.Fatalf("list registries after apply: %v", err)
+	}
+	prefixes := make(map[string]struct{}, len(registries))
+	for _, registry := range registries {
+		prefixes[registry.Prefix] = struct{}{}
+	}
+	if _, exists := prefixes["c.example"]; exists {
+		t.Fatal("want c.example registry deleted")
+	}
+	if _, exists := prefixes["b.example"]; !exists {
+		t.Fatal("want b.example registry created")
+	}
+
+	hostProfile, err := hostStore.Get()
+	if err != nil {
+		t.Fatalf("get host profile after apply: %v", err)
+	}
+	if hostProfile.DisplayName != "prod-vps-1" || hostProfile.DashboardAccessMode != internalapi.DashboardAccessModeWAFAndLogin {
+		t.Fatalf("unexpected host profile after apply: %#v", hostProfile)
+	}
+
+	planPath2 := filepath.Join(t.TempDir(), "plan-2.json")
+	if err := runConfig([]string{"plan", "-f", configPath, "--out", planPath2}, io.Discard); err != nil {
+		t.Fatalf("second plan run: %v", err)
+	}
+	planBytes2, err := os.ReadFile(planPath2)
+	if err != nil {
+		t.Fatalf("read second plan: %v", err)
+	}
+	var plan2 configplan.Document
+	if err := json.Unmarshal(planBytes2, &plan2); err != nil {
+		t.Fatalf("decode second plan: %v", err)
+	}
+
+	out.Reset()
+	if err := runConfig([]string{"apply", "-f", configPath, "--plan", planPath2, "--approve", plan2.Fingerprint}, &out); err != nil {
+		t.Fatalf("second apply run: %v", err)
+	}
+	if err := json.Unmarshal(out.Bytes(), &applyResult); err != nil {
+		t.Fatalf("decode second apply output: %v", err)
+	}
+	if applyResult.PartialFailed || applyResult.Summary.Failed != 0 {
+		t.Fatalf("want idempotent successful second apply, got %s", out.String())
+	}
+}
+
+func TestRunConfigApply_RejectsStaleFingerprint(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "deployments.json")
+	t.Setenv("LOTSEN_DATA", storePath)
+
+	s, err := store.NewJSONStore(storePath)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	if _, err := s.Create(store.Deployment{ID: "dep-1", Name: "app", Image: "ghcr.io/acme/app:1", Domain: "app.example.com", Public: true, Status: store.StatusHealthy}); err != nil {
+		t.Fatalf("seed deployment: %v", err)
+	}
+
+	hostStore, err := internalapi.NewFileHostProfileStore(hostProfilePath(storePath))
+	if err != nil {
+		t.Fatalf("new host profile store: %v", err)
+	}
+	if _, err := hostStore.Update(internalapi.HostProfile{}); err != nil {
+		t.Fatalf("seed host profile: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "desired.json")
+	desired := `{
+  "apiVersion": "lotsen/v1",
+  "kind": "LotsenConfig",
+  "spec": {
+    "deployments": [
+      {
+        "name": "app",
+        "image": "ghcr.io/acme/app:2",
+        "domain": "app.example.com",
+        "public": true
+      }
+    ],
+    "registries": [],
+    "host": {}
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(desired), 0o644); err != nil {
+		t.Fatalf("write desired config: %v", err)
+	}
+
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	if err := runConfig([]string{"plan", "-f", configPath, "--out", planPath}, io.Discard); err != nil {
+		t.Fatalf("plan run: %v", err)
+	}
+
+	planBytes, err := os.ReadFile(planPath)
+	if err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	var plan configplan.Document
+	if err := json.Unmarshal(planBytes, &plan); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+
+	if _, err := s.Create(store.Deployment{ID: "dep-race", Name: "race", Image: "ghcr.io/acme/race:1", Domain: "race.example.com", Public: true, Status: store.StatusHealthy}); err != nil {
+		t.Fatalf("introduce drift: %v", err)
+	}
+
+	err = runConfig([]string{"apply", "-f", configPath, "--plan", planPath, "--approve", plan.Fingerprint}, io.Discard)
+	if err == nil {
+		t.Fatal("want stale fingerprint error")
+	}
+	if !strings.Contains(err.Error(), "stale approval fingerprint") {
+		t.Fatalf("want stale fingerprint error, got %v", err)
+	}
+}

--- a/api/internal/configapply/apply.go
+++ b/api/internal/configapply/apply.go
@@ -1,0 +1,440 @@
+package configapply
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+
+	internalapi "github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/configplan"
+	"github.com/lotsendev/lotsen/internal/configv1"
+	"github.com/lotsendev/lotsen/store"
+)
+
+type StateStore interface {
+	List() ([]store.Deployment, error)
+	Create(d store.Deployment) (store.Deployment, error)
+	Update(d store.Deployment) (store.Deployment, error)
+	Delete(id string) error
+
+	ListRegistries() ([]store.RegistryEntry, error)
+	CreateRegistry(id, prefix, username, password string) (store.RegistryEntry, error)
+	UpdateRegistry(id, prefix, username, password string) (store.RegistryEntry, error)
+	DeleteRegistry(id string) error
+}
+
+type HostProfileStore interface {
+	Update(profile internalapi.HostProfile) (internalapi.HostProfile, error)
+}
+
+type Status string
+
+const (
+	StatusApplied Status = "applied"
+	StatusNoop    Status = "noop"
+	StatusFailed  Status = "failed"
+)
+
+type Outcome struct {
+	ResourceType string `json:"resourceType"`
+	Action       string `json:"action"`
+	Resource     string `json:"resource"`
+	Status       Status `json:"status"`
+	Message      string `json:"message,omitempty"`
+}
+
+type Summary struct {
+	Applied int `json:"applied"`
+	Noop    int `json:"noop"`
+	Failed  int `json:"failed"`
+}
+
+type Result struct {
+	Fingerprint   string    `json:"fingerprint"`
+	Outcomes      []Outcome `json:"outcomes"`
+	Summary       Summary   `json:"summary"`
+	PartialFailed bool      `json:"partialFailed"`
+}
+
+func Execute(desired configv1.Document, plan configplan.Document, stateStore StateStore, hostProfiles HostProfileStore) (Result, error) {
+	result := Result{Fingerprint: plan.Fingerprint, Outcomes: make([]Outcome, 0)}
+
+	desiredDeployments := make(map[string]configv1.Deployment, len(desired.Spec.Deployments))
+	for _, deployment := range desired.Spec.Deployments {
+		desiredDeployments[deployment.Name] = deployment
+	}
+	desiredRegistries := make(map[string]configv1.Registry, len(desired.Spec.Registries))
+	for _, registry := range desired.Spec.Registries {
+		desiredRegistries[registry.Prefix] = registry
+	}
+
+	liveDeployments, err := stateStore.List()
+	if err != nil {
+		return result, fmt.Errorf("list deployments: %w", err)
+	}
+	liveByName := make(map[string]store.Deployment, len(liveDeployments))
+	for _, deployment := range liveDeployments {
+		liveByName[deployment.Name] = deployment
+	}
+
+	registryEntries, err := stateStore.ListRegistries()
+	if err != nil {
+		return result, fmt.Errorf("list registries: %w", err)
+	}
+	registryIDByPrefix := make(map[string]string, len(registryEntries))
+	for _, entry := range registryEntries {
+		registryIDByPrefix[entry.Prefix] = entry.ID
+	}
+
+	for _, change := range plan.Actions.Registries.Noop {
+		appendOutcome(&result, Outcome{ResourceType: "registry", Action: "noop", Resource: change.Resource, Status: StatusNoop})
+	}
+	for _, change := range plan.Actions.Registries.Create {
+		registry, ok := desiredRegistries[change.Resource]
+		if !ok {
+			appendOutcome(&result, Outcome{ResourceType: "registry", Action: "create", Resource: change.Resource, Status: StatusFailed, Message: "missing in desired config"})
+			continue
+		}
+		id, newIDErr := newID()
+		if newIDErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "registry", Action: "create", Resource: change.Resource, Status: StatusFailed, Message: newIDErr.Error()})
+			continue
+		}
+		if _, createErr := stateStore.CreateRegistry(id, registry.Prefix, registry.Username, registry.Password); createErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "registry", Action: "create", Resource: change.Resource, Status: StatusFailed, Message: createErr.Error()})
+			continue
+		}
+		appendOutcome(&result, Outcome{ResourceType: "registry", Action: "create", Resource: change.Resource, Status: StatusApplied})
+	}
+	for _, change := range plan.Actions.Registries.Update {
+		registry, ok := desiredRegistries[change.Resource]
+		if !ok {
+			appendOutcome(&result, Outcome{ResourceType: "registry", Action: "update", Resource: change.Resource, Status: StatusFailed, Message: "missing in desired config"})
+			continue
+		}
+		id, ok := registryIDByPrefix[change.Resource]
+		if !ok {
+			appendOutcome(&result, Outcome{ResourceType: "registry", Action: "update", Resource: change.Resource, Status: StatusFailed, Message: "missing in live state"})
+			continue
+		}
+		if _, updateErr := stateStore.UpdateRegistry(id, registry.Prefix, registry.Username, registry.Password); updateErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "registry", Action: "update", Resource: change.Resource, Status: StatusFailed, Message: updateErr.Error()})
+			continue
+		}
+		appendOutcome(&result, Outcome{ResourceType: "registry", Action: "update", Resource: change.Resource, Status: StatusApplied})
+	}
+
+	for _, change := range plan.Actions.Deployments.Noop {
+		appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "noop", Resource: change.Resource, Status: StatusNoop})
+	}
+	for _, change := range plan.Actions.Deployments.Create {
+		deployment, ok := desiredDeployments[change.Resource]
+		if !ok {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "create", Resource: change.Resource, Status: StatusFailed, Message: "missing in desired config"})
+			continue
+		}
+		id, newIDErr := newID()
+		if newIDErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "create", Resource: change.Resource, Status: StatusFailed, Message: newIDErr.Error()})
+			continue
+		}
+
+		created, convertErr := deploymentFromDesired(deployment, id)
+		if convertErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "create", Resource: change.Resource, Status: StatusFailed, Message: convertErr.Error()})
+			continue
+		}
+		created.Status = store.StatusDeploying
+		if _, createErr := stateStore.Create(created); createErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "create", Resource: change.Resource, Status: StatusFailed, Message: createErr.Error()})
+			continue
+		}
+		appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "create", Resource: change.Resource, Status: StatusApplied})
+	}
+	for _, change := range plan.Actions.Deployments.Update {
+		desiredDeployment, ok := desiredDeployments[change.Resource]
+		if !ok {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "update", Resource: change.Resource, Status: StatusFailed, Message: "missing in desired config"})
+			continue
+		}
+		existing, ok := liveByName[change.Resource]
+		if !ok {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "update", Resource: change.Resource, Status: StatusFailed, Message: "missing in live state"})
+			continue
+		}
+
+		updated, convertErr := deploymentFromDesired(desiredDeployment, existing.ID)
+		if convertErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "update", Resource: change.Resource, Status: StatusFailed, Message: convertErr.Error()})
+			continue
+		}
+		updated.Status = existing.Status
+		updated.Reason = existing.Reason
+		updated.Error = existing.Error
+		if redeployRequired(change.Changes) {
+			updated.Status = store.StatusDeploying
+			updated.Reason = ""
+			updated.Error = ""
+		}
+
+		if _, updateErr := stateStore.Update(updated); updateErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "update", Resource: change.Resource, Status: StatusFailed, Message: updateErr.Error()})
+			continue
+		}
+		appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "update", Resource: change.Resource, Status: StatusApplied})
+	}
+
+	for _, change := range plan.Actions.Host.Noop {
+		appendOutcome(&result, Outcome{ResourceType: "host", Action: "noop", Resource: change.Resource, Status: StatusNoop})
+	}
+	for _, change := range plan.Actions.Host.Update {
+		if desired.Spec.Host == nil {
+			appendOutcome(&result, Outcome{ResourceType: "host", Action: "update", Resource: change.Resource, Status: StatusFailed, Message: "missing in desired config"})
+			continue
+		}
+		profile := hostProfileFromDesired(*desired.Spec.Host)
+		if _, updateErr := hostProfiles.Update(profile); updateErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "host", Action: "update", Resource: change.Resource, Status: StatusFailed, Message: updateErr.Error()})
+			continue
+		}
+		appendOutcome(&result, Outcome{ResourceType: "host", Action: "update", Resource: change.Resource, Status: StatusApplied})
+	}
+
+	for _, change := range plan.Actions.Deployments.Delete {
+		existing, ok := liveByName[change.Resource]
+		if !ok {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "delete", Resource: change.Resource, Status: StatusFailed, Message: "missing in live state"})
+			continue
+		}
+		if deleteErr := stateStore.Delete(existing.ID); deleteErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "delete", Resource: change.Resource, Status: StatusFailed, Message: deleteErr.Error()})
+			continue
+		}
+		appendOutcome(&result, Outcome{ResourceType: "deployment", Action: "delete", Resource: change.Resource, Status: StatusApplied})
+	}
+	for _, change := range plan.Actions.Registries.Delete {
+		id, ok := registryIDByPrefix[change.Resource]
+		if !ok {
+			appendOutcome(&result, Outcome{ResourceType: "registry", Action: "delete", Resource: change.Resource, Status: StatusFailed, Message: "missing in live state"})
+			continue
+		}
+		if deleteErr := stateStore.DeleteRegistry(id); deleteErr != nil {
+			appendOutcome(&result, Outcome{ResourceType: "registry", Action: "delete", Resource: change.Resource, Status: StatusFailed, Message: deleteErr.Error()})
+			continue
+		}
+		appendOutcome(&result, Outcome{ResourceType: "registry", Action: "delete", Resource: change.Resource, Status: StatusApplied})
+	}
+
+	if result.Summary.Failed > 0 {
+		result.PartialFailed = true
+		return result, fmt.Errorf("apply finished with %d failed actions", result.Summary.Failed)
+	}
+
+	return result, nil
+}
+
+func appendOutcome(result *Result, outcome Outcome) {
+	result.Outcomes = append(result.Outcomes, outcome)
+	switch outcome.Status {
+	case StatusApplied:
+		result.Summary.Applied++
+	case StatusNoop:
+		result.Summary.Noop++
+	case StatusFailed:
+		result.Summary.Failed++
+	}
+}
+
+func deploymentFromDesired(in configv1.Deployment, id string) (store.Deployment, error) {
+	basicAuth, err := hashBasicAuth(in.BasicAuth)
+	if err != nil {
+		return store.Deployment{}, err
+	}
+
+	volumes, err := volumeBindingsFromMounts(id, in.VolumeMounts)
+	if err != nil {
+		return store.Deployment{}, err
+	}
+
+	out := store.Deployment{
+		ID:         id,
+		Name:       strings.TrimSpace(in.Name),
+		Image:      strings.TrimSpace(in.Image),
+		Envs:       cloneMap(in.Env),
+		Ports:      slices.Clone(in.Ports),
+		Volumes:    volumes,
+		FileMounts: fileMountsFromDesired(in.FileMounts),
+		Domain:     strings.TrimSpace(in.Domain),
+		BasicAuth:  basicAuth,
+		Security:   securityFromDesired(in.Security),
+	}
+	if in.Public != nil {
+		out.Public = *in.Public
+	}
+	if in.ProxyPort != nil {
+		out.ProxyPort = *in.ProxyPort
+	}
+
+	return out, nil
+}
+
+func hashBasicAuth(in *configv1.BasicAuth) (*store.BasicAuthConfig, error) {
+	if in == nil {
+		return nil, nil
+	}
+	if len(in.Users) == 0 {
+		return nil, nil
+	}
+
+	users := make([]store.BasicAuthUser, 0, len(in.Users))
+	for _, user := range in.Users {
+		password := strings.TrimSpace(user.Password)
+		if _, err := bcrypt.Cost([]byte(password)); err != nil {
+			hashed, hashErr := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+			if hashErr != nil {
+				return nil, fmt.Errorf("hash basic auth password for %q: %w", user.Username, hashErr)
+			}
+			password = string(hashed)
+		}
+		users = append(users, store.BasicAuthUser{Username: strings.TrimSpace(user.Username), Password: password})
+	}
+
+	return &store.BasicAuthConfig{Users: users}, nil
+}
+
+func volumeBindingsFromMounts(deploymentID string, mounts []configv1.VolumeMount) ([]string, error) {
+	if len(mounts) == 0 {
+		return nil, nil
+	}
+
+	bindings := make([]string, 0, len(mounts))
+	for _, mount := range mounts {
+		mode := strings.ToLower(strings.TrimSpace(mount.Mode))
+		target := strings.TrimSpace(mount.Target)
+		source := strings.TrimSpace(mount.Source)
+		switch mode {
+		case "managed":
+			source = filepath.Join(managedVolumesBaseDirFromEnv(), deploymentID, source)
+		case "bind":
+		default:
+			return nil, fmt.Errorf("unsupported volume mount mode %q", mount.Mode)
+		}
+		bindings = append(bindings, source+":"+target)
+	}
+
+	return bindings, nil
+}
+
+func managedVolumesBaseDirFromEnv() string {
+	if dir := strings.TrimSpace(os.Getenv("LOTSEN_MANAGED_VOLUMES_DIR")); dir != "" {
+		return filepath.Clean(dir)
+	}
+	return "/var/lib/lotsen/volumes"
+}
+
+func fileMountsFromDesired(in []configv1.FileMount) []store.FileMount {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]store.FileMount, 0, len(in))
+	for _, mount := range in {
+		out = append(out, store.FileMount{
+			Source:   strings.TrimSpace(mount.Source),
+			Target:   strings.TrimSpace(mount.Target),
+			Content:  mount.Content,
+			UID:      mount.UID,
+			GID:      mount.GID,
+			FileMode: strings.TrimSpace(mount.FileMode),
+			ReadOnly: mount.ReadOnly,
+		})
+	}
+
+	return out
+}
+
+func securityFromDesired(in *configv1.Security) *store.SecurityConfig {
+	if in == nil {
+		return nil
+	}
+
+	return &store.SecurityConfig{
+		WAFEnabled:  in.WAFEnabled,
+		WAFMode:     strings.TrimSpace(in.WAFMode),
+		IPDenylist:  slices.Clone(in.IPDenylist),
+		IPAllowlist: slices.Clone(in.IPAllowlist),
+		CustomRules: slices.Clone(in.CustomRules),
+	}
+}
+
+func redeployRequired(changes []string) bool {
+	for _, field := range changes {
+		switch strings.TrimSpace(field) {
+		case "image", "env", "ports", "proxyPort", "volumeMounts", "basicAuth":
+			return true
+		}
+	}
+	return false
+}
+
+func hostProfileFromDesired(in configv1.Host) internalapi.HostProfile {
+	profile := internalapi.HostProfile{
+		DisplayName:         strings.TrimSpace(in.DisplayName),
+		DashboardAccessMode: normalizeDashboardAccessMode(in.DashboardAccessMode),
+		DashboardWAF: internalapi.DashboardWAFConfig{
+			Mode: "detection",
+		},
+	}
+
+	if in.DashboardWAF == nil {
+		return profile
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(in.DashboardWAF.Mode))
+	if mode == "enforcement" {
+		profile.DashboardWAF.Mode = "enforcement"
+	}
+	profile.DashboardWAF.IPAllowlist = slices.Clone(in.DashboardWAF.IPAllowlist)
+	profile.DashboardWAF.CustomRules = slices.Clone(in.DashboardWAF.CustomRules)
+
+	return profile
+}
+
+func normalizeDashboardAccessMode(mode string) internalapi.DashboardAccessMode {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "waf_only":
+		return internalapi.DashboardAccessModeWAFOnly
+	case "waf_and_login":
+		return internalapi.DashboardAccessModeWAFAndLogin
+	default:
+		return internalapi.DashboardAccessModeLoginOnly
+	}
+}
+
+func cloneMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+
+	return out
+}
+
+func newID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("new id: %w", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
+}

--- a/api/internal/configapply/apply_test.go
+++ b/api/internal/configapply/apply_test.go
@@ -1,0 +1,109 @@
+package configapply
+
+import (
+	"errors"
+	"testing"
+
+	internalapi "github.com/lotsendev/lotsen/internal/api"
+	"github.com/lotsendev/lotsen/internal/configplan"
+	"github.com/lotsendev/lotsen/internal/configv1"
+	"github.com/lotsendev/lotsen/store"
+)
+
+func TestExecute_ContinuesAfterFailureAndReportsPartial(t *testing.T) {
+	public := true
+	desired := configv1.Document{
+		APIVersion: configv1.APIVersion,
+		Kind:       configv1.Kind,
+		Spec: &configv1.Spec{
+			Deployments: []configv1.Deployment{{Name: "app", Image: "ghcr.io/acme/app:2", Domain: "app.example.com", Public: &public}},
+			Registries:  []configv1.Registry{{Prefix: "a.example", Username: "user", Password: "${LOTSEN_SECRET_A}"}},
+			Host:        &configv1.Host{DisplayName: "host-a", DashboardAccessMode: "waf_and_login"},
+		},
+	}
+
+	plan := configplan.Document{
+		Fingerprint: "sha256:test",
+		Actions: configplan.Actions{
+			Deployments: configplan.ResourceActions{
+				Update: []configplan.ResourceChange{{Resource: "app", Changes: []string{"image"}}},
+			},
+			Registries: configplan.ResourceActions{
+				Update: []configplan.ResourceChange{{Resource: "a.example", Changes: []string{"username"}}},
+			},
+			Host: configplan.HostActions{
+				Update: []configplan.ResourceChange{{Resource: "host"}},
+			},
+		},
+	}
+
+	store := &stubStore{
+		deployments:        []store.Deployment{{ID: "dep-1", Name: "app", Image: "ghcr.io/acme/app:1", Domain: "app.example.com", Public: true, Status: store.StatusHealthy}},
+		registries:         []store.RegistryEntry{{ID: "reg-1", Prefix: "a.example", Username: "old-user"}},
+		failRegistryUpdate: true,
+	}
+	hostStore := &stubHostStore{}
+
+	result, err := Execute(desired, plan, store, hostStore)
+	if err == nil {
+		t.Fatal("want partial failure error")
+	}
+	if result.Summary.Failed != 1 {
+		t.Fatalf("want 1 failure, got %d", result.Summary.Failed)
+	}
+	if result.Summary.Applied != 2 {
+		t.Fatalf("want 2 applied outcomes, got %d", result.Summary.Applied)
+	}
+	if !result.PartialFailed {
+		t.Fatal("want partialFailed=true")
+	}
+
+	if len(store.updatedDeployments) != 1 {
+		t.Fatalf("want deployment update to continue, got %d updates", len(store.updatedDeployments))
+	}
+	if hostStore.updated.DisplayName != "host-a" {
+		t.Fatalf("want host update to continue, got %#v", hostStore.updated)
+	}
+}
+
+type stubStore struct {
+	deployments []store.Deployment
+	registries  []store.RegistryEntry
+
+	updatedDeployments []store.Deployment
+
+	failRegistryUpdate bool
+}
+
+func (s *stubStore) List() ([]store.Deployment, error) { return s.deployments, nil }
+func (s *stubStore) Create(d store.Deployment) (store.Deployment, error) {
+	return d, nil
+}
+func (s *stubStore) Update(d store.Deployment) (store.Deployment, error) {
+	s.updatedDeployments = append(s.updatedDeployments, d)
+	return d, nil
+}
+func (s *stubStore) Delete(_ string) error { return nil }
+
+func (s *stubStore) ListRegistries() ([]store.RegistryEntry, error) {
+	return s.registries, nil
+}
+func (s *stubStore) CreateRegistry(id, prefix, username, password string) (store.RegistryEntry, error) {
+	return store.RegistryEntry{ID: id, Prefix: prefix, Username: username}, nil
+}
+func (s *stubStore) UpdateRegistry(id, prefix, username, password string) (store.RegistryEntry, error) {
+	if s.failRegistryUpdate {
+		return store.RegistryEntry{}, errors.New("update failed")
+	}
+	return store.RegistryEntry{ID: id, Prefix: prefix, Username: username}, nil
+}
+func (s *stubStore) DeleteRegistry(_ string) error { return nil }
+
+type stubHostStore struct {
+	updated internalapi.HostProfile
+}
+
+func (s *stubHostStore) Update(profile internalapi.HostProfile) (internalapi.HostProfile, error) {
+	s.updated = profile
+	return profile, nil
+}


### PR DESCRIPTION
## Summary
- add the Lotsen config-as-code v1 backend foundation with canonical validation/export, deterministic planning, and a new `config apply` command that enforces fingerprint approval gating
- introduce an apply engine with safe operation ordering, idempotent reruns, and per-resource outcomes including partial-failure reporting for deployments, registries, and host settings
- extend managed deployment configuration support with file-mount handling and end-to-end tests covering plan -> approve -> apply behavior, stale approval rejection, and partial-failure execution

## Testing
- go test ./... (api)